### PR TITLE
evil_locale.c: Fix infinite recursion call to evil_setlocale

### DIFF
--- a/src/lib/evil/evil_locale.c
+++ b/src/lib/evil/evil_locale.c
@@ -17,6 +17,8 @@
  */
 static char _evil_locale_buf[18];
 
+#undef setlocale
+
 char *evil_setlocale(int category, const char *locale)
 {
    char buf[9];


### PR DESCRIPTION
In the Windows platform, setlocale is defined as an alias to
evil_setlocale, causing an infinite recursive call when category is
different from LC_MESSAGE.

We undef setlocale in the implementation file, which will fall back to
the c runtime function.