### PR TITLE
windows: Fix header symbol check for synchapi.h

### DIFF
--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -362,12 +362,14 @@ if sys_osx == true
 endif
 
 if sys_windows == true
-   if cc.has_header_symbol('synchapi.h', 'SetCriticalSectionSpinCount')
-      eina_config.set('EINA_HAVE_WIN32_SPINLOCK', '1')
-   endif
-   if cc.has_header_symbol('synchapi.h', 'InitializeSynchronizationBarrier')
-      eina_config.set('EINA_HAVE_WIN32_BARRIER', '1')
-   endif
+  synchapi_prefix = '#include <windows.h>'
+
+  if cc.has_header_symbol('synchapi.h', 'SetCriticalSectionSpinCount', prefix : synchapi_prefix)
+     eina_config.set('EINA_HAVE_WIN32_SPINLOCK', '1')
+  endif
+  if cc.has_header_symbol('synchapi.h', 'InitializeSynchronizationBarrier', prefix : synchapi_prefix)
+     eina_config.set('EINA_HAVE_WIN32_BARRIER', '1')
+  endif
 endif
 
 if host_machine.endian() == 'big'


### PR DESCRIPTION
@cauebs pointed he was having problems with `InitializeSynchronizationBarrier` not being found in `synchapi.h`, which should be false since it's in Windows' C stdlib implementation ([see code here](https://github.com/tpn/winsdk-10/blob/9b69fd26ac0c7d0b83d378dba01080e93349c2ed/Include/10.0.16299.0/um/synchapi.h#L161)).

Checking `<builddir>/meson-logs/meson-log.txt`, the following could be found:

```
Compiler stderr:
 In file included from C:\Users\Tiz\source\repos\efl\build\meson-private\tmpvyu6_kne\testfile.c:2:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\synchapi.h:18:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\shared\minwindef.h:182:
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(173,2): error: "No Target Architecture"
#error "No Target Architecture"
 ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(8906,5): error: unknown type name 'PCONTEXT'
    PCONTEXT ContextRecord;
    ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(19272,11): error: unknown type name 'PCONTEXT'
    _Out_ PCONTEXT ContextRecord
          ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(19923,11): error: unknown type name 'PSLIST_HEADER'
    _Out_ PSLIST_HEADER ListHead
          ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(19931,16): error: unknown type name 'SLIST_HEADER'
    _In_ const SLIST_HEADER *ListHead
               ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(19938,13): error: unknown type name 'PSLIST_HEADER'
    _Inout_ PSLIST_HEADER ListHead
            ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(19945,13): error: unknown type name 'PSLIST_HEADER'
    _Inout_ PSLIST_HEADER ListHead,
            ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(19953,13): error: unknown type name 'PSLIST_HEADER'
    _Inout_ PSLIST_HEADER ListHead,
            ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(19963,13): error: unknown type name 'PSLIST_HEADER'
    _Inout_ PSLIST_HEADER ListHead
            ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winnt.h(19970,10): error: unknown type name 'PSLIST_HEADER'
    _In_ PSLIST_HEADER ListHead
         ^
In file included from C:\Users\Tiz\source\repos\efl\build\meson-private\tmpvyu6_kne\testfile.c:2:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\synchapi.h:19:
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\minwinbase.h(384,9): error: unknown type name 'PCONTEXT'
typedef PCONTEXT LPCONTEXT;
        ^
C:\Users\Tiz\source\repos\efl\build\meson-private\tmpvyu6_kne\testfile.c(6,17): warning: expression result unused [-Wunused-value]
                InitializeSynchronizationBarrier;
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 11 errors generated.
```

The solution pointed [in this answer](https://stackoverflow.com/a/4845893) suggests that `Windows.h` should be included before `windef.h` (which is indirectly included by `synchapi.h`, since it includes `minwindef.h`).

## Test Plan

- Apply this commit;
- `configure.bat` should show the following (near the end of the output):

```
Header <synchapi.h> has symbol "SetCriticalSectionSpinCount" : YES
Header <synchapi.h> has symbol "InitializeSynchronizationBarrier" : YES
```