### PR TITLE
[temporary] Use a custom version of libcheck

### DIFF
--- a/subprojects/check.wrap
+++ b/subprojects/check.wrap
@@ -1,10 +1,3 @@
-[wrap-file]
-directory = check-0.14.0
-
-source_url = https://github.com/libcheck/check/archive/0.14.0.tar.gz
-source_filename = check-0.14.0.tar.gz
-source_hash = d55782b36827e36472b77d577953795403fb708f94a202558ffaa054bd328c60
-
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/check/0.14.0/1/get_zip
-patch_filename = check-0.14.0-1-wrap.zip
-patch_hash = b63cabd8de2db73188634f17b6d12141c0880cb3c7a75ec001fd36e9ed0933c9
+[wrap-git]
+url = https://github.com/expertisesolutions/check
+revision = windows-mutex-lock-meson


### PR DESCRIPTION
While we don't merge the windows lock fix in the main libcheck, let's
use our fork to keep going with efl port.