### PR TITLE
Windows:sys/time.h: Correct sys/time.h errors

### DIFF
--- a/src/lib/evil/unposix/sys/time.c
+++ b/src/lib/evil/unposix/sys/time.c
@@ -25,4 +25,3 @@ struct tm *localtime_r(const time_t * time, struct tm * result)
     localtime_s(result, time);
     return result;
 }
-

--- a/src/lib/evil/unposix/sys/time.h
+++ b/src/lib/evil/unposix/sys/time.h
@@ -1,11 +1,17 @@
-#ifndef SYS_TIME_H
-#define SYS_TIME_H
+#ifndef UNPOSIX_SYS_TIME_H
+#define UNPOSIX_SYS_TIME_H
 
 #ifndef WIN32_LEAN_AND_MEAN
 # define WIN32_LEAN_AND_MEAN
 #endif
-// Windows Kit for Windows 10 already defines `struct timeval` and `time_t`
+
+#include <windows.h>
 #include <winsock2.h>
+#include <minwinbase.h>
+#include <sysinfoapi.h>
+#include <timezoneapi.h>
+
+#include <stdint.h>
 #include <time.h>
 
 typedef unsigned short u_short;
@@ -14,10 +20,6 @@ struct timezone {
   int tz_minuteswest;     /* minutes west of Greenwich */
   int tz_dsttime;         /* type of DST correction */
 };
-
-typedef long suseconds_t;
-
-typedef struct timeval timeval;
 
 int gettimeofday(struct timeval * tp, struct timezone * tzp);
 


### PR DESCRIPTION
Windows:sys/time.h: Correct sys/time.h errors

Summary:
The way sys/time.h was added it was not being compiled in the right way.
PR#16 makes possible to compile unposix/sys, so it was possible to
detect some errors.
The errors were about fault includes.
Now there should be no compile errors at sys/time.h.

Depends on PR#16

Test Plan:
- comment -Wno-missing-variable-declarations at meson.build;
- added -k0 to NINJAFLAGS at build.bat;
- there should not be any errors/warnings about sys/types.h.