### PR TITLE
windows: Prevent path from stacking in every configure/build call.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,11 @@
 @set vcvars64="C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 @set CLICOLOR_FORCE=1
-%vcvars64% && ninja --verbose -C build
+
+@if not defined DevEnvDir (
+    call %vcvars64%
+)
+
+ninja --verbose -C build
+
+@set vcvars64=%__OLD_vcvars64%
+@set __OLD_vcvars64=

--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,4 @@
+@set __OLD_vcvars64=%vcvars64%
 @set vcvars64="C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
 @set CLICOLOR_FORCE=1
 


### PR DESCRIPTION
Everytime you call `vcvars64.bat`, it adds Visual Studio variables into `%path%`, eventually leading into `input line too long` error in CMD.

This patch:
- Fixes the `input line too long` issue by just running `vcvars64.bat` if it never ran in current shell session;
- Breaks meson flags into multiple line when showing them (so flag debugging gets _very_ easier).

**OBS:** Please, **rebase+merge** when **both** have reviewed and no errors were encountered.