### PR TITLE
Actions: fix meson path

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,10 @@ jobs:
     - name: install meson
       run: py -3 -m pip install meson
     - name: add meson to path
-      run: echo "::add-path::C:\hostedtoolcache\windows\Python\3.8.2\x64\Scripts"
+      run: |
+        $python_version = (py -3 --version).replace("Python ", "")
+        $meson_path = ($(echo C:\hostedtoolcache\windows\Python\$python_version\x64\Scripts ) -join "")
+        echo "::add-path::$meson_path"
     - name: test meson
       run: meson -v
     - name: Cache OpenSSL compilation


### PR DESCRIPTION
Our 'EFL on Windows' Action is failing because the path for meson depends of the installed version of Python, this PR uses the output of `python --version` to get the right path for meson.