### PR TITLE
Bug: Remove warnings introduced by last merge

### DIFF
--- a/src/lib/eina/eina_debug.c
+++ b/src/lib/eina/eina_debug.c
@@ -554,10 +554,10 @@ _monitor(void *_data)
    _opcodes_register_all(session);
 
    // set a name for this thread for system debugging
-#ifdef EINA_HAVE_PTHREAD_SETNAME || EINA_HAVE_WIN32_THREAD_SETNAME
+#if (defined (EINA_HAVE_PTHREAD_SETNAME) || defined (EINA_HAVE_WIN32_THREAD_SETNAME))
    eina_thread_name_set(eina_thread_self(), "Edbg-mon");
 #endif
-   
+
    // sit forever processing commands or timeouts in the debug monitor
    // thread - this is separate to the rest of the app so it shouldn't
    // impact the application specifically
@@ -698,14 +698,14 @@ eina_debug_session_data_get(Eina_Debug_Session *session)
 Eina_Bool
 eina_debug_init(void)
 {
-   
+
    Eina_Thread self;
 
    eina_threads_init();
    // For Windows support GetModuleFileName can be used
    // set up thread things
    eina_spinlock_new(&_eina_debug_lock);
-   eina_spinlock_new(&_eina_debug_thread_lock); 
+   eina_spinlock_new(&_eina_debug_thread_lock);
    self = eina_thread_self();
    _eina_debug_thread_mainloop_set(&self);
    _eina_debug_thread_add(&self);
@@ -730,7 +730,7 @@ Eina_Bool
 eina_debug_shutdown(void)
 {
    Eina_Debug_Session *session;
-   Eina_Thread self = eina_thread_self(); 
+   Eina_Thread self = eina_thread_self();
 
    EINA_LIST_FREE(sessions, session)
      eina_debug_session_terminate(session);

--- a/src/lib/eina/eina_debug_timer.c
+++ b/src/lib/eina/eina_debug_timer.c
@@ -94,7 +94,7 @@ _monitor(void *_data EINA_UNUSED)
    event.events = EPOLLIN;
    ret = epoll_ctl(epfd, EPOLL_CTL_ADD, event.data.fd, &event);
    if (ret) perror("epoll_ctl/add");
-# ifdef EINA_HAVE_PTHREAD_SETNAME || EINA_HAVE_WIN32_THREAD_SETNAME
+# if (defined(EINA_HAVE_PTHREAD_SETNAME) || defined(EINA_HAVE_WIN32_THREAD_SETNAME))
    eina_thread_name_set(eina_thread_self(), "Edbg-tim");
 # endif
 
@@ -174,8 +174,9 @@ eina_debug_timer_add(unsigned int timeout_ms, Eina_Debug_Timer_Cb cb, void *data
         sigaddset(&newset, SIGPWR);
    # endif
         pthread_sigmask(SIG_BLOCK, &newset, &oldset);
-   #endif       
-        int err = eina_thread_create(&_thread, EINA_THREAD_BACKGROUND, NULL,(Eina_Thread_Cb)_monitor, NULL);
+   #endif
+        int err = eina_thread_create(&_thread, EINA_THREAD_BACKGROUND, -1
+                                    , (Eina_Thread_Cb)_monitor, NULL);
    #ifndef _WIN32
         pthread_sigmask(SIG_SETMASK, &oldset, NULL);
    #endif

--- a/src/lib/eina/eina_inline_thread_posix.x
+++ b/src/lib/eina/eina_inline_thread_posix.x
@@ -28,7 +28,7 @@ _eina_thread_join(Eina_Thread t)
    return NULL;
 }
 
-static inline Eina_Bool 
+static inline Eina_Bool
 _eina_thread_name_set(Eina_Thread thread, char *buf)
 {
 #ifndef __linux__
@@ -105,15 +105,15 @@ _eina_thread_self(void)
 }
 
 static inline void
-_eina_thread_setcanceltype(int type, int *oldtype)
+_eina_thread_setcanceltype(EINA_UNUSED int type, int *oldtype)
 {
-   pthread_setcanceltype(EINA_THREAD_CANCEL_DEFERRED, &oldtype);
+   pthread_setcanceltype(EINA_THREAD_CANCEL_DEFERRED, oldtype);
 }
 
 static inline int
 _eina_thread_setcancelstate(int type, int *oldtype)
 {
-   return pthread_setcancelstate(type, &oldtype);
+   return pthread_setcancelstate(type, oldtype);
 }
 
 static inline Eina_Bool


### PR DESCRIPTION
The last merge introduced this warnings:
```
   [17/4260] Compiling C object 'src/lib/eina/803ee99@@eina@sha/eina_debug_timer.c.o'.
   ../src/lib/eina/eina_debug_timer.c: In function ‘_monitor’:
   ../src/lib/eina/eina_debug_timer.c:97:35: warning: extra tokens at end of #ifdef directive
      97 | # ifdef EINA_HAVE_PTHREAD_SETNAME || EINA_HAVE_WIN32_THREAD_SETNAME
         |                                   ^~
   ../src/lib/eina/eina_debug_timer.c: In function ‘eina_debug_timer_add’:
   ../src/lib/eina/eina_debug_timer.c:178:72: warning: passing argument 3 of ‘eina_thread_create’ makes integer from pointer without a cast [-Wint-conversion]
     178 |         int err = eina_thread_create(&_thread, EINA_THREAD_BACKGROUND, NULL,(Eina_Thread_Cb)_monitor, NULL);
         |                                                                        ^~~~
         |                                                                        |
         |                                                                        void *
   In file included from ../src/lib/eina/eina_debug_timer.c:42:
   ../src/lib/eina/eina_thread.h:102:66: note: expected ‘int’ but argument is of type ‘void *’
     102 |                                   Eina_Thread_Priority prio, int affinity,
         |
   [22/4260] Compiling C object 'src/lib/eina/803ee99@@eina@sha/eina_debug.c.o'.
   ../src/lib/eina/eina_debug.c: In function ‘_monitor’:
   ../src/lib/eina/eina_debug.c:557:34: warning: extra tokens at end of #ifdef directive
     557 | #ifdef EINA_HAVE_PTHREAD_SETNAME || EINA_HAVE_WIN32_THREAD_SETNAME
         |                                  ^~
   [50/4260] Compiling C object 'src/lib/eina/803ee99@@eina@sha/eina_thread.c.o'.
   In file included from ../src/lib/eina/eina_thread.c:37:
   ../src/lib/eina/eina_inline_thread_posix.x: In function ‘_eina_thread_setcanceltype’:
   ../src/lib/eina/eina_inline_thread_posix.x:110:55: warning: passing argument 2 of ‘pthread_setcanceltype’ from incompatible pointer type [-Wincompatible-pointer-types]
     110 |    pthread_setcanceltype(EINA_THREAD_CANCEL_DEFERRED, &oldtype);
         |                                                       ^~~~~~~~
         |                                                       |
         |                                                       int **
   In file included from ../src/lib/eina/eina_inline_lock_posix.x:38,
                    from ../src/lib/eina/eina_lock.h:100,
                    from ../src/lib/eina/eina_thread.c:25:
   /usr/include/pthread.h:486:52: note: expected ‘int *’ but argument is of type ‘int **’
     486 | extern int pthread_setcanceltype (int __type, int *__oldtype);
         |                                               ~~~~~^~~~~~~~~
   In file included from ../src/lib/eina/eina_thread.c:37:
   ../src/lib/eina/eina_inline_thread_posix.x:108:32: warning: unused parameter ‘type’ [-Wunused-parameter]
     108 | _eina_thread_setcanceltype(int type, int *oldtype)
         |                            ~~~~^~~~
   ../src/lib/eina/eina_inline_thread_posix.x: In function ‘_eina_thread_setcancelstate’:
   ../src/lib/eina/eina_inline_thread_posix.x:116:40: warning: passing argument 2 of ‘pthread_setcancelstate’ from incompatible pointer type [-Wincompatible-pointer-types]
     116 |    return pthread_setcancelstate(type, &oldtype);
         |                                        ^~~~~~~~
         |                                        |
         |                                        int **
   In file included from ../src/lib/eina/eina_inline_lock_posix.x:38,
                    from ../src/lib/eina/eina_lock.h:100,
                    from ../src/lib/eina/eina_thread.c:25:
   /usr/include/pthread.h:482:54: note: expected ‘int *’ but argument is of type ‘int **’
     482 | extern int pthread_setcancelstate (int __state, int *__oldstate);
         |
```

This PR deals with them.