### PR TITLE
windows: Link with pcre_posix alongside pcre8

### DIFF
--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -217,7 +217,10 @@ if sys_windows
   pcre_project = subproject('pcre')
 
   pcre = pcre_project.get_variable('pcre8')
-  pcre_dep = pcre_project.get_variable('pcre_dep')
+  pcre_posix = pcre_project.get_variable('pcre_posix')
+  original_pcre_dep = pcre_project.get_variable('pcre_dep')
+
+  pcre_dep = declare_dependency(link_with : [pcre, pcre_posix], dependencies : original_pcre_dep)
 
   # zlib
   zlib_project = subproject('zlib')

--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -407,7 +407,7 @@ else
 endif
 
 eina_lib = library('eina', sources,
-  c_args : ['-DEINA_BUILD', '-DPCRE_STATIC'],
+  c_args : ['-DEINA_BUILD'],
   include_directories : config_dir,
   dependencies: eina_lib_deps,
   install: true,

--- a/src/lib/evil/meson.build
+++ b/src/lib/evil/meson.build
@@ -1,6 +1,4 @@
 if target_machine.system() == 'windows'
-  #subdir('unposix')
-
   evil_src = [
     'evil_dlfcn.c',
     'evil_fcntl.c',
@@ -29,7 +27,7 @@ if target_machine.system() == 'windows'
   evil_pub_deps = [psapi, ole32, ws2_32, secur32, uuid, pcre_dep, getopt_dep]
 
   evil_lib = library('evil', evil_src,
-    c_args : ['-DEVIL_BUILD', '-DEVIL_DLL', '-DPCRE_STATIC'],
+    c_args : ['-DEVIL_BUILD', '-DEVIL_DLL'],
     dependencies : evil_deps,
     include_directories : [config_dir, 'unposix'],
     install: true,
@@ -40,6 +38,7 @@ if target_machine.system() == 'windows'
     include_directories: [include_directories('.', 'unposix')],
     dependencies : evil_pub_deps,
     link_with: evil_lib,
+    compile_args : ['-DPCRE_STATIC'],
   )
 else
   evil = declare_dependency()


### PR DESCRIPTION
Should be able to properly link functions used in `src/lib/eina/eina_fnmatch.c`.