### PR TITLE
bug: efl includes <pthread.h>

### DIFF
--- a/src/examples/elementary/efl_thread_1.c
+++ b/src/examples/elementary/efl_thread_1.c
@@ -1,7 +1,7 @@
 //Compile with:
 //gcc -o efl_thread_1 efl_thread_1.c -g `pkg-config --cflags --libs elementary`
 #include <Elementary.h>
-#include <pthread.h>
+#include <Eina.h>
 
 static Evas_Object *win = NULL;
 static Evas_Object *rect = NULL;

--- a/src/lib/ecore/ecore_signal.c
+++ b/src/lib/ecore/ecore_signal.c
@@ -12,7 +12,7 @@
 #include <assert.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <pthread.h>
+#include <Eina.h>
 
 #include "Ecore.h"
 #include "ecore_private.h"

--- a/src/lib/eina/eina_cpu.c
+++ b/src/lib/eina/eina_cpu.c
@@ -37,7 +37,7 @@
 # elif defined (__linux__) || defined(__GLIBC__)
 #  include <sched.h>
 # endif
-# include <pthread.h>
+# include "eina_thread.h"
 
 # define TH_MAX 32
 #endif

--- a/src/lib/eina/eina_debug.c
+++ b/src/lib/eina/eina_debug.c
@@ -597,37 +597,15 @@ _monitor(void *_data)
 static void
 _thread_start(Eina_Debug_Session *session)
 {
-#ifndef _WIN32
-   pthread_t monitor_thread;
-   int err;
-   sigset_t oldset, newset;
+   Eina_Thread monitor_thread;
 
-   sigemptyset(&newset);
-   sigaddset(&newset, SIGPIPE);
-   sigaddset(&newset, SIGALRM);
-   sigaddset(&newset, SIGCHLD);
-   sigaddset(&newset, SIGUSR1);
-   sigaddset(&newset, SIGUSR2);
-   sigaddset(&newset, SIGHUP);
-   sigaddset(&newset, SIGQUIT);
-   sigaddset(&newset, SIGINT);
-   sigaddset(&newset, SIGTERM);
-#ifdef SIGPWR
-   sigaddset(&newset, SIGPWR);
-#endif
-   pthread_sigmask(SIG_BLOCK, &newset, &oldset);
+   Eina_Bool err = eina_thread_create(&monitor_thread,EINA_THREAD_BACKGROUND,-1,(Eina_Thread_Cb)_monitor,session);
 
-   err = pthread_create(&monitor_thread, NULL, _monitor, session);
-
-   pthread_sigmask(SIG_SETMASK, &oldset, NULL);
-   if (err != 0)
+   if (!err)
      {
         e_debug("EINA DEBUG ERROR: Can't create monitor debug thread!");
         abort();
      }
-#else
-   (void)session;
-#endif
 }
 
 /*

--- a/src/lib/eina/eina_debug_cpu.c
+++ b/src/lib/eina/eina_debug_cpu.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -24,7 +23,7 @@
 #include "eina_util.h"
 #include "eina_evlog.h"
 #include "eina_debug_private.h"
-
+include "eina_thread.h"
 #ifndef _WIN32
 volatile int           _eina_debug_sysmon_reset = 0;
 volatile int           _eina_debug_sysmon_active = 0;

--- a/src/modules/ecore_imf/scim/scim_imcontext.cpp
+++ b/src/modules/ecore_imf/scim/scim_imcontext.cpp
@@ -13,7 +13,7 @@
 #include <sys/time.h>
 #include <sys/times.h>
 #include <unistd.h>
-#include <pthread.h>
+#include <Eina.h>
 #include <Ecore_Evas.h>
 #include <Ecore_X.h>
 #include <Ecore.h>


### PR DESCRIPTION
Efl still includes pthreads.h when it should be #include <Einha.h> outside eina/ and #include "eina_threads.h" inside eina/.

With this PR, efl will include <Eina.h> or "eina_threads.h"