### PR TITLE
Eina: Resolve bad comparison while using windows strerror_s

### DIFF
--- a/src/lib/eina/eina_error.c
+++ b/src/lib/eina/eina_error.c
@@ -350,7 +350,7 @@ eina_error_msg_get(Eina_Error error)
                EINA_SAFETY_ERROR("strerror_r() failed");
              else
                {
-                  if (strncmp(str, unknown_prefix, sizeof(unknown_prefix) -1) == 0)
+                  if (strncmp(str, unknown_prefix, sizeof(unknown_prefix) - 2) == 0)
                     msg = NULL;
                   else
                     {


### PR DESCRIPTION
`strerror_s` is the windows alternative of `strerror_r` used by EFL.

`strerror_s` never return the error code with the message as
`strerror_r` does, because of that, while comparing the first 14
characters of `Unknown error ` to the message from unknown code 4096
(`Unknown error`) they were accusing being different - in UNIX this
works because the message returned is `Unknown error 4096`.

So comparing only the first 13 characters does the trick.

Depends on #64

Test Plan:
----------
- Apply #64;
- Let every other test case from `eina_suite.c` commented;
- The test should pass;