### PR TITLE
Fixed problematic sign-extension of enum used as bit-fields at eina_rbtree

### DIFF
--- a/src/lib/eina/eina_rbtree.c
+++ b/src/lib/eina/eina_rbtree.c
@@ -61,7 +61,7 @@ struct _Eina_Iterator_Rbtree_List
 {
    Eina_Rbtree *tree;
 
-   Eina_Rbtree_Direction dir : 1;
+   unsigned int dir : 1;
    Eina_Bool up : 1;
 };
 
@@ -476,7 +476,7 @@ eina_rbtree_inline_remove(Eina_Rbtree *root,
 	       rt = (*rt)->son + dir;
 	    }
 
-	 if (q != NULL) 
+	 if (q != NULL)
 	    {
 	       int r_color = r->color;
 	       Eina_Rbtree *nd = q->son[dir ^ 1];


### PR DESCRIPTION
Some places at `eina_rbtree.c` were using `_Eina_Iterator_Rbtree_List`
`dir` (an enum bit-field) as an array index, causing a wrong
sign-extension to `-1` that yields a `segfault`.

Test Plan:
----------
- Let every other test case from `eina_suite.c` commented;
- The test should pass;