### PR TITLE
Removing deleted headers

### DIFF
--- a/src/lib/evil/unposix/meson.build
+++ b/src/lib/evil/unposix/meson.build
@@ -4,13 +4,11 @@ if sys_windows
   evil_unposix_src = []
 
   evil_unposix_header_src = [
-    'libgen.h',
     'limits.h',
     'locale.h',
     'math.h',
     'pthread.h',
     'stdlib.h',
-    'string.h',
     'strings.h',
     'unimplemented.h',
     'unistd.h',


### PR DESCRIPTION
`libgen.h` and `string.h` no longer exists.