### PR TITLE
windows: Enable implicit-function-declaration error.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,7 @@ if sys_windows == true
         '-Wno-nonportable-system-include-path',
         '-Wno-microsoft-enum-forward-reference',
       # Syntax/Parsing
-        '-Wno-implicit-function-declaration',
+      #'-Wno-implicit-function-declaration',
         '-Wno-missing-prototypes',
         '-Wno-unreachable-code',
         '-Wno-unreachable-code-return',
@@ -175,7 +175,7 @@ if sys_windows == true
       # ------------------------------------
       # Default flags for native compilation
       '-Wno-language-extension-token',
-      '-DWIN32_LEAN_AND_MEAN'
+      '-DWIN32_LEAN_AND_MEAN',
     ], language : 'c')
 endif
 


### PR DESCRIPTION
As implicit-function-declaration is a really important warning for who is
reviewing/creating PR's I suggest to disable
`Wno-implicit-function-declaration` at meson build. The ones who need
the warning disabled can do it themselves.