### PR TITLE
Windows:sys/types.h: Should add every needed non pthread_* type

### DIFF
--- a/src/lib/evil/unposix/sys/time.h
+++ b/src/lib/evil/unposix/sys/time.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <time.h>
+#include <sys/types.h>
 
 typedef unsigned short u_short;
 

--- a/src/lib/evil/unposix/sys/types.h
+++ b/src/lib/evil/unposix/sys/types.h
@@ -1,11 +1,27 @@
 #ifndef UNPOSIX_SYS_TYPES_H
 #define UNPOSIX_SYS_TYPES_H
 
-#include <stdint.h>
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 
 #ifdef _MSC_VER
 #include <BaseTsd.h>
-#define ssize_t SSIZE_T
+typedef SSIZE_T ssize_t;
 #endif
+
+
+#include <stdint.h>
+#include <time.h>
+#include <wchar.h>
+#include <crtdefs.h>
+#include_next <sys/types.h>
+
+typedef int clockid_t;
+typedef int gid_t;
+typedef int mode_t;
+typedef unsigned long pid_t;
+typedef long suseconds_t;
+typedef int uid_t;
 
 #endif

--- a/src/lib/evil/unposix/sys/types.h
+++ b/src/lib/evil/unposix/sys/types.h
@@ -1,11 +1,11 @@
 #ifndef UNPOSIX_SYS_TYPES_H
 #define UNPOSIX_SYS_TYPES_H
 
+#ifdef _MSC_VER
 #ifndef WIN32_LEAN_AND_MEAN
 # define WIN32_LEAN_AND_MEAN
 #endif
 
-#ifdef _MSC_VER
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #endif


### PR DESCRIPTION
It does so by:
- including definitions that Windows already has;
- `typedef` the ones that Windows doesn't have, following `sys/types.h`
  manual guidelines;
- `pid_t` is a process id, so on this implementation is
  `typedef` as an `DWORD`, the type returned by `GetCurrentProcessId`
  function, and thus it is an `unsigned long`. `sys\types.h` manual
  establishes that it should be a `signed int` and when changed, it
  should not be larger than a `long`;

Depends on PR#16
Test Plan:
- comment `-Wno-missing-variable-declarations` at `meson.build`;
- added `-k0` to `NINJAFLAGS` at `build.bat`;
- there should not be any errors/warnings about sys/types.h.