### PR TITLE
Solves some POSIX missing headers

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,12 +1,27 @@
-@set __OLD_vcvars64=%vcvars64%
-@set vcvars64="C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
-@set CLICOLOR_FORCE=1
+@echo off
+setlocal
 
-@if not defined DevEnvDir (
+set __OLD_vcvars64=%vcvars64%
+set vcvars64="C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
+set CLICOLOR_FORCE=1
+
+set NINJAFLAGS=
+
+if "%~1"=="--verbose" (
+    echo Verbose ON.
+    set NINJAFLAGS=--verbose %NINJAFLAGS%
+) else (
+    echo Verbose OFF.
+)
+
+set vcvars64="C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvars64.bat"
+set CLICOLOR_FORCE=1
+
+if not defined DevEnvDir (
     call %vcvars64%
 )
 
-ninja --verbose -C build
+ninja %NINJAFLAGS% -C build
 
-@set vcvars64=%__OLD_vcvars64%
-@set __OLD_vcvars64=
+set vcvars64=%__OLD_vcvars64%
+set __OLD_vcvars64=

--- a/configure.bat
+++ b/configure.bat
@@ -80,8 +80,9 @@ exit /B 0
         set CFLAGS=-Wno-deprecated-declarations %CFLAGS%
         set CFLAGS=-Wno-gnu-zero-variadic-macro-arguments %CFLAGS%
         set CFLAGS=-Wno-nonportable-system-include-path %CFLAGS%
+        set CFLAGS=-Wno-microsoft-enum-forward-reference %CFLAGS%
     :: Syntax/Parsing
-        set CFLAGS=-Wno-implicit-function-declaration %CFLAGS%
+        :: set CFLAGS=-Wno-implicit-function-declaration %CFLAGS%
         set CFLAGS=-Wno-missing-prototypes %CFLAGS%
         set CFLAGS=-Wno-unreachable-code %CFLAGS%
         set CFLAGS=-Wno-unreachable-code-return %CFLAGS%
@@ -92,6 +93,10 @@ exit /B 0
         :: A global variable declared in a .c file is not static and hasn't
         :: been declarated with `extern` anywhere.
         set CFLAGS=-Wno-missing-variable-declarations %CFLAGS%
+        set CFLAGS=-Wno-missing-noreturn %CFLAGS%
+        :: Possible misuse of comma operator
+        set CFLAGS=-Wno-comma %CFLAGS%
+        set CFLAGS=-Wno-unreachable-code-break %CFLAGS%
     :: Architectural
         set CFLAGS=-Wno-cast-align %CFLAGS%
         set CFLAGS=-Wno-shorten-64-to-32 %CFLAGS%
@@ -116,15 +121,27 @@ exit /B 0
         :: Comparing float with == is unsafe (since floats not necessarily will
         :: have that specific value)
         set CFLAGS=-Wno-float-equal %CFLAGS%
+        :: Implicit conversion turns string literal into bool
+        set CFLAGS=-Wno-string-conversion %CFLAGS%
+        set CFLAGS=-Wno-sign-compare %CFLAGS%
+        set CFLAGS=-Wno-shadow %CFLAGS%
     :: Pointer-related
         set CFLAGS=-Wno-pointer-integer-compare %CFLAGS%
+    :: Safety (important!)
+        set CFLAGS=-Wno-uninitialized %CFLAGS%
     :: Others
-        :: Using an undefined macro (which will be evaluated to 0)
-        set CFLAGS=-Wno-undef %CFLAGS%
+        set CFLAGS=-Wno-covered-switch-default %CFLAGS%
         set CFLAGS=-Wno-documentation %CFLAGS%
         set CFLAGS=-Wno-documentation-unknown-command %CFLAGS%
+        set CFLAGS=-Wno-format-nonliteral %CFLAGS%
+        :: Using an undefined macro (which will be evaluated to 0)
+        set CFLAGS=-Wno-undef %CFLAGS%
+        set CFLAGS=-Wno-unused-function %CFLAGS%
         set CFLAGS=-Wno-unused-macros %CFLAGS%
         set CFLAGS=-Wno-unused-parameter %CFLAGS%
+        set CFLAGS=-Wno-class-varargs %CFLAGS%
+        :: Leave until functions are going to be implemented
+        set CFLAGS=-Wno-#warnings %CFLAGS%
 
     :: ------------------------------------
     :: Default flags for native compilation

--- a/configure.bat
+++ b/configure.bat
@@ -1,6 +1,13 @@
 @echo off
 setlocal EnableDelayedExpansion
 
+if "%~1"=="--verbose" (
+    echo Verbose ON.
+    set VERBOSE=ON
+) else (
+    echo Verbose OFF.
+)
+
 call :main || (echo Build configure failed.)
 exit /B %errorlevel%
 
@@ -117,6 +124,10 @@ exit /B 0
     :: ------------------------------------
     :: Default flags for native compilation
     set CFLAGS=-Wno-language-extension-token %CFLAGS%
+
+    if defined VERBOSE (
+        set CFLAGS=-v %CFLAGS%
+    )
 
     @echo - Using CFLAGS=%CFLAGS%
 

--- a/configure.bat
+++ b/configure.bat
@@ -156,10 +156,10 @@ exit /B 0
 
     :: ------------------------------------------------------
     set MESONFLAGS=^
-            -Dopenssl_dir=%OPENSSL_DIR%^
-            -Dregex_include_dir=%REGEX_INCLUDE_DIR%^
-            -Dregex_dir=%REGEX_DIR%^
-            -Dzlib_dir=%ZLIB_DIR%^
+            -Dopenssl_dir="%OPENSSL_DIR:"=%"^
+            -Dregex_include_dir="%REGEX_INCLUDE_DIR:"=%"^
+            -Dregex_dir="%REGEX_DIR:"=%"^
+            -Dzlib_dir="%ZLIB_DIR:"=%"^
             -Dcrypto=openssl^
             -Dnls=false^
             -Dsystemd=false^

--- a/configure.bat
+++ b/configure.bat
@@ -20,20 +20,24 @@ exit /B %errorlevel%
     if not defined OPENSSL_DIR set all_set=0
     if not defined REGEX_INCLUDE_DIR set all_set=0
     if not defined REGEX_DIR set all_set=0
+    if not defined ZLIB_DIR set all_set=0
 
     if %all_set%==1 (
         @echo - Using OpenSSL: %OPENSSL_DIR%
         @echo - Using Regex Include Directory: %REGEX_INCLUDE_DIR%
         @echo - Using Regex Lib Directory: %REGEX_DIR%
+        @echo - Using zlib: %ZLIB_DIR%
     ) else (
         @echo At least one of the following variables were not set:
         @echo     - OPENSSL_DIR: %OPENSSL_DIR%
         @echo     - REGEX_INCLUDE_DIR: %REGEX_INCLUDE_DIR%
         @echo     - REGEX_DIR: %REGEX_DIR%
+        @echo     - ZLIB_DIR: %ZLIB_DIR%
         @echo Please define them using by creating a "env.bat" file containing:
         @echo     @set OPENSSL_DIR=^<your OpenSSL directory^>
         @echo     @set REGEX_INCLUDE_DIR=^<your pcre/include directory^>
         @echo     @set REGEX_DIR=^<your pcre/lib directory^>
+        @echo     @set ZLIB_DIR=^<your zlib directory^>
         exit /B 1
     )
     set all_set=
@@ -121,6 +125,7 @@ exit /B 0
             -Dopenssl_dir=%OPENSSL_DIR%^
             -Dregex_include_dir=%REGEX_INCLUDE_DIR%^
             -Dregex_dir=%REGEX_DIR%^
+            -Dzlib_dir=%ZLIB_DIR%^
             -Dcrypto=openssl^
             -Dnls=false^
             -Dsystemd=false^

--- a/configure.bat
+++ b/configure.bat
@@ -124,6 +124,7 @@ exit /B 0
     :: ------------------------------------
     :: Default flags for native compilation
     set CFLAGS=-Wno-language-extension-token %CFLAGS%
+    set CFLAGS=-DWIN32_LEAN_AND_MEAN %CFLAGS%
 
     if defined VERBOSE (
         set CFLAGS=-v %CFLAGS%

--- a/configure.bat
+++ b/configure.bat
@@ -67,6 +67,11 @@ exit /B 0
     set CFLAGS=-fansi-escape-codes -fcolor-diagnostics %CFLAGS%
 
     :: ---------------------------------
+    :: Reimplementing libraries
+    set CFLAGS=-I%cd:\=/%/src/lib/evil %CFLAGS%
+    set CFLAGS=-I%cd:\=/%/src/lib/evil/unposix/ %CFLAGS%
+
+    :: ---------------------------------
     :: Ignored warnings
     :: TODO: Re-enable warnings one by one and solve them.
 

--- a/configure.bat
+++ b/configure.bat
@@ -82,7 +82,7 @@ exit /B 0
         set CFLAGS=-Wno-nonportable-system-include-path %CFLAGS%
         set CFLAGS=-Wno-microsoft-enum-forward-reference %CFLAGS%
     :: Syntax/Parsing
-        :: set CFLAGS=-Wno-implicit-function-declaration %CFLAGS%
+        set CFLAGS=-Wno-implicit-function-declaration %CFLAGS%
         set CFLAGS=-Wno-missing-prototypes %CFLAGS%
         set CFLAGS=-Wno-unreachable-code %CFLAGS%
         set CFLAGS=-Wno-unreachable-code-return %CFLAGS%

--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -214,19 +214,14 @@ endif
 
 regexp = []
 if sys_windows == true
-  if sys_windows == true
-    inc_arg = '-I' + get_option('regex_include_dir')
-    if cc.has_header('regex.h', args: inc_arg) == false
-      error('regex can not be found')
-    endif
-    regexp = cc.find_library('pcre',
-                             dirs : [get_option('regex_dir')],
-                             required: true)
-  else
-    regexp = cc.find_library('regex',
-                             has_headers: ['regex.h', 'fnmatch.h'],
-                             required: true)
+  # PCRE
+  inc_arg = '-I' + get_option('regex_include_dir')
+  if cc.has_header('regex.h', args: inc_arg) == false
+    error('regex can not be found')
   endif
+  regexp = cc.find_library('pcre',
+                           dirs : [get_option('regex_dir')],
+                           required: true)
   if regexp.found() == false
     error('regex can not be found')
   endif

--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -213,19 +213,34 @@ if sys_linux and config_h.has('HAVE_LISTXATTR') and config_h.has('HAVE_SETXATTR'
 endif
 
 regexp = []
+zlib = []
 if sys_windows == true
   # PCRE
   inc_arg = '-I' + get_option('regex_include_dir')
   if cc.has_header('regex.h', args: inc_arg) == false
-    error('regex can not be found')
+    error('regex.h cannot be found')
   endif
   regexp = cc.find_library('pcre',
                            dirs : [get_option('regex_dir')],
                            required: true)
   if regexp.found() == false
-    error('regex can not be found')
+    error('regex library cannot be found')
+  endif
+
+  # zlib
+  zlib_dir = get_option('zlib_dir')
+  zlib_include_dir = zlib_dir + '/include'
+  if cc.has_header('zlib.h', args: '-I' + zlib_include_dir) == false
+    error('zlib.h cannot be found')
+  endif
+  zlib = cc.find_library('zlib',
+                         dirs: [zlib_dir + '/lib'],
+                         required: true)
+  if not zlib.found()
+    error('zlib library can not be found')
   endif
 else
+  zlib = dependency('zlib')
   if cc.has_header_symbol('fnmatch.h', 'fnmatch') == false
     error('fnmatch can not be found')
   endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -127,7 +127,13 @@ option('regex_include_dir',
 option('regex_dir',
   type : 'string',
   value : '',
-  description : 'Which SSL Crypto library used in efl'
+  description : 'Which is the /lib directory for PCRE'
+)
+
+option('zlib_dir',
+  type : 'string',
+  value : '',
+  description : 'Which is the /lib directory for zlib'
 )
 
 option('glib',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -133,7 +133,7 @@ option('regex_dir',
 option('zlib_dir',
   type : 'string',
   value : '',
-  description : 'Which is the /lib directory for zlib'
+  description : 'Which directory is zlib installed'
 )
 
 option('glib',

--- a/src/generic/evas/meson.build
+++ b/src/generic/evas/meson.build
@@ -11,7 +11,7 @@ subdir('common')
 
 common = static_library('evas_loader_common',
     generic_src,
-    include_directories : config_dir,
+    include_directories : [config_dir, zlib_include_dir],
     dependencies: [generic_deps, rt],
 )
 

--- a/src/generic/evas/xcf/meson.build
+++ b/src/generic/evas/xcf/meson.build
@@ -4,5 +4,5 @@ generic_src = files([
   'pixelfuncs.c'
 ])
 
-generic_deps = [eina, dependency('zlib')]
+generic_deps = [eina, zlib]
 generic_support = ['xcf.gz']

--- a/src/lib/eina/eina_counter.c
+++ b/src/lib/eina/eina_counter.c
@@ -20,8 +20,6 @@
 # include "config.h"
 #endif
 
-#ifdef HAVE_CYGWIN
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -226,5 +224,3 @@ eina_counter_dump(Eina_Counter *counter)
 
    return result;
 }
-
-#endif

--- a/src/lib/eina/eina_cpu.c
+++ b/src/lib/eina/eina_cpu.c
@@ -22,7 +22,9 @@
 
 #ifdef EFL_HAVE_THREADS
 # ifdef _WIN32
+#  ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN
+#  endif
 #  include <windows.h>
 # elif defined (__sun) || defined(__GNU__) || defined(__CYGWIN__)
 #  include <unistd.h>

--- a/src/lib/eina/eina_inline_private.h
+++ b/src/lib/eina/eina_inline_private.h
@@ -19,8 +19,6 @@
 #ifndef EINA_INLINE_PRIVATE_H_
 # define EINA_INLINE_PRIVATE_H_
 
-#ifdef HAVE_CYGWIN
-
 # include <time.h>
 # include <sys/time.h>
 
@@ -76,5 +74,4 @@ _eina_time_delta(Eina_Nano_Time *start, Eina_Nano_Time *end)
   return r;
 }
 
-#endif
 #endif

--- a/src/lib/eina/eina_xattr.h
+++ b/src/lib/eina/eina_xattr.h
@@ -21,7 +21,6 @@
 
 #include "eina_types.h"
 #include <sys/types.h>
-//#endif
 
 /**
  * @addtogroup Eina_Tools_Group Tools

--- a/src/lib/eina/eina_xattr.h
+++ b/src/lib/eina/eina_xattr.h
@@ -20,8 +20,8 @@
 #define EINA_XATTR_H_
 
 #include "eina_types.h"
-
 #include <sys/types.h>
+//#endif
 
 /**
  * @addtogroup Eina_Tools_Group Tools

--- a/src/lib/elementary/config_embed.bat
+++ b/src/lib/elementary/config_embed.bat
@@ -1,0 +1,3 @@
+@echo "static const char *embedded_config = \"\"" > %~2
+:: TODO: Sorry, no sed :)
+@echo "\"\";" >> %~2

--- a/src/lib/elementary/meson.build
+++ b/src/lib/elementary/meson.build
@@ -257,7 +257,11 @@ endforeach
 
 eolian_include_directories += ['-I', meson.current_source_dir()]
 
-embed_script = find_program('config_embed')
+if sys_windows == true
+  embed_script = find_program('config_embed.bat')
+else
+  embed_script = find_program('config_embed')
+endif
 
 embed_config = custom_target('create_embedded_default_config',
   input: join_paths(meson.source_root(), 'data', 'elementary', 'config', 'standard', 'base.src.in'),

--- a/src/lib/embryo/Embryo.h
+++ b/src/lib/embryo/Embryo.h
@@ -444,7 +444,7 @@ extern "C" {
 	Embryo_Cell c;
      } Embryo_Float_Cell;
 
-#if defined _MSC_VER || defined __SUNPRO_C
+#ifdef __SUNPRO_C
 /** Float to Embryo_Cell */
 # define EMBRYO_FLOAT_TO_CELL(f) (((Embryo_Float_Cell *)&(f))->c)
 /** Embryo_Cell to float */

--- a/src/lib/emile/meson.build
+++ b/src/lib/emile/meson.build
@@ -1,4 +1,4 @@
-emile_deps = [jpeg, crypto, dependency('zlib', required: false)]
+emile_deps = [jpeg, crypto, zlib]
 emile_pub_deps = [eina, efl]
 
 emile_headers = [

--- a/src/lib/evil/evil_eapi.h
+++ b/src/lib/evil/evil_eapi.h
@@ -1,0 +1,18 @@
+#ifndef EVIL_EAPI
+#define EVIL_EAPI
+
+#ifdef EAPI
+# undef EAPI
+#endif
+
+#ifdef EFL_BUILD
+# ifdef DLL_EXPORT
+#  define EAPI __declspec(dllexport)
+# else
+#  define EAPI
+# endif
+#else
+# define EAPI __declspec(dllimport)
+#endif
+
+#endif

--- a/src/lib/evil/evil_macro_wrapper.h
+++ b/src/lib/evil/evil_macro_wrapper.h
@@ -33,18 +33,6 @@
 #endif
 #define rename(src, dst) evil_rename(src, dst)
 
-/**
- * @def mkdir(dirname, mode)
- *
- * Wrapper around evil_mkdir().
- *
- * @since 1.15
- */
-#ifdef mkdir
-# undef mkdir
-#endif
-#define mkdir(dirname, mode) evil_mkdir(dirname, mode)
-
 /*
  * evil_unistd.h
  */

--- a/src/lib/evil/evil_macro_wrapper.h
+++ b/src/lib/evil/evil_macro_wrapper.h
@@ -33,6 +33,18 @@
 #endif
 #define rename(src, dst) evil_rename(src, dst)
 
+/**
+ * @def mkdir(dirname, mode)
+ *
+ * Wrapper around evil_mkdir().
+ *
+ * @since 1.15
+ */
+#ifdef mkdir
+# undef mkdir
+#endif
+#define mkdir(dirname, ...) _mkdir(dirname)
+
 /*
  * evil_unistd.h
  */

--- a/src/lib/evil/evil_private.h
+++ b/src/lib/evil/evil_private.h
@@ -30,19 +30,8 @@ extern "C" {
 #include <sys/stat.h> /* for mkdir in evil_macro_wrapper */
 
 
-#ifdef EAPI
-# undef EAPI
-#endif
+#include "evil_eapi.h"
 
-#ifdef EFL_BUILD
-# ifdef DLL_EXPORT
-#  define EAPI __declspec(dllexport)
-# else
-#  define EAPI
-# endif
-#else
-# define EAPI __declspec(dllimport)
-#endif
 
 #ifndef PATH_MAX
 # define PATH_MAX MAX_PATH

--- a/src/lib/evil/evil_stdlib.h
+++ b/src/lib/evil/evil_stdlib.h
@@ -1,6 +1,7 @@
 #ifndef __EVIL_STDLIB_H__
 #define __EVIL_STDLIB_H__
 
+#include <evil_private.h>
 
 /**
  * @file evil_stdlib.h

--- a/src/lib/evil/evil_string.h
+++ b/src/lib/evil/evil_string.h
@@ -35,7 +35,7 @@
  *
  * Supported OS: Windows XP.
  */
-EAPI char *strcasestr(const char *haystack, const char *needle);
+//EAPI char *strcasestr(const char *haystack, const char *needle);
 
 /**
  * @brief Implements the strsep function which is used to separate strings.

--- a/src/lib/evil/evil_string.h
+++ b/src/lib/evil/evil_string.h
@@ -35,7 +35,7 @@
  *
  * Supported OS: Windows XP.
  */
-//EAPI char *strcasestr(const char *haystack, const char *needle);
+EAPI char *strcasestr(const char *haystack, const char *needle);
 
 /**
  * @brief Implements the strsep function which is used to separate strings.

--- a/src/lib/evil/evil_time.c
+++ b/src/lib/evil/evil_time.c
@@ -3,11 +3,19 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <string.h>
+#include <strings.h>
 #include <inttypes.h>
 #include <ctype.h>
 #include <time.h>
 
+#include <Windows.h>
+
 #include "evil_private.h"
+
+inline struct tm *localtime_r(const time_t * time, struct tm * result)
+{
+    return NULL;
+}
 
 /*
  * strptime
@@ -68,6 +76,10 @@ static const char * const nadt[5] = {
    "EDT",    "CDT",    "MDT",    "PDT",    "\0\0\0"
 };
 
+/**
+ * Finds string in string table starting from table entry `n1` until entry
+ * `n2`.
+ */
 static const unsigned char *
 find_string(const unsigned char *bp, int *tgt,
             const char *const *n1, const char *const *n2,
@@ -416,8 +428,15 @@ strptime(const char *buf, const char *fmt, struct tm *tm)
               }
               else
                 {
+                   TIME_ZONE_INFORMATION zone_info;
+                   GetTimeZoneInformation(&zone_info);
+                   const char timezone_table[3] = {
+                       zone_info.StandardName,
+                       zone_info.DaylightName,
+                       NULL,
+                   };
                    ep = find_string(bp, &i,
-                                    (const char * const *)tzname,
+                                    (const char * const *)timezone_table,
                                     NULL, 2);
                    if (ep != NULL)
                      {

--- a/src/lib/evil/evil_unistd.h
+++ b/src/lib/evil/evil_unistd.h
@@ -1,6 +1,7 @@
 #ifndef __EVIL_UNISTD_H__
 #define __EVIL_UNISTD_H__
 
+#include "evil_eapi.h"
 
 /**
  * @file evil_unistd.h

--- a/src/lib/evil/unposix/fnmatch.h
+++ b/src/lib/evil/unposix/fnmatch.h
@@ -1,0 +1,23 @@
+#ifndef UNPOSIX_FNMATCH_H
+#define UNPOSIX_FNMATCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// The string does not match the specified pattern.
+#define FNM_NOMATCH 1
+// <slash> in string only matches <slash> in pattern.
+#define FNM_PATHNAME (1 << 0)
+// Disable backslash escaping.
+#define FNM_NOESCAPE (1 << 1)
+// Leading <period> in string must be exactly matched by <period> in pattern.
+#define FNM_PERIOD (1 << 2)
+
+int fnmatch(const char *, const char *, int);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/lib/evil/unposix/getopt.h
+++ b/src/lib/evil/unposix/getopt.h
@@ -1,0 +1,28 @@
+#ifndef UNPOSIX_GETOPT_H
+#define UNPOSIX_GETOPT_H
+
+#include "unimplemented.h"
+
+#include <unistd.h>
+
+UNIMPLEMENTED int getopt(int argc, char * const argv[],
+          const char *optstring)
+{
+#warning getopt is not implemented
+}
+
+#include_next <getopt.h>
+
+UNIMPLEMENTED int getopt_long(int argc, char * const argv[],
+          const char *optstring,
+          const struct option *longopts, int *longindex)
+{
+#warning getopt_long is not implemented
+}
+
+UNIMPLEMENTED int getopt_long_only(int argc, char * const argv[],
+          const char *optstring,
+          const struct option *longopts, int *longindex)
+{
+#warning getopt_long_only is not implemented
+}

--- a/src/lib/evil/unposix/libgen.h
+++ b/src/lib/evil/unposix/libgen.h
@@ -1,0 +1,7 @@
+#ifndef UNPOSIX_LIBGEN_H
+#define UNPOSIX_LIBGEN_H
+
+char *basename(char *);
+char *dirname(char *);
+
+#endif

--- a/src/lib/evil/unposix/limits.h
+++ b/src/lib/evil/unposix/limits.h
@@ -1,0 +1,17 @@
+#ifndef UNPOSIX_LIMITS_H
+#define UNPOSIX_LIMITS_H
+
+
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+# undef WIN32_LEAN_AND_MEAN
+# include_next <limits.h>
+# ifndef PATH_MAX
+#  define PATH_MAX MAX_PATH
+# endif
+#endif
+
+#endif

--- a/src/lib/evil/unposix/locale.h
+++ b/src/lib/evil/unposix/locale.h
@@ -1,0 +1,7 @@
+#ifndef UNPOSIX_LOCALE_H
+#define UNPOSIX_LOCALE_H
+
+#include_next <locale.h>
+typedef _locale_t locale_t;
+
+#endif

--- a/src/lib/evil/unposix/math.h
+++ b/src/lib/evil/unposix/math.h
@@ -1,0 +1,11 @@
+#ifndef UNPOSIX_MATH_H
+#define UNPOSIX_MATH_H
+
+
+#ifdef _WIN32
+# define _USE_MATH_DEFINES
+#endif
+#include_next <math.h>
+
+#endif
+

--- a/src/lib/evil/unposix/pthread.h
+++ b/src/lib/evil/unposix/pthread.h
@@ -1,28 +1,68 @@
 #ifndef PTHREAD_H
 #define PTHREAD_H
 
-struct pthread_key_t { int x; };
+#include "unimplemented.h"
 
-typedef struct pthread_key_t pthread_key_t;
+UNIMPLEMENTED typedef unsigned long long pthread_t;
 
-typedef struct { int x; } sem_t;
+UNIMPLEMENTED_STRUCT_T(pthread_mutexattr)
+UNIMPLEMENTED_STRUCT_T(pthread_condattr)
+UNIMPLEMENTED_STRUCT_T(pthread_attr)
+UNIMPLEMENTED_STRUCT_T(pthread_rwlock)
+UNIMPLEMENTED_STRUCT_T(pthread_cond)
+UNIMPLEMENTED_STRUCT_T(pthread_mutex)
+UNIMPLEMENTED_STRUCT_T(sem)
 
-struct pthread_mutex_t { int x; };
+UNIMPLEMENTED struct sched_param {
+    int sched_priority;
+};
 
-typedef struct pthread_mutex_t pthread_mutex_t;
+UNIMPLEMENTED typedef int pthread_key_t;
 
-struct pthread_cond_t { int x; };
+#define SCHED_RR 5
+#define SCHED_FIFO 6
 
-typedef struct pthread_cond_t pthread_cond_t;
+#define PTHREAD_BARRIER_SERIAL_THREAD 1
+#define PTHREAD_CANCEL_ASYNCHRONOUS 2
+#define PTHREAD_CANCEL_ENABLE 3
+#define PTHREAD_CANCEL_DEFERRED 4
+#define PTHREAD_CANCEL_DISABLE 5
+#define PTHREAD_CANCELED 6
+#define PTHREAD_CREATE_DETACHED 7
+#define PTHREAD_CREATE_JOINABLE 8
+#define PTHREAD_EXPLICIT_SCHED 9
+#define PTHREAD_INHERIT_SCHED 10
+#define PTHREAD_MUTEX_DEFAULT 11
+#define PTHREAD_MUTEX_ERRORCHECK 12
+#define PTHREAD_MUTEX_NORMAL 13
+#define PTHREAD_MUTEX_RECURSIVE 14
+#define PTHREAD_MUTEX_ROBUST 15
+#define PTHREAD_MUTEX_STALLED 16
+#define PTHREAD_ONCE_INIT 17
+#define PTHREAD_PRIO_INHERIT 18
+#define PTHREAD_PRIO_NONE 19
+#define PTHREAD_PRIO_PROTECT 20
+#define PTHREAD_PROCESS_SHARED 21
+#define PTHREAD_PROCESS_PRIVATE 22
+#define PTHREAD_SCOPE_PROCESS 23
+#define PTHREAD_SCOPE_SYSTEM 24
 
-struct pthread_rwlock_t { int x; };
+UNIMPLEMENTED inline int pthread_mutex_trylock(void* m)
+{
+    #warning pthread_mutex_trylock is not implemented.
+    return 0;
+}
 
-typedef struct pthread_rwlock_t pthread_rwlock_t;
+UNIMPLEMENTED inline int pthread_mutex_lock(void* m)
+{
+    #warning pthread_mutex_lock is not implemented.
+    return 0;
+}
 
-/* struct pthread_t { int x; }; */
-
-/* typedef struct pthread_t pthread_t; */
-
-typedef unsigned long long pthread_t;
+UNIMPLEMENTED inline int pthread_mutex_unlock(void* m)
+{
+    #warning pthread_mutex_unlock is not implemented.
+    return 0;
+}
 
 #endif

--- a/src/lib/evil/unposix/pthread.h
+++ b/src/lib/evil/unposix/pthread.h
@@ -1,0 +1,28 @@
+#ifndef PTHREAD_H
+#define PTHREAD_H
+
+struct pthread_key_t { int x; };
+
+typedef struct pthread_key_t pthread_key_t;
+
+typedef struct { int x; } sem_t;
+
+struct pthread_mutex_t { int x; };
+
+typedef struct pthread_mutex_t pthread_mutex_t;
+
+struct pthread_cond_t { int x; };
+
+typedef struct pthread_cond_t pthread_cond_t;
+
+struct pthread_rwlock_t { int x; };
+
+typedef struct pthread_rwlock_t pthread_rwlock_t;
+
+/* struct pthread_t { int x; }; */
+
+/* typedef struct pthread_t pthread_t; */
+
+typedef unsigned long long pthread_t;
+
+#endif

--- a/src/lib/evil/unposix/pthread.h
+++ b/src/lib/evil/unposix/pthread.h
@@ -65,4 +65,214 @@ UNIMPLEMENTED inline int pthread_mutex_unlock(void* m)
     return 0;
 }
 
+UNIMPLEMENTED inline int pthread_cond_wait(void* c, void* m)
+{
+    #warning pthread_cond_wait is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_cond_timedwait(void* c, void* m, int t)
+{
+    #warning pthread_cond_timedwait is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_cond_broadcast(void* c)
+{
+    #warning pthread_cond_broadcast is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_cond_signal(void* c)
+{
+    #warning pthread_cond_signal is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_rwlock_rdlock(void* c)
+{
+    #warning pthread_rwlock_rdlock is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_rwlock_wrlock(void* c)
+{
+    #warning pthread_rwlock_wrlock is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_rwlock_unlock(void* c)
+{
+    #warning pthread_rwlock_unlock is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_key_create(void* c, void * d)
+{
+    #warning pthread_key_create is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_key_delete(void* c)
+{
+    #warning pthread_key_delete is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_getspecific(void* c)
+{
+    #warning pthread_getspecific is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_setspecific(void* c, const void* d)
+{
+    #warning pthread_setspecific is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_mutexattr_init(void* c, ...)
+{
+    #warning pthread_mutexattr_init is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_getschedparam(void* a, ...)
+{
+    #warning pthread_getschedparam is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_self()
+{
+    #warning pthread_self is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_setschedparam(void* c, void* d, void* e)
+{
+    #warning pthread_ is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_rwlock_init(void* a, ...)
+{
+    #warning pthread_rwlock_init is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_mutexattr_settype(void* a, ...)
+{
+    #warning pthread_mutexattr_settype is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_mutex_init(void* a, ...)
+{
+    #warning pthread_mutex_init is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_mutex_destroy(void* a, ...)
+{
+    #warning pthread_mutex_destroy is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_condattr_init(void* a, ...)
+{
+    #warning pthread_condattr_init is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_cond_init(void* a, ...)
+{
+    #warning pthread_cond_init is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_condattr_destroy(void* a, ...)
+{
+    #warning pthread_condattr_destroy is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_cond_destroy(void* a, ...)
+{
+    #warning pthread_cond_destroy is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_rwlock_destroy(void* a, ...)
+{
+    #warning pthread_rwlock_destroy is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_cancel(void* a, ...)
+{
+    #warning pthread_cancel is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_setcancelstate(void* a, ...)
+{
+    #warning pthread_setcancelstate is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_testcancel()
+{
+    #warning pthread_testcancel is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_cleanup_pop(void* a, ...)
+{
+    #warning pthread_cleanup_pop is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_cleanup_push(void* a, ...)
+{
+    #warning pthread_cleanup_push is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_attr_init(void* a, ...)
+{
+    #warning pthread_attr_init is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_join(void* a, ...)
+{
+    #warning pthread_join is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_create(void* a, ...)
+{
+    #warning pthread_create is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_equal(void* a, ...)
+{
+    #warning pthread_equal is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_setcanceltype(void* a, ...)
+{
+    #warning pthread_setcanceltype is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline int pthread_mutexattr_destroy(void* a, ...)
+{
+    #warning pthread_mutexattr_destroy is not implemented.
+    return 0;
+}
+
 #endif

--- a/src/lib/evil/unposix/semaphore.h
+++ b/src/lib/evil/unposix/semaphore.h
@@ -1,17 +1,59 @@
 #ifndef SEMAPHORE_H
 #define SEMAPHORE_H
 
-int    sem_close(sem_t *);
-int    sem_destroy(sem_t *);
-int    sem_getvalue(sem_t *restrict, int *restrict);
-int    sem_init(sem_t *, int, unsigned);
-sem_t *sem_open(const char *, int, ...);
-int    sem_post(sem_t *);
-int    sem_timedwait(sem_t *restrict, const struct timespec *restrict);
-int    sem_trywait(sem_t *);
-int    sem_unlink(const char *);
-int    sem_wait(sem_t *);
+#include "unimplemented.h"
 
+UNIMPLEMENTED_STRUCT_T(sem)
+
+UNIMPLEMENTED inline int sem_close(sem_t* sem)
+{
+    #warning sem_close is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int sem_destroy(sem_t* sem)
+{
+    #warning sem_destroy is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int sem_getvalue(sem_t* restrict sem, int* restrict x)
+{
+    #warning sem_getvalue is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int sem_init(sem_t* sem, int x, unsigned y)
+{
+    #warning sem_init is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline sem_t* sem_open(const char* name, int x, ...)
+{
+    #warning sem_open is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int sem_post(sem_t* sem)
+{
+    #warning sem_post is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int sem_timedwait(sem_t* restrict sem, const struct timespec* restrict timeout)
+{
+    #warning sem_timedwait is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int sem_trywait(sem_t* sem)
+{
+    #warning sem_trywait is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int sem_unlink(const char* name)
+{
+    #warning sem_unlink is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int sem_wait(sem_t* sem)
+{
+    #warning sem_wait is not implemented
+    return 0;
+}
 
 #endif
-

--- a/src/lib/evil/unposix/semaphore.h
+++ b/src/lib/evil/unposix/semaphore.h
@@ -1,0 +1,17 @@
+#ifndef SEMAPHORE_H
+#define SEMAPHORE_H
+
+int    sem_close(sem_t *);
+int    sem_destroy(sem_t *);
+int    sem_getvalue(sem_t *restrict, int *restrict);
+int    sem_init(sem_t *, int, unsigned);
+sem_t *sem_open(const char *, int, ...);
+int    sem_post(sem_t *);
+int    sem_timedwait(sem_t *restrict, const struct timespec *restrict);
+int    sem_trywait(sem_t *);
+int    sem_unlink(const char *);
+int    sem_wait(sem_t *);
+
+
+#endif
+

--- a/src/lib/evil/unposix/stdlib.h
+++ b/src/lib/evil/unposix/stdlib.h
@@ -1,0 +1,27 @@
+#ifndef UNPOSIX_STDLIB_H
+#define UNPOSIX_STDLIB_H
+
+#include "unimplemented.h"
+
+#include <evil_stdlib.h>
+
+UNIMPLEMENTED inline int mkstemp(char* template)
+{
+    #warning mkstemp is not implemented
+    return 0;
+}
+UNIMPLEMENTED inline int mkostemp(char* template, int flags)
+{
+    #warning mkostemp is not implemented
+    return 0;
+}
+
+UNIMPLEMENTED inline int mkostemps(char* template, int suffixlen, int flags)
+{
+    #warning mkostemps is not implemented
+    return 0;
+}
+
+#include_next <stdlib.h>
+
+#endif

--- a/src/lib/evil/unposix/string.h
+++ b/src/lib/evil/unposix/string.h
@@ -1,0 +1,9 @@
+#ifndef UNPOSIX_STRING_H
+#define UNPOSIX_STRING_H
+
+#include_next <string.h>
+
+#include <strings.h>
+
+#endif
+

--- a/src/lib/evil/unposix/strings.h
+++ b/src/lib/evil/unposix/strings.h
@@ -1,0 +1,37 @@
+#ifndef UNPOSIX_STRINGS_H
+#define UNPOSIX_STRINGS_H
+
+#include <sys/types.h>
+#include <locale.h>
+
+inline int ffs(int i)
+{
+    #warning ffs is not implemented.
+    return 0;
+}
+
+inline int strcasecmp(const char* s1, const char* s2)
+{
+    #warning strcasecmp is not implemented.
+    return 0;
+}
+
+inline int strcasecmp_l(const char* s1, const char* s2, locale_t locale)
+{
+    #warning strcasecmp_l is not implemented.
+    return 0;
+}
+
+inline int strncasecmp(const char* s1, const char* s2, size_t size)
+{
+    #warning strncasecmp is not implemented.
+    return 0;
+}
+
+inline int strncasecmp_l(const char* s1, const char* s2, size_t size, locale_t locale)
+{
+    #warning strncasecmp_l is not implemented.
+    return 0;
+}
+
+#endif

--- a/src/lib/evil/unposix/sys/stat.h
+++ b/src/lib/evil/unposix/sys/stat.h
@@ -1,0 +1,32 @@
+#ifndef UNPOSIX_SYS_STAT_H
+#define UNPOSIX_SYS_STAT_H
+
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+#endif
+#include <../ucrt/sys/types.h>
+#include_next <sys/stat.h>
+#include <corecrt.h>
+
+// Missing definitions:
+// Note: some pieces of code were based on LibreSSL-Portable's compat lib and
+// adapted to EFL standards.
+#if defined(_MSC_VER)
+# define S_IRWXU  0                           /* RWX user */
+# define S_IRUSR  S_IREAD                     /* Read user */
+# define S_IWUSR  S_IWRITE                    /* Write user */
+# define S_IXUSR  0                           /* Execute user */
+# define S_IRWXG  0                           /* RWX group */
+# define S_IRGRP  0                           /* Read group */
+# define S_IWGRP  0                           /* Write group */
+# define S_IXGRP  0                           /* Execute group */
+# define S_IRWXO  0                           /* RWX others */
+# define S_IROTH  0                           /* Read others */
+# define S_IWOTH  0                           /* Write others */
+# define S_IXOTH  0                           /* Execute others */
+#endif
+
+#endif

--- a/src/lib/evil/unposix/sys/time.h
+++ b/src/lib/evil/unposix/sys/time.h
@@ -1,12 +1,26 @@
 #ifndef TIME_H
 #define TIME_H
 
-//typedef long time_t;
+#include "unimplemented.h"
+
+// Windows Kit for Windows 10 already defines `struct timeval` and `time_t`
+#include <winsock2.h>
+
+typedef unsigned short u_short;
 
 typedef long suseconds_t;
 
 typedef struct timeval timeval;
 
-int gettimeofday(timeval* a, void* b);
+UNIMPLEMENTED inline int gettimeofday(struct timeval* a, void* b) {
+    #warning gettimeofday is not implemented.
+    return 0;
+}
+
+UNIMPLEMENTED inline struct tm *localtime_r(const time_t * time, struct tm * result)
+{
+    #warning localtime_r is not implemented.
+    return 0;
+}
 
 #endif

--- a/src/lib/evil/unposix/sys/time.h
+++ b/src/lib/evil/unposix/sys/time.h
@@ -1,0 +1,12 @@
+#ifndef TIME_H
+#define TIME_H
+
+//typedef long time_t;
+
+typedef long suseconds_t;
+
+typedef struct timeval timeval;
+
+int gettimeofday(timeval* a, void* b);
+
+#endif

--- a/src/lib/evil/unposix/sys/types.h
+++ b/src/lib/evil/unposix/sys/types.h
@@ -1,0 +1,11 @@
+#ifndef UNPOSIX_SYS_TYPES_H
+#define UNPOSIX_SYS_TYPES_H
+
+#include <stdint.h>
+
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+#define ssize_t SSIZE_T
+#endif
+
+#endif

--- a/src/lib/evil/unposix/unimplemented.h
+++ b/src/lib/evil/unposix/unimplemented.h
@@ -1,0 +1,18 @@
+/**
+ * Defines stubs for unimplemented features/functions/structs in UNPOSIX namespace.
+ */
+#ifndef UNPOSIX_UNIMPLEMENTED_H
+#define UNPOSIX_UNIMPLEMENTED_H
+
+#define UNIMPLEMENTED // For future checks. Use when some type is just a stub to implement later.
+
+UNIMPLEMENTED struct unimplemented {
+    int attr;
+};
+
+UNIMPLEMENTED typedef struct unimplemented unimplemented_struct_t;
+
+#define UNIMPLEMENTED_STRUCT_T(type) typedef unimplemented_struct_t  type ## _t;
+#define UNIMPLEMENTED_STRUCT(type) struct type { int x; };
+
+#endif

--- a/src/lib/evil/unposix/unistd.h
+++ b/src/lib/evil/unposix/unistd.h
@@ -1,0 +1,6 @@
+#ifndef UNISTD_H
+#define UNISTD_H
+
+#include <evil_unistd.h>
+
+#endif

--- a/src/lib/evil/unposix/unistd.h
+++ b/src/lib/evil/unposix/unistd.h
@@ -1,6 +1,16 @@
 #ifndef UNISTD_H
 #define UNISTD_H
 
+#include "unimplemented.h"
+
 #include <evil_unistd.h>
+
+#define F_OK 0
+#define W_OK 2
+#define R_OK 4
+#define X_OK 0
+
+UNIMPLEMENTED extern char *optarg;
+UNIMPLEMENTED extern int optind, opterr, optopt;
 
 #endif


### PR DESCRIPTION
- Check filenames in `src/lib/evil/unposix/` for which missing headers are resolved;
- Also fixes `zlib` dependency by adding a `ZLIB_DIR` environment variable;
- Adds a `--verbose` flag for both `build.bat` and `configure.bat`:
  - `build --verbose` passes `--verbose` to `ninja`, so you see file by file what happened instead of just a build summary;
  - `configure --verbose` turns on `-v` flag for `clang-cl`, which shows include-paths used when compiling a file.
- Should resolve timezone API usage in `evil_time.c`.