### PR TITLE
Eina: Missing brackets at eina_vpath()

### DIFF
--- a/src/lib/eina/eina_vpath.c
+++ b/src/lib/eina/eina_vpath.c
@@ -233,8 +233,10 @@ _eina_vpath_resolve(const char *path, char *str, size_t size)
         // ~username/ <- homedir of user "username"
         else
 #ifndef HAVE_GETPWENT
-          ERR("User fetching is disabled on this system\nThe string was: %s", path);
-          return 0;
+	  {
+             ERR("User fetching is disabled on this system\nThe string was: %s", path);
+             return 0;
+	  }
 #else
           {
              const char *p;


### PR DESCRIPTION
Due to this missing brackets, the function returns 0 when it in fact executed the 'if' with success.
This is the cause behind `eina_test_vpath` test failing on windows.