### PR TITLE
Compile `devs/expertise/native-windows on Linux

### DIFF
--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -212,7 +212,7 @@ if sys_linux and config_h.has('HAVE_LISTXATTR') and config_h.has('HAVE_SETXATTR'
   config_h.set10('HAVE_XATTR', true)
 endif
 
-if sys_windows == true
+if sys_windows
   # pcre
   pcre_project = subproject('pcre')
 
@@ -245,7 +245,9 @@ config_h.set('VREV', '0')
 
 jpeg = dependency('libjpeg', required: false)
 if jpeg.found() == false
-#  jpeg = cc.find_library('jpeg')
+  if not sys_windows
+    jpeg = cc.find_library('jpeg')
+  endif
 endif
 
 if sys_bsd == true

--- a/meson.build
+++ b/meson.build
@@ -91,12 +91,12 @@ endforeach
 add_global_arguments(dev_cflags, language: 'c')
 add_global_arguments(dev_cflags, language: 'cpp')
 
-if not get_option('dbus')
-  dbus = declare_dependency()
-  eldbus = declare_dependency()
-endif
+if sys_windows
+  if not get_option('dbus')
+    dbus = declare_dependency()
+    eldbus = declare_dependency()
+  endif
 
-if sys_windows == true
   dl = declare_dependency()
   m = declare_dependency()
 
@@ -361,7 +361,11 @@ luaold_interpreters = [
 
 lua_pc_name = ''
 
-if get_option('lua-interpreter') == 'lua'
+if sys_windows or get_option('lua-interpreter') == 'lua'
+  if sys_windows and get_option('lua-interpreter') != 'lua'
+    warning('There is no "' + get_option('lua-interpreter')
+            + '" binding option for Windows, backing up to "lua"')
+  endif
   foreach l : luaold_interpreters
     lua = dependency(l[0], version: l[1], required:false)
     lua_pc_name = l[0]
@@ -371,8 +375,7 @@ if get_option('lua-interpreter') == 'lua'
   endforeach
 else
   lua = dependency(get_option('lua-interpreter'))
-  #lua_pc_name = 'luajit'
-  lua_pc_name = 'lua'
+  lua_pc_name = 'luajit'
 endif
 
 if sys_osx == true and get_option('lua-interpreter') == 'luajit'
@@ -392,8 +395,17 @@ subprojects = [
 ['efl'              ,[]                    , false,  true, false, false,  true, false, ['eo'], []],
 ['emile'            ,[]                    , false,  true, false, false,  true,  true, ['eina', 'efl'], ['lz4', 'rg_etc']],
 ['eet'              ,[]                    , false,  true,  true, false,  true,  true, ['eina', 'emile', 'efl'], []],
-['ecore'            ,[]                    , false,  true, false, false, false, false, ['eina', 'eo', 'efl'], ['buildsystem']],
-# ['eldbus'           ,[]                    , false,  true,  true, false,  true,  true, ['eina', 'eo', 'efl'], []],
+['ecore'            ,[]                    , false,  true, false, false, false,
+  false, ['eina', 'eo', 'efl'], ['buildsystem']]]
+
+if not sys_windows
+  subprojects += [['eldbus'           ,[]                    , false,  true,
+    true, false,  true,  true, ['eina', 'eo', 'efl'], []]]
+  assert(subprojects[-1] == ['eldbus'           ,[]                    , false,
+    true, true, false,  true,  true, ['eina', 'eo', 'efl'], []])
+endif
+
+subprojects += [
 ['ecore'            ,[]                    ,  true, false, false, false,  true,  true, ['eina', 'eo', 'efl'], []], #ecores modules depend on eldbus
 ['ecore_audio'      ,['audio']             , false,  true, false, false, false, false, ['eina', 'eo'], []],
 ['ecore_avahi'      ,['avahi']             , false,  true, false, false, false,  true, ['eina', 'ecore'], []],
@@ -408,8 +420,17 @@ subprojects = [
 ['ecore_win32'      ,[]                    , false,  true, false, false, false, false, ['eina'], []],
 ['ecore_ipc'        ,[]                    , false,  true, false, false, false, false, ['eina'], []],
 ['ecore_buffer'     ,['buffer']            ,  true,  true,  true, false, false, false, ['eina'], []],
-['ector'            ,[]                    , false,  true, false, false,  true, false, ['eina', 'efl'], ['draw', 'triangulator', 'freetype']],
-# ['elput'            ,['drm']               , false,  true, false, false,  true, false, ['eina', 'eldbus'], []],
+['ector'            ,[]                    , false,  true, false, false,  true,
+  false, ['eina', 'efl'], ['draw', 'triangulator', 'freetype']],]
+
+if not sys_windows
+  subprojects +=  [['elput'            ,['drm']               , false,  true,
+    false, false,  true, false, ['eina', 'eldbus'], []]]
+  assert(subprojects[-1] == ['elput'            ,['drm']               , false,
+    true, false, false,  true, false, ['eina', 'eldbus'], []])
+endif
+
+subprojects += [
 ['ecore_drm2'       ,['drm']               , false,  true, false, false, false, false, ['ecore'], ['libdrm']],
 ['ecore_cocoa'      ,['cocoa']             , false,  true, false, false, false, false, ['eina'], []],
 ['evas'             ,[]                    ,  true,  true, false, false,  true,  true, ['eina', 'efl', 'eo'], ['vg_common', 'libunibreak']],
@@ -427,12 +448,29 @@ subprojects = [
 ['ethumb'           ,[]                    ,  true,  true,  true, false, false, false, ['eina', 'efl', 'eo'], []],
 ['ethumb_client'    ,[]                    , false,  true,  true, false, false,  true, ['eina', 'efl', 'eo', 'ethumb'], []],
 ['elementary'       ,[]                    ,  true,  true,  true,  true,  true,  true, ['eina', 'efl', 'eo', 'eet', 'evas', 'ecore', 'ecore-evas', 'ecore-file', 'ecore-input', 'edje', 'ethumb-client', 'emotion', 'ecore-imf', 'ecore-con', 'eldbus', 'efreet', 'efreet-mime', 'efreet-trash', 'eio'], ['atspi']],
-['efl_canvas_wl'    ,['wl']                , false,  true,  true, false, false, false, ['eina', 'efl', 'eo', 'evas', 'ecore'], []],
-['elua'             ,['elua']              , false,  true,  true, false,  true, false, ['eina', 'luajit'], []],
+['efl_canvas_wl'    ,['wl']                , false,  true,  true, false, false,
+  false, ['eina', 'efl', 'eo', 'evas', 'ecore'], []],]
+
+if not sys_windows
+  subprojects +=  [['elua'             ,['elua']              , false,  true,
+    true, false,  true, false, ['eina', 'luajit'], []]]
+  assert(subprojects[-1] == ['elua'             ,['elua']              , false,
+    true, true, false,  true, false, ['eina', 'luajit'], []])
+else
+  subprojects +=  [['elua'             ,['elua']              , false,  true,
+    true, false,  true, false, ['eina', 'lua'], []]]
+  assert(subprojects[-1] == ['elua'             ,['elua']              , false,
+    true, true, false,  true, false, ['eina', 'lua'], []])
+endif
+
+subprojects += [
 ['ecore_wayland'    ,['wl-deprecated']     , false,  true, false, false, false, false, ['eina'], []],
 ['ecore_drm'        ,['drm-deprecated']    , false,  true, false, false, false, false, ['eina'], []],
 ['exactness'        ,[]                    , false,  false,  true, false, false, false, ['eina, evas, eet'], []],
 ]
+
+assert(subprojects[-1] == ['exactness'        ,[]                    , false,
+  false,  true, false, false, false, ['eina, evas, eet'], []])
 
 # We generate Efl_Config.h and config.h later, they will be available here
 config_dir += include_directories('.')
@@ -621,8 +659,9 @@ configure_file(
 )
 
 subdir(join_paths('systemd-services'))
-if get_option('dbus')
-subdir(join_paths('dbus-services'))
+
+if not sys_windows and get_option('dbus')
+  subdir(join_paths('dbus-services'))
 endif
 
 if sys_windows == false

--- a/meson.build
+++ b/meson.build
@@ -395,14 +395,11 @@ subprojects = [
 ['efl'              ,[]                    , false,  true, false, false,  true, false, ['eo'], []],
 ['emile'            ,[]                    , false,  true, false, false,  true,  true, ['eina', 'efl'], ['lz4', 'rg_etc']],
 ['eet'              ,[]                    , false,  true,  true, false,  true,  true, ['eina', 'emile', 'efl'], []],
-['ecore'            ,[]                    , false,  true, false, false, false,
-  false, ['eina', 'eo', 'efl'], ['buildsystem']]]
+['ecore'            ,[]                    , false,  true, false, false, false, false, ['eina', 'eo', 'efl'], ['buildsystem']]]
 
 if not sys_windows
   subprojects += [['eldbus'           ,[]                    , false,  true,
     true, false,  true,  true, ['eina', 'eo', 'efl'], []]]
-  assert(subprojects[-1] == ['eldbus'           ,[]                    , false,
-    true, true, false,  true,  true, ['eina', 'eo', 'efl'], []])
 endif
 
 subprojects += [
@@ -426,8 +423,6 @@ subprojects += [
 if not sys_windows
   subprojects +=  [['elput'            ,['drm']               , false,  true,
     false, false,  true, false, ['eina', 'eldbus'], []]]
-  assert(subprojects[-1] == ['elput'            ,['drm']               , false,
-    true, false, false,  true, false, ['eina', 'eldbus'], []])
 endif
 
 subprojects += [
@@ -454,13 +449,9 @@ subprojects += [
 if not sys_windows
   subprojects +=  [['elua'             ,['elua']              , false,  true,
     true, false,  true, false, ['eina', 'luajit'], []]]
-  assert(subprojects[-1] == ['elua'             ,['elua']              , false,
-    true, true, false,  true, false, ['eina', 'luajit'], []])
 else
   subprojects +=  [['elua'             ,['elua']              , false,  true,
     true, false,  true, false, ['eina', 'lua'], []]]
-  assert(subprojects[-1] == ['elua'             ,['elua']              , false,
-    true, true, false,  true, false, ['eina', 'lua'], []])
 endif
 
 subprojects += [
@@ -468,9 +459,6 @@ subprojects += [
 ['ecore_drm'        ,['drm-deprecated']    , false,  true, false, false, false, false, ['eina'], []],
 ['exactness'        ,[]                    , false,  false,  true, false, false, false, ['eina, evas, eet'], []],
 ]
-
-assert(subprojects[-1] == ['exactness'        ,[]                    , false,
-  false,  true, false, false, false, ['eina, evas, eet'], []])
 
 # We generate Efl_Config.h and config.h later, they will be available here
 config_dir += include_directories('.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -297,8 +297,8 @@ option('nls',
 
 option('bindings',
   type : 'array',
-  choices : ['cxx', 'mono'],
-  value : ['cxx'],
+  choices : ['luajit','cxx', 'mono'],
+  value : ['luajit', 'cxx'],
   description : 'Which auto-generated language bindings for efl to enable',
 )
 
@@ -334,8 +334,8 @@ option('dotnet',
 
 option('lua-interpreter',
   type: 'combo',
-  choices: ['lua'],
-  value: 'lua',
+  choices: ['luajit', 'lua'],
+  value: 'luajit',
   description: 'Which Lua back-end library to use in efl'
 )
 

--- a/src/bindings/cxx/meson.build
+++ b/src/bindings/cxx/meson.build
@@ -9,8 +9,14 @@ cxx_sublibs = [
   ['Eet',         true,  true, false, []],
   ['Eio',        false, false,  true, []],
   ['Evas',       false,  true,  true, []],
-  ['Edje',       false, false,  true, []],
-#  ['Eldbus',      true,  true,  true, []],
+  ['Edje',       false, false,  true, []],]
+
+if (not sys_windows)
+  cxx_sublibs += [['Eldbus',      true,  true,  true, []]]
+  assert(cxx_sublibs[-1] == ['Eldbus',      true,  true,  true, []])
+endif
+
+cxx_sublibs += [
   ['Elementary',  true,  true,  true, []]
 ]
 

--- a/src/bindings/cxx/meson.build
+++ b/src/bindings/cxx/meson.build
@@ -11,9 +11,8 @@ cxx_sublibs = [
   ['Evas',       false,  true,  true, []],
   ['Edje',       false, false,  true, []],]
 
-if (not sys_windows)
+if not sys_windows
   cxx_sublibs += [['Eldbus',      true,  true,  true, []]]
-  assert(cxx_sublibs[-1] == ['Eldbus',      true,  true,  true, []])
 endif
 
 cxx_sublibs += [

--- a/src/bindings/meson.build
+++ b/src/bindings/meson.build
@@ -1,6 +1,6 @@
 
 bindings = get_option('bindings')
-if (not sys_windows)
+if not sys_windows
   bindings_order = ['luajit', 'cxx', 'mono']
 else
   bindings_order = ['lua', 'cxx', 'mono']

--- a/src/bindings/meson.build
+++ b/src/bindings/meson.build
@@ -1,6 +1,10 @@
 
 bindings = get_option('bindings')
-bindings_order = ['cxx', 'mono']
+if (not sys_windows)
+  bindings_order = ['luajit', 'cxx', 'mono']
+else
+  bindings_order = ['lua', 'cxx', 'mono']
+endif
 
 if (get_option('dotnet') and not bindings.contains('mono'))
   message('dotnet support requires the C# bindings')

--- a/src/generic/evas/meson.build
+++ b/src/generic/evas/meson.build
@@ -9,10 +9,22 @@ generic_deps = []
 
 subdir('common')
 
+inc_dir = config_dir
+common_deps = generic_deps
+if (sys_windows)
+  inc_dir = [inc_dir, zlib_include_dir]
+  assert(inc_dir[0] == config_dir)
+  assert(inc_dir[1] == zlib_include_dir)
+else
+  common_deps = [generic_deps, rt]
+  assert(common_deps[0] == generic_deps)
+  assert(common_deps[1] == rt)
+endif
+
 common = static_library('evas_loader_common',
     generic_src,
-    include_directories : [config_dir, zlib_include_dir],
-    dependencies: [generic_deps, rt, evil_unposix],
+    include_directories : inc_dir,
+    dependencies: common_deps,
 )
 
 bin_ext=''

--- a/src/generic/evas/meson.build
+++ b/src/generic/evas/meson.build
@@ -11,14 +11,10 @@ subdir('common')
 
 inc_dir = config_dir
 common_deps = generic_deps
-if (sys_windows)
+if sys_windows
   inc_dir = [inc_dir, zlib_include_dir]
-  assert(inc_dir[0] == config_dir)
-  assert(inc_dir[1] == zlib_include_dir)
 else
   common_deps = [generic_deps, rt]
-  assert(common_deps[0] == generic_deps)
-  assert(common_deps[1] == rt)
 endif
 
 common = static_library('evas_loader_common',

--- a/src/generic/evas/xcf/meson.build
+++ b/src/generic/evas/xcf/meson.build
@@ -4,7 +4,7 @@ generic_src = files([
   'pixelfuncs.c'
 ])
 
-if (not sys_windows)
+if not sys_windows
   generic_deps = [eina, dependency('zlib')]
 else
   generic_deps = [eina, zlib]

--- a/src/generic/evas/xcf/meson.build
+++ b/src/generic/evas/xcf/meson.build
@@ -4,5 +4,9 @@ generic_src = files([
   'pixelfuncs.c'
 ])
 
-generic_deps = [eina, zlib]
+if (not sys_windows)
+  generic_deps = [eina, dependency('zlib')]
+else
+  generic_deps = [eina, zlib]
+endif
 generic_support = ['xcf.gz']

--- a/src/lib/ecore/meson.build
+++ b/src/lib/ecore/meson.build
@@ -196,10 +196,17 @@ if get_option('systemd') == true
   ecore_deps += systemd
 endif
 
+if (not sys_windows)
+  ecore_lib_deps = [m, buildsystem, ecore_deps]
+else
+  ecore_lib_deps = [buildsystem, ecore_deps]
+endif
+
 ecore_lib = library('ecore',
     ecore_src, pub_eo_file_target,
-    dependencies: ecore_pub_deps + [buildsystem, ecore_deps],
-    include_directories : config_dir + [include_directories(join_paths('..','..'))],
+    dependencies: ecore_pub_deps + ecore_lib_deps,
+    include_directories : config_dir +
+                          [include_directories(join_paths('..','..'))],
     install: true,
     c_args : package_c_args,
     version : meson.project_version()

--- a/src/lib/ecore/meson.build
+++ b/src/lib/ecore/meson.build
@@ -196,7 +196,7 @@ if get_option('systemd') == true
   ecore_deps += systemd
 endif
 
-if (not sys_windows)
+if not sys_windows
   ecore_lib_deps = [m, buildsystem, ecore_deps]
 else
   ecore_lib_deps = [buildsystem, ecore_deps]

--- a/src/lib/eet/meson.build
+++ b/src/lib/eet/meson.build
@@ -1,7 +1,6 @@
 eet_deps = [crypto, jpeg, rg_etc]
 if not sys_windows
   eet_deps += m
-  assert(eet_deps[-1] == m)
 endif
 
 eet_pub_deps = [eina, emile, efl]

--- a/src/lib/eet/meson.build
+++ b/src/lib/eet/meson.build
@@ -1,4 +1,9 @@
 eet_deps = [crypto, jpeg, rg_etc]
+if not sys_windows
+  eet_deps += m
+  assert(eet_deps[-1] == m)
+endif
+
 eet_pub_deps = [eina, emile, efl]
 
 eet_header_src = [

--- a/src/lib/efl/meson.build
+++ b/src/lib/efl/meson.build
@@ -11,9 +11,15 @@ efl_src = []
 subdir('interfaces')
 package_header_subdirs += 'interfaces'
 
+efl_lib_deps = [eina, eo]
+
+if not sys_windows
+  efl_lib_deps += m
+endif
+
 efl_lib = library('efl',
     efl_src, pub_eo_file_target,
-    dependencies: [eina, eo],
+    dependencies: efl_lib_deps,
     install: true,
     version : meson.project_version()
 )

--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -1,4 +1,4 @@
-if sys_windows == false
+if not sys_windows
   eina_deps = [dl]
 else
   eina_deps = []
@@ -372,9 +372,16 @@ endif
 
 execinfo = cc.find_library('execinfo', required: false)
 
+if sys_windows
+  eina_lib_deps = [execinfo, iconv, eina_deps, thread_dep, eina_mem_pools, evil]
+else
+  eina_lib_deps = [m, rt, dl, execinfo, iconv, eina_deps, thread_dep
+                  , eina_mem_pools, evil]
+endif
+
 eina_lib = library('eina', sources,
   include_directories : config_dir,
-  dependencies: [execinfo, iconv, eina_deps, thread_dep, eina_mem_pools, evil, evil_unposix],
+  dependencies: eina_lib_deps,
   install: true,
   version : meson.project_version()
 )
@@ -396,7 +403,7 @@ install_headers(public_sub_headers,
 
 automatic_pkgfile = false
 
-if sys_windows == false
+if not sys_windows
 pkgconfig.generate(eina_lib,
   name : 'eina',
   subdirs : ['eina-'+version_major, 'efl-'+version_major, join_paths('eina-'+version_major, 'eina')],

--- a/src/lib/elementary/meson.build
+++ b/src/lib/elementary/meson.build
@@ -258,7 +258,7 @@ endforeach
 
 eolian_include_directories += ['-I', meson.current_source_dir()]
 
-if sys_windows == true
+if sys_windows
   embed_script = find_program('config_embed.bat')
 else
   embed_script = find_program('config_embed')

--- a/src/lib/elua/meson.build
+++ b/src/lib/elua/meson.build
@@ -4,9 +4,14 @@ elua_pub_deps = [lua]
 elua_src = ['elua.c', 'io.c', 'cache.c']
 elua_header_src = ['Elua.h']
 
+elua_lib_deps = []
+if not sys_windows
+  elua_lib_deps = [m, dl]
+endif
+
 elua_lib = library('elua',
     elua_src,
-    dependencies: [m, dl] + elua_deps + elua_pub_deps,
+    dependencies: elua_lib_deps + elua_deps + elua_pub_deps,
     include_directories : config_dir + [include_directories(join_paths('..','..'))],
     install: true,
     c_args : package_c_args,

--- a/src/lib/emile/meson.build
+++ b/src/lib/emile/meson.build
@@ -23,10 +23,16 @@ elif (get_option('crypto') == 'openssl')
   emile_src += 'emile_cipher_openssl.c'
 endif
 
+if not sys_windows
+  emili_lib_deps = [lz4, rg_etc, m]
+else
+  emili_lib_deps = [lz4, rg_etc]
+endif
+
 emile_lib = library('emile',
     emile_src,
     include_directories: config_dir,
-    dependencies: emile_pub_deps + emile_deps + [lz4, rg_etc],
+    dependencies: emile_pub_deps + emile_deps + emili_lib_deps,
     install: true,
     version : meson.project_version()
 )

--- a/src/lib/eo/meson.build
+++ b/src/lib/eo/meson.build
@@ -43,16 +43,28 @@ endforeach
 
 eolian_include_directories += ['-I', meson.current_source_dir()]
 
+if (sys_windows)
+  eo_lib_deps = [eina, valgrind, execinfo]
+else
+  eo_lib_deps = [eina, valgrind, dl, execinfo]
+endif
+
 eo_lib = library('eo',
     eo_src, pub_eo_file_target,
-    dependencies: [eina, valgrind, execinfo],
+    dependencies: eo_lib_deps,
     install: true,
     version : meson.project_version(),
 )
 
+if sys_windows
+  eo_lib_dbg_deps = [eina, valgrind, execinfo]
+else
+  eo_lib_dbg_deps = [eina, valgrind, dl, execinfo]
+endif
+
 eo_lib_dbg = library('eo_dbg',
     eo_src, pub_eo_file_target,
-    dependencies: [eina, valgrind, execinfo],
+    dependencies: eo_lib_dbg_deps,
     install: true,
     c_args : '-DEO_DEBUG',
     version : meson.project_version(),

--- a/src/lib/evas/meson.build
+++ b/src/lib/evas/meson.build
@@ -21,7 +21,7 @@ endif
 webp = dependency('libwebp', required: get_option('evas-loaders-disabler').contains('webp') == false)
 libopenjp2 = dependency('libopenjp2', required: get_option('evas-loaders-disabler').contains('jp2k') == false)
 
-if (sys_windows and get_option('evas-loaders-disabler').contains('generic'))
+if sys_windows and get_option('evas-loaders-disabler').contains('generic')
   rt = declare_dependency()
 endif
 

--- a/src/lib/evas/meson.build
+++ b/src/lib/evas/meson.build
@@ -4,17 +4,24 @@
 # as 'source :', later everything is build as libevas.so.
 #
 
-png = dependency('libpng', required: false)
-tiff = dependency('libtiff-4', required: get_option('evas-loaders-disabler').contains('tiff') == false)
-if get_option('evas-loaders-disabler').contains('gif')
-  giflib = declare_dependency()
+if not sys_windows
+  png = dependency('libpng')
 else
-  giflib = cc.find_library('gif')
+  png = declare_dependency()
 endif
+
+tiff = dependency('libtiff-4', required: get_option('evas-loaders-disabler').contains('tiff') == false)
+
+if not sys_windows
+  giflib = cc.find_library('gif')
+elif get_option('evas-loaders-disabler').contains('gif')
+  giflib = declare_dependency()
+endif
+
 webp = dependency('libwebp', required: get_option('evas-loaders-disabler').contains('webp') == false)
 libopenjp2 = dependency('libopenjp2', required: get_option('evas-loaders-disabler').contains('jp2k') == false)
 
-if get_option('evas-loaders-disabler').contains('generic')
+if (sys_windows and get_option('evas-loaders-disabler').contains('generic'))
   rt = declare_dependency()
 endif
 
@@ -147,7 +154,7 @@ evas_src_opt = [ ]
 
 evas_src += vg_common_src
 
-if sys_windows == false
+if not sys_windows
   evas_deps += dependency('freetype2')
 endif
 

--- a/src/tests/elua/meson.build
+++ b/src/tests/elua/meson.build
@@ -6,7 +6,13 @@ elua_suite_src = [
    'elua_lib.c'
 ]
 
-elua_bindings_dir = join_paths(meson.source_root(), 'src', 'bindings')
+if not sys_windows
+  elua_bindings_dir = join_paths(meson.source_root(), 'src'
+                                , 'bindings', 'luajit')
+else
+  elua_bindings_dir = join_paths(meson.source_root(), 'src', 'bindings')
+endif
+
 elua_core_dir = join_paths(meson.source_root(), 'src', 'scripts', 'elua', 'core')
 elua_modules_dir = join_paths(meson.source_root(), 'src', 'scripts', 'elua', 'modules')
 elua_apps_dir = join_paths(meson.source_root(), 'src', 'tests', 'elua', 'data', 'apps')


### PR DESCRIPTION
Bug: Compile `native-windows` on Linux

Summary:
========
This PR makes `devs/expertise/native-windows` compile on linux.

lua was a little problematic:
luajit is a default option to bindings in `master` but at
`devs/expertise/native-windows` it was changed to lua, This PR brings
luajit back as a default option, but make a Windows build always use
lua - semantically equal to what happened at
`devs/expertise/native-windows`

Ref Issue #38

Linux Test plan:
================
- `meson` configured with `-Dbindigns=cxx,mono`;
- `ninja` should return every warning that `master` does, nothing else;
- `meson test -C <build dir>` should pass in everything that `master`
  does;

Windows Test plan:
==================
- Run `configure.bat` normally;
- Run `build.bat` it should yield the same erros/warnigs that
  `devs/expertise/native-windows` does;