### PR TITLE
Windows: Wrapper to Open/Close a File descriptor

### DIFF
--- a/src/lib/evil/evil_fcntl.c
+++ b/src/lib/evil/evil_fcntl.c
@@ -2,12 +2,18 @@
 # include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <evil_windows.h>
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif /* WIN32_LEAN_AND_MEAN */
+
+# include <sys/locking.h>
+# include <winsock2.h> /* for ioctlsocket */
+# include <io.h>
+# undef WIN32_LEAN_AND_MEAN
+#endif /* _WIN32 */
 
 #include <stdio.h>
-#include <sys/locking.h>
-
-#include <io.h>
 
 #include "evil_private.h"
 
@@ -136,3 +142,16 @@ int fcntl(int fd, int cmd, ...)
 
    return res;
 }
+
+EVIL_API int
+open (const char *path, int oflag, ...)
+{
+   va_list varargs;
+   va_start (varargs, oflag);
+
+   int ret = _open(path, oflag, varargs);
+
+   va_end (varargs);
+   return ret;
+}
+

--- a/src/lib/evil/evil_fcntl.h
+++ b/src/lib/evil/evil_fcntl.h
@@ -2,7 +2,14 @@
 #define __EVIL_FCNTL_H__
 
 
-# include <sys/types.h>
+# ifdef _WIN32
+#  ifndef _CRT_DECLARE_NONSTDC_NAMES
+#   define _CRT_DECLARE_NONSTDC_NAMES 1
+#  endif /* _CRT_DECLARE_NONSTDC_NAMES */
+#  include <fcntl.h>
+#  include <sys/stat.h>
+#  include <sys/types.h>
+# endif /* _WIN32 */
 
 
 /**
@@ -109,5 +116,6 @@ struct flock
  */
 EVIL_API int fcntl(int fd, int cmd, ...);
 
+EVIL_API int open (const char *path, int oflag, ...);
 
 #endif /* __EVIL_FCNTL_H__ */

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -2,6 +2,19 @@
 # include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <errno.h>
+#include <direct.h>
+# include <sys/time.h>
+
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <winsock2.h>
+# include <io.h>
+# undef WIN32_LEAN_AND_MEAN
+#endif /* _WIN32 */
+
 #include "evil_private.h"
 
 #include <evil_windows.h>
@@ -190,4 +203,10 @@ evil_pipe(int *fds)
    fds[1] = -1;
 
    return -1;
+}
+
+EVIL_API int
+close (int fd)
+{
+   return _close(fd);
 }

--- a/src/lib/evil/evil_unistd.h
+++ b/src/lib/evil/evil_unistd.h
@@ -88,5 +88,6 @@ EVIL_API int evil_pipe(int *fds);
  * @}
  */
 
+EVIL_API int close (int fd);
 
 #endif /* __EVIL_UNISTD_H__ */


### PR DESCRIPTION
This adds `open` and `close` functions to deal with file descriptors.

`open` is defined at `evil_fcntl` and `close` at `evil_unistd`.