### PR TITLE
ecore_x should be a dependency if using x11

### DIFF
--- a/src/examples/elementary/meson.build
+++ b/src/examples/elementary/meson.build
@@ -121,8 +121,15 @@ examples = [
   'efl_canvas_textblock_obstacles_example'
 ]
 
+examples_deps = [elementary, ecore, eio]
+
+if get_option('x11')
+  config_h.set('HAVE_ELEMENTARY_X', '1')
+  examples_deps += ecore_x
+endif
+
 foreach example : examples
-  executable(example, example + '.c', dependencies: [elementary, ecore, eio])
+  executable(example, example + '.c', dependencies: examples_deps)
 endforeach
 if get_option('bindings').contains('cxx')
   cxx_examples = [


### PR DESCRIPTION
It fixes an error when building `devs/expertise/native-windows` on linux that shows up since last merge:  

```
[3788/3871] Compiling C object 'src/examples/elementary/86fd80b@@win_example@exe/win_example.c.o'
../src/examples/elementary/win_example.c: In function ‘_force_focus_cb’:
../src/examples/elementary/win_example.c:162:4: warning: implicit declaration of function ‘ecore_x_window_focus’ [-Wimplicit-function-declaration]
  162 |    ecore_x_window_focus(xwin);
      |    ^~~~~~~~~~~~~~~~~~~~
[3789/3871] Linking target src/examples/elementary/theme_example_02
[3790/3871] Compiling C object 'src/examples/elementary/86fd80b@@transit_example_02@exe/transit_example_02.c.o'
[3791/3871] Linking target src/examples/elementary/theme_example_01
[3792/3871] Linking target src/examples/elementary/efl_thread_5
[3793/3871] Linking target src/examples/elementary/win_example
FAILED: src/examples/elementary/win_example
<VERY LONG LINE SUPRESSED HERE>
/usr/bin/ld: src/examples/elementary/86fd80b@@win_example@exe/win_example.c.o: undefined reference to symbol 'ecore_x_window_focus'
/usr/bin/ld: /home/joaoantoniocardoso/ExpertiseSolutions/linux/efl/build/src/lib/ecore_x/libecore_x.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

But continues with a warning:  
```
../src/examples/elementary/win_example.c:162:4: warning: implicit declaration of function ‘ecore_x_window_focus’ [-Wimplicit-function-declaration]
     162 |    ecore_x_window_focus(xwin);
         |    ^~~~~~~~~~~~~~~~~~~~
```

I don't know if is in fact the best way to fix it, but...