### PR TITLE
windows: Transform zlib and pcre into wrap dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,8 @@ efl_libs.csv
 
 #native windows files
 env.bat
+
+# Subprojects
+subprojects/pcre-*
+subprojects/zlib-*
+subprojects/packagecache

--- a/configure.bat
+++ b/configure.bat
@@ -25,26 +25,14 @@ exit /B %errorlevel%
 
     set all_set=1
     if not defined OPENSSL_DIR set all_set=0
-    if not defined REGEX_INCLUDE_DIR set all_set=0
-    if not defined REGEX_DIR set all_set=0
-    if not defined ZLIB_DIR set all_set=0
 
     if %all_set%==1 (
         @echo - Using OpenSSL: %OPENSSL_DIR%
-        @echo - Using Regex Include Directory: %REGEX_INCLUDE_DIR%
-        @echo - Using Regex Lib Directory: %REGEX_DIR%
-        @echo - Using zlib: %ZLIB_DIR%
     ) else (
         @echo At least one of the following variables were not set:
         @echo     - OPENSSL_DIR: %OPENSSL_DIR%
-        @echo     - REGEX_INCLUDE_DIR: %REGEX_INCLUDE_DIR%
-        @echo     - REGEX_DIR: %REGEX_DIR%
-        @echo     - ZLIB_DIR: %ZLIB_DIR%
         @echo Please define them using by creating a "env.bat" file containing:
         @echo     @set OPENSSL_DIR=^<your OpenSSL directory^>
-        @echo     @set REGEX_INCLUDE_DIR=^<your pcre/include directory^>
-        @echo     @set REGEX_DIR=^<your pcre/lib directory^>
-        @echo     @set ZLIB_DIR=^<your zlib directory^>
         exit /B 1
     )
     set all_set=
@@ -81,9 +69,6 @@ exit /B 0
     :: ------------------------------------------------------
     set MESONFLAGS=^
             -Dopenssl_dir="%OPENSSL_DIR:"=%"^
-            -Dregex_include_dir="%REGEX_INCLUDE_DIR:"=%"^
-            -Dregex_dir="%REGEX_DIR:"=%"^
-            -Dzlib_dir="%ZLIB_DIR:"=%"^
             -Dcrypto=openssl^
             -Dnls=false^
             -Dsystemd=false^

--- a/configure.bat
+++ b/configure.bat
@@ -54,11 +54,6 @@ exit /B 0
     :: Windows terminal specific options
     set CFLAGS=-fansi-escape-codes -fcolor-diagnostics %CFLAGS%
 
-    :: ---------------------------------
-    :: Reimplementing libraries
-    set CFLAGS=-I%cd:\=/%/src/lib/evil %CFLAGS%
-    set CFLAGS=-I%cd:\=/%/src/lib/evil/unposix/ %CFLAGS%
-
 
     if defined VERBOSE (
         set CFLAGS=-v %CFLAGS%

--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -212,41 +212,28 @@ if sys_linux and config_h.has('HAVE_LISTXATTR') and config_h.has('HAVE_SETXATTR'
   config_h.set10('HAVE_XATTR', true)
 endif
 
-regexp = []
-zlib = []
 if sys_windows == true
-  # PCRE
-  inc_arg = '-I' + get_option('regex_include_dir')
-  if cc.has_header('regex.h', args: inc_arg) == false
-    error('regex.h cannot be found')
-  endif
-  regexp = cc.find_library('pcre',
-                           dirs : [get_option('regex_dir')],
-                           required: true)
-  if regexp.found() == false
-    error('regex library cannot be found')
-  endif
+  # pcre
+  pcre_project = subproject('pcre')
+
+  pcre = pcre_project.get_variable('pcre8')
+  pcre_dep = pcre_project.get_variable('pcre_dep')
 
   # zlib
-  zlib_dir = get_option('zlib_dir')
-  zlib_include_dir = zlib_dir + '/include'
-  if cc.has_header('zlib.h', args: '-I' + zlib_include_dir) == false
-    error('zlib.h cannot be found (tried "' + zlib_include_dir + '")')
-  endif
-  zlib = cc.find_library('zlib',
-                         dirs: [zlib_dir + '/lib'],
-                         required: true)
-  if not zlib.found()
-    error('zlib library can not be found')
-  endif
+  zlib_project = subproject('zlib')
+
+  zlib = zlib_project.get_variable('zlib')
+  zlib_dep = zlib_project.get_variable('zlib_dep')
+  zlib_include_dir = zlib_project.get_variable('incdir')
 else
   zlib = dependency('zlib')
-  if cc.has_header_symbol('fnmatch.h', 'fnmatch') == false
-    error('fnmatch can not be found')
-  endif
   if cc.has_header_symbol('regex.h', 'regcomp') == false
     error('regcomp can not be found')
   endif
+endif
+
+if cc.has_header_symbol('fnmatch.h', 'fnmatch') == false
+  error('fnmatch can not be found')
 endif
 
 config_h.set('VMAJ', version_major)

--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -227,13 +227,13 @@ if sys_windows == true
   zlib_include_dir = zlib_project.get_variable('incdir')
 else
   zlib = dependency('zlib')
-  if cc.has_header_symbol('regex.h', 'regcomp') == false
+  if not cc.has_header_symbol('regex.h', 'regcomp')
     error('regcomp can not be found')
   endif
-endif
 
-if cc.has_header_symbol('fnmatch.h', 'fnmatch') == false
-  error('fnmatch can not be found')
+  if not cc.has_header_symbol('fnmatch.h', 'fnmatch')
+    error('fnmatch can not be found')
+  endif
 endif
 
 config_h.set('VMAJ', version_major)

--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -226,7 +226,7 @@ if sys_windows == true
   zlib_dep = zlib_project.get_variable('zlib_dep')
   zlib_include_dir = zlib_project.get_variable('incdir')
 else
-  zlib = dependency('zlib')
+  zlib_dep = dependency('zlib')
   if not cc.has_header_symbol('regex.h', 'regcomp')
     error('regcomp can not be found')
   endif

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,7 @@ foreach cf: dev_cflags_try
     dev_cflags += cf
   endif
 endforeach
+
 add_global_arguments(dev_cflags, language: 'c')
 add_global_arguments(dev_cflags, language: 'cpp')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -118,24 +118,6 @@ option('openssl_dir',
   description : 'Which directory is SSL library installed. Used only if crypto is set to openssl'
 )
 
-option('regex_include_dir',
-  type : 'string',
-  value : '',
-  description : 'Which directory contains the regex.h file for PCRE'
-)
-
-option('regex_dir',
-  type : 'string',
-  value : '',
-  description : 'Which is the /lib directory for PCRE'
-)
-
-option('zlib_dir',
-  type : 'string',
-  value : '',
-  description : 'Which directory is zlib installed'
-)
-
 option('glib',
   type : 'boolean',
   value : false,

--- a/src/generic/evas/meson.build
+++ b/src/generic/evas/meson.build
@@ -12,7 +12,7 @@ subdir('common')
 common = static_library('evas_loader_common',
     generic_src,
     include_directories : [config_dir, zlib_include_dir],
-    dependencies: [generic_deps, rt],
+    dependencies: [generic_deps, rt, evil_unposix],
 )
 
 bin_ext=''
@@ -32,7 +32,7 @@ foreach loader : generic_loaders
         generic_src,
         include_directories : config_dir + [include_directories('common')],
         link_with : common,
-        dependencies: [eina, generic_deps],
+        dependencies: [eina, generic_deps, evil_unposix],
         install_dir : join_paths(dir_lib, 'evas', 'utils'),
         install : true,
     )

--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -374,7 +374,7 @@ execinfo = cc.find_library('execinfo', required: false)
 
 eina_lib = library('eina', sources,
   include_directories : config_dir,
-  dependencies: [execinfo, iconv, eina_deps, thread_dep, eina_mem_pools, evil],
+  dependencies: [execinfo, iconv, eina_deps, thread_dep, eina_mem_pools, evil, evil_unposix],
   install: true,
   version : meson.project_version()
 )

--- a/src/lib/emile/meson.build
+++ b/src/lib/emile/meson.build
@@ -1,4 +1,4 @@
-emile_deps = [jpeg, crypto, zlib]
+emile_deps = [jpeg, crypto, zlib_dep]
 emile_pub_deps = [eina, efl]
 
 emile_headers = [

--- a/src/lib/eo/meson.build
+++ b/src/lib/eo/meson.build
@@ -47,7 +47,7 @@ eo_lib = library('eo',
     eo_src, pub_eo_file_target,
     dependencies: [eina, valgrind, execinfo],
     install: true,
-    version : meson.project_version()
+    version : meson.project_version(),
 )
 
 eo_lib_dbg = library('eo_dbg',
@@ -55,7 +55,7 @@ eo_lib_dbg = library('eo_dbg',
     dependencies: [eina, valgrind, execinfo],
     install: true,
     c_args : '-DEO_DEBUG',
-    version : meson.project_version()
+    version : meson.project_version(),
 )
 
 eo = declare_dependency(

--- a/src/lib/evas/meson.build
+++ b/src/lib/evas/meson.build
@@ -221,7 +221,7 @@ if cpu_sse3 == true or cpu_neon == true and cpu_neon_intrinsics == false
       evas_include_directories +
       [vg_common_inc_dir],
     c_args: native_arch_opt_c_args,
-    dependencies: [eina, eo, ector, emile, evas_deps, m],
+    dependencies: [eina, eo, ector, emile, evas_deps, m, evil_unposix],
   )
   evas_link += [ evas_opt ]
 endif
@@ -292,7 +292,7 @@ endforeach
 evas_lib = library('evas',
     include_directories: evas_include_directories + [vg_common_inc_dir],
     sources : [evas_src, pub_eo_file_target, priv_eo_file_target],
-    dependencies: [evas_deps, m, draw, valgrind, libunibreak, evas_static_list],
+    dependencies: [evas_deps, m, draw, valgrind, libunibreak, evas_static_list, evil_unposix],
     link_with: evas_link,
     install: true,
     c_args : '-DPACKAGE_DATA_DIR="'+join_paths(dir_data, 'evas')+'"',
@@ -302,13 +302,13 @@ evas_lib = library('evas',
 evas = declare_dependency(
    link_with : [evas_lib],
    sources: pub_eo_file_target,
-   dependencies : [m] + evas_pub_deps + evas_deps,
+   dependencies : [m] + evas_pub_deps + evas_deps + [evil_unposix],
    include_directories: evas_include_directories + [vg_common_inc_dir] + [include_directories(join_paths('..', '..', 'modules', 'evas', 'engines', 'buffer'))],
 )
 
 evas_bin = declare_dependency(
    link_with : [evas_lib],
-   dependencies : [eina, ecore, ector, emile, lua],
+   dependencies : [eina, ecore, ector, emile, lua, evil_unposix],
    include_directories : evas_include_directories
 )
 

--- a/src/lib/evil/meson.build
+++ b/src/lib/evil/meson.build
@@ -1,8 +1,7 @@
 evil_deps = []
 evil_pub_deps = []
-if target_machine.system() == 'windows'
-  subdir('unposix')
 
+if target_machine.system() == 'windows'
   evil_src = [
     'evil_dlfcn.c',
     'evil_fcntl.c',
@@ -40,6 +39,7 @@ if target_machine.system() == 'windows'
   )
 else
   evil = declare_dependency()
+  evil_unposix = declare_dependency()
 endif
 
 automatic_pkgfile = false

--- a/src/lib/evil/meson.build
+++ b/src/lib/evil/meson.build
@@ -1,7 +1,6 @@
-evil_deps = []
-evil_pub_deps = []
-
 if target_machine.system() == 'windows'
+  subdir('unposix')
+
   evil_src = [
     'evil_dlfcn.c',
     'evil_fcntl.c',
@@ -25,8 +24,11 @@ if target_machine.system() == 'windows'
   secur32 = cc.find_library('secur32')
   uuid = cc.find_library('uuid')
 
+  evil_deps = [psapi, ole32, ws2_32, secur32, uuid, pcre_dep, evil_unposix]
+  evil_pub_deps = [psapi, ole32, ws2_32, secur32, uuid, pcre_dep, evil_unposix]
+
   evil_lib = library('evil', evil_src,
-    dependencies : [psapi, ole32, ws2_32, secur32, uuid, pcre_dep, evil_unposix],
+    dependencies : evil_deps,
     include_directories : [config_dir],
     install: true,
     version: meson.project_version(),
@@ -34,7 +36,7 @@ if target_machine.system() == 'windows'
 
   evil = declare_dependency(
     include_directories: [include_directories('.')],
-    dependencies : [psapi, ole32, ws2_32, secur32, uuid, pcre_dep, evil_unposix],
+    dependencies : evil_pub_deps,
     link_with: evil_lib,
   )
 else

--- a/src/lib/evil/meson.build
+++ b/src/lib/evil/meson.build
@@ -27,7 +27,7 @@ if target_machine.system() == 'windows'
   uuid = cc.find_library('uuid')
 
   evil_lib = library('evil', evil_src,
-    dependencies : [psapi, ole32, ws2_32, secur32, uuid, regexp],
+    dependencies : [psapi, ole32, ws2_32, secur32, uuid, pcre_dep],
     include_directories : [config_dir],
     install: true,
     version: meson.project_version(),
@@ -35,7 +35,7 @@ if target_machine.system() == 'windows'
 
   evil = declare_dependency(
     include_directories: [include_directories('.')],
-    dependencies : [psapi, ole32, ws2_32, secur32, uuid, regexp],
+    dependencies : [psapi, ole32, ws2_32, secur32, uuid, pcre_dep],
     link_with: evil_lib,
   )
 else

--- a/src/lib/evil/meson.build
+++ b/src/lib/evil/meson.build
@@ -27,7 +27,7 @@ if target_machine.system() == 'windows'
   uuid = cc.find_library('uuid')
 
   evil_lib = library('evil', evil_src,
-    dependencies : [psapi, ole32, ws2_32, secur32, uuid, pcre_dep],
+    dependencies : [psapi, ole32, ws2_32, secur32, uuid, pcre_dep, evil_unposix],
     include_directories : [config_dir],
     install: true,
     version: meson.project_version(),
@@ -35,7 +35,7 @@ if target_machine.system() == 'windows'
 
   evil = declare_dependency(
     include_directories: [include_directories('.')],
-    dependencies : [psapi, ole32, ws2_32, secur32, uuid, pcre_dep],
+    dependencies : [psapi, ole32, ws2_32, secur32, uuid, pcre_dep, evil_unposix],
     link_with: evil_lib,
   )
 else

--- a/src/lib/evil/pcre/regex.h
+++ b/src/lib/evil/pcre/regex.h
@@ -1,6 +1,6 @@
-#ifndef __EVIL_PCRE_REGEX_H__
-#define __EVIL_PCRE_REGEX_H__
+#ifndef EVIL_PCRE_REGEX_H
+#define EVIL_PCRE_REGEX_H
 
-#include <pcreposix.h>
+#include <pcre.h>
 
 #endif

--- a/src/lib/evil/unposix/meson.build
+++ b/src/lib/evil/unposix/meson.build
@@ -24,14 +24,14 @@ if sys_windows
   evil_unposix_lib = static_library('evil_unposix',
     evil_unposix_src,
     include_directories: [include_directories('.'), config_dir],
-    dependencies : [],
+    dependencies : [pcre_dep],
     install: true,
     version: meson.project_version(),
   )
 
   evil_unposix = declare_dependency(
     include_directories: [include_directories('.')],
-    dependencies: [],
+    dependencies: [pcre_dep],
     link_with: evil_unposix_lib,
   )
 

--- a/src/lib/evil/unposix/meson.build
+++ b/src/lib/evil/unposix/meson.build
@@ -1,8 +1,6 @@
 dir_package_include = '.'
 
-if target_machine.system() == 'windows'
-  subdir('sys')
-
+if sys_windows
   evil_unposix_src = []
 
   evil_unposix_header_src = [
@@ -21,6 +19,7 @@ if target_machine.system() == 'windows'
     'unistd.h',
   ]
 
+  subdir('sys')
 
   evil_unposix_lib = static_library('evil_unposix',
     evil_unposix_src,
@@ -39,10 +38,8 @@ if target_machine.system() == 'windows'
   install_headers(evil_unposix_header_src,
     install_dir : dir_package_include,
   )
-
 else
   evil_unposix = declare_dependency()
-
 endif
 
 automatic_pkgfile = (sys_windows == false)

--- a/src/lib/evil/unposix/stdlib.h
+++ b/src/lib/evil/unposix/stdlib.h
@@ -3,7 +3,7 @@
 
 #include "unimplemented.h"
 
-#include <evil_stdlib.h>
+#include_next <stdlib.h>
 
 UNIMPLEMENTED inline int mkstemp(char* template)
 {

--- a/src/lib/evil/unposix/sys/meson.build
+++ b/src/lib/evil/unposix/sys/meson.build
@@ -1,31 +1,11 @@
-if target_machine.system() == 'windows'
-
-  evil_unposix_sys_src = [
-    'time.c',
+if sys_windows
+  evil_unposix_src += [
+    'sys/time.c',
   ]
 
-  evil_unposix_sys_header_src = [
-    'time.h', 
-    'stat.h', 
-    'types.h'
+  evil_unposix_header_src += [
+    'sys/time.h',
+    'sys/stat.h',
+    'sys/types.h'
   ]
-
-  evil_unposix_sys_lib = library('evil_unposix_sys',
-    evil_unposix_sys_src,
-    version: meson.project_version(),
-    install: true,
-  )
-  
-  evil_unposix_sys = declare_dependency(
-    include_directories: [include_directories('.')],
-    dependencies: [],
-    link_with: evil_unposix_sys_lib,
-  )
-
-  install_headers(evil_unposix_sys_header_src,
-    install_dir : dir_package_include,
-  ) 
-
 endif
-
-automatic_pkgfile = (sys_windows == false)

--- a/src/lib/evil/unposix/sys/time.c
+++ b/src/lib/evil/unposix/sys/time.c
@@ -1,4 +1,4 @@
-#include<sys/time.h>
+#include <sys/time.h>
 
 int gettimeofday(struct timeval * tp, struct timezone * tzp)
 {

--- a/src/lib/evil/unposix/unistd.h
+++ b/src/lib/evil/unposix/unistd.h
@@ -3,8 +3,6 @@
 
 #include "unimplemented.h"
 
-#include <evil_unistd.h>
-
 #define F_OK 0
 #define W_OK 2
 #define R_OK 4

--- a/subprojects/pcre.wrap
+++ b/subprojects/pcre.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = pcre-8.37
+
+source_url = https://ftp.pcre.org/pub/pcre/pcre-8.37.tar.bz2
+source_filename = pcre-8.37.tar.bz2
+source_hash = 51679ea8006ce31379fb0860e46dd86665d864b5020fc9cd19e71260eef4789d
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/pcre/8.37/1/get_zip
+patch_filename = pcre-8.37-1-wrap.zip
+patch_hash = c0e179b0e8bcf0ecfb17d7154cc666070e3bde698126c2b2fefa37b6120328bf

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = zlib-1.2.11
+
+source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
+source_filename = zlib-1.2.11.tar.gz
+source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/4/get_zip
+patch_filename = zlib-1.2.11-4-wrap.zip
+patch_hash = f733976fbfc59e0bcde01aa9469a24eeb16faf0a4280b17e9eaa60a301d75657


### PR DESCRIPTION
Title says it all.

This way we don't have to deal with compiling zlib nor pcre separately, and it is built using `clang-cl` itself, in a manner meson expects. No need for `{ZLIB,REGEX_LIB,REGEX_INCLUDE}_DIR` env-vars.

Next step: do the same with OpenSSL.