### PR TITLE
Linux: Bug: Remove some errors at a Linux build that would reflect at a windows build

### DIFF
--- a/src/lib/eina/eina_inline_lock_posix.x
+++ b/src/lib/eina/eina_inline_lock_posix.x
@@ -156,23 +156,6 @@ EINA_API extern pthread_mutex_t _eina_tracking_lock;
 EINA_API extern Eina_Inlist *_eina_tracking;
 #endif
 
-
-EINA_API Eina_Bool _eina_lock_new(Eina_Lock *mutex, Eina_Bool recursive);
-EINA_API void      _eina_lock_free(Eina_Lock *mutex);
-EINA_API Eina_Bool _eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex);
-EINA_API void      _eina_condition_free(Eina_Condition *cond);
-EINA_API Eina_Bool _eina_rwlock_new(Eina_RWLock *mutex);
-EINA_API void      _eina_rwlock_free(Eina_RWLock *mutex);
-EINA_API Eina_Bool _eina_spinlock_new(Eina_Spinlock *spinlock);
-EINA_API void      _eina_spinlock_free(Eina_Spinlock *spinlock);
-EINA_API Eina_Bool _eina_semaphore_new(Eina_Semaphore *sem, int count_init);
-EINA_API Eina_Bool _eina_semaphore_free(Eina_Semaphore *sem);
-#ifdef EINA_HAVE_OSX_SPINLOCK
-EINA_API Eina_Lock_Result _eina_spinlock_macos_take(Eina_Spinlock *spinlock);
-EINA_API Eina_Lock_Result _eina_spinlock_macos_take_try(Eina_Spinlock *spinlock);
-EINA_API Eina_Lock_Result _eina_spinlock_macos_release(Eina_Spinlock *spinlock);
-#endif
-
 static inline Eina_Bool
 _eina_lock_new(Eina_Lock *mutex, Eina_Bool recursive)
 {

--- a/src/lib/eina/eina_log.c
+++ b/src/lib/eina/eina_log.c
@@ -21,6 +21,10 @@
 # include "config.h"
 #endif
 
+#ifdef _WIN32
+# include <evil_private.h> /* vasprintf */
+#endif /* _WIN32 */
+
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -57,7 +61,6 @@
 
 #include "eina_inline_private.h"
 
-#include <evil_vasprintf.h>
 
 /* TODO
  * + printing logs to stdout or stderr can be implemented

--- a/src/lib/eina/eina_slstr.c
+++ b/src/lib/eina/eina_slstr.c
@@ -10,7 +10,9 @@
 #include "Eina.h"
 #include "eina_private.h"
 
-#include <evil_vasprintf.h>
+#ifdef _WIN32
+# include <evil_private.h> /* vasprintf */
+#endif /* _WIN32 */
 
 // ========================================================================= //
 

--- a/src/lib/eina/eina_strbuf.c
+++ b/src/lib/eina/eina_strbuf.c
@@ -11,7 +11,9 @@
 #include "eina_strbuf_common.h"
 #include "eina_unicode.h"
 
-#include <evil_vasprintf.h>
+#ifdef _WIN32
+# include <evil_private.h> /* vasprintf */
+#endif /* _WIN32 */
 
 /*============================================================================*
  *                                  Local                                     *

--- a/src/lib/eina/eina_stringshare.c
+++ b/src/lib/eina/eina_stringshare.c
@@ -41,7 +41,9 @@
 #include "eina_safety_checks.h"
 #include "eina_stringshare.h"
 
-#include <evil_vasprintf.h>
+#ifdef _WIN32
+# include <evil_private.h> /* vasprintf */
+#endif /* _WIN32 */
 
 #ifdef CRI
 #undef CRI

--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -402,8 +402,8 @@ if sys_windows
     , evil]
 else
   eina_lib_deps = [m, rt, dl, execinfo, iconv, eina_deps, thread_dep
-  #                  , eina_mem_pools, evil]
-  ]
+  #                  , eina_mem_pools
+  , evil]
 endif
 
 eina_lib = library('eina', sources,

--- a/src/lib/evil/evil_private.h
+++ b/src/lib/evil/evil_private.h
@@ -47,6 +47,7 @@ extern "C" {
 #include "evil_time.h"
 #include "evil_unistd.h"
 #include "evil_util.h"
+#include "evil_vasprintf.h"
 
 #define sigsetjmp(Env, Save) setjmp(Env)
 

--- a/src/tests/eina/eina_test_abi.c
+++ b/src/tests/eina/eina_test_abi.c
@@ -43,8 +43,8 @@ typedef uint32_t Eina_Unicode;
 #include "eina_main.h"
 #include "eina_safety_checks.h"
 
-EAPI Eina_Unicode eina_unicode_utf8_get_next(const char *buf, int *iindex);
-EAPI unsigned int eina_mempool_alignof(unsigned int size);
+EINA_API Eina_Unicode eina_unicode_utf8_get_next(const char *buf, int *iindex);
+EINA_API unsigned int eina_mempool_alignof(unsigned int size);
 
 EFL_START_TEST(eina_unicode_utf8)
 {


### PR DESCRIPTION
Those errors were:
- `error: static declaration of <function> follows non-static declaration` at some functions from `eina_inline_lock_posix.x`, that happened due to non-static declarations, but they actually weren't used, so they have been removed.
- `fatal error: evil_vasprintf.h: No such file or directory` at
  `eina_log.c`, `eina_slstr.c`, `eina_strbuf.c` and
  `eina_stringshare.c`, as those files should include `evil_private.h`
  instead of `evil_vasprintf.h` directly; and `evil_private.h` now include
  `evil_vasprintf.h`
- `eina_test_abi.c` was still using `EAPI` instead of `EINA_API`