### PR TITLE
Compile lib EFL

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -396,7 +396,7 @@ subprojects = [
 # name              |   option              | mod  | lib  | bin  | bench | tests | examples | pkg-config options | name of static libs
 ['evil'             ,[]                    , false,  true, false, false, false, false, [], []],
 ['eina'             ,[]                    , false,  true,  true,  true,  true,  true, [], []],
-#['eolian'           ,[]                    , false,  true,  true, false,  true, false, ['eina'], []],
+['eolian'           ,[]                    , false,  true,  true, false,  false, false, ['eina'], []],
 #['eo'               ,[]                    , false,  true, false,  true,  true, false, ['eina'], []],
 #['efl'              ,[]                    , false,  true, false, false,  true, false, ['eo'], []],
 #['emile'            ,[]                    , false,  true, false, false,  true,  true, ['eina', 'efl'], ['lz4', 'rg_etc']],

--- a/meson.build
+++ b/meson.build
@@ -398,7 +398,7 @@ subprojects = [
 ['eina'             ,[]                    , false,  true,  true,  true,  true,  true, [], []],
 ['eolian'           ,[]                    , false,  true,  true, false,  false, false, ['eina'], []],
 #['eo'               ,[]                    , false,  true, false,  true,  true, false, ['eina'], []],
-#['efl'              ,[]                    , false,  true, false, false,  true, false, ['eo'], []],
+['efl'              ,[]                    , false,  true, false, false,  false, false, [], []],
 #['emile'            ,[]                    , false,  true, false, false,  true,  true, ['eina', 'efl'], ['lz4', 'rg_etc']],
 #['eet'              ,[]                    , false,  true,  true, false,  true,  true, ['eina', 'emile', 'efl'], []],
 #['ecore'            ,[]                    , false,  true, false, false, false, false, ['eina', 'eo', 'efl'], ['buildsystem']]

--- a/src/lib/efl/Efl.h
+++ b/src/lib/efl/Efl.h
@@ -7,8 +7,8 @@ extern "C" {
 
 #include <Eo.h>
 
-#ifdef EAPI
-# undef EAPI
+#ifdef EFL_API
+# undef EFL_API
 #endif
 #ifdef EWAPI
 # undef EWAPI
@@ -20,31 +20,31 @@ extern "C" {
 #ifdef _WIN32
 # ifdef EFL_BUILD
 #  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
+#   define EFL_API __declspec(dllexport)
 #  else
-#   define EAPI
+#   define EFL_API
 #  endif
 # else
-#  define EAPI __declspec(dllimport)
+#  define EFL_API __declspec(dllimport)
 # endif
-# define EAPI_WEAK
+# define EFL_API_WEAK
 #else
 # ifdef __GNUC__
 #  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#   define EAPI_WEAK __attribute__ ((weak))
+#   define EFL_API __attribute__ ((visibility("default")))
+#   define EFL_API_WEAK __attribute__ ((weak))
 #  else
-#   define EAPI
-#   define EAPI_WEAK
+#   define EFL_API
+#   define EFL_API_WEAK
 #  endif
 # else
-#  define EAPI
-#  define EAPI_WEAK
+#  define EFL_API
+#  define EFL_API_WEAK
 # endif
 #endif
 
-#define EWAPI EAPI EAPI_WEAK
-#define EOAPI EAPI EAPI_WEAK
+#define EWAPI EFL_API EFL_API_WEAK
+#define EOAPI EFL_API EFL_API_WEAK
 
 #define EFL_VERSION_1_18 1
 #define EFL_VERSION_1_19 1
@@ -229,11 +229,11 @@ typedef Efl_Gfx_Path_Command_Type Efl_Gfx_Path_Command;
  *
  * @since 1.21
  */
-EAPI Efl_Object *efl_part(const Eo *obj, const char *name);
+EFL_API Efl_Object *efl_part(const Eo *obj, const char *name);
 
 #ifdef EFL_BETA_API_SUPPORT
 
-EAPI void efl_observable_tuple_free(Efl_Observable_Tuple *tuple);
+EFL_API void efl_observable_tuple_free(Efl_Observable_Tuple *tuple);
 
 
 
@@ -340,13 +340,13 @@ efl_config_string_get(const Efl_Config *obj, const char *name)
 #endif
 
 /* work-around bug in gcc --as-needed link optimization */
-EAPI void __efl_internal_init(void);
+EFL_API void __efl_internal_init(void);
 
 #if defined ( __cplusplus )
 }
 #endif
 
-#undef EAPI
-#define EAPI
+#undef EFL_API
+#define EFL_API
 
 #endif

--- a/src/lib/efl/Efl.h
+++ b/src/lib/efl/Efl.h
@@ -19,11 +19,7 @@ extern "C" {
 
 #ifdef _WIN32
 # ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EFL_API __declspec(dllexport)
-#  else
-#   define EFL_API
-#  endif
+#  define EFL_API __declspec(dllexport)
 # else
 #  define EFL_API __declspec(dllimport)
 # endif

--- a/src/lib/efl/Efl_MVVM_Common.h
+++ b/src/lib/efl/Efl_MVVM_Common.h
@@ -3,22 +3,22 @@
 
 #include <Eina.h>
 
-EAPI extern Eina_Error EFL_MODEL_ERROR_UNKNOWN;
-EAPI extern Eina_Error EFL_MODEL_ERROR_NOT_SUPPORTED;
-EAPI extern Eina_Error EFL_MODEL_ERROR_NOT_FOUND;
-EAPI extern Eina_Error EFL_MODEL_ERROR_READ_ONLY;
-EAPI extern Eina_Error EFL_MODEL_ERROR_INIT_FAILED;
-EAPI extern Eina_Error EFL_MODEL_ERROR_INCORRECT_VALUE;
-EAPI extern Eina_Error EFL_MODEL_ERROR_PERMISSION_DENIED;
-EAPI extern Eina_Error EFL_MODEL_ERROR_INVALID_OBJECT; /**< @since 1.19 */
+EFL_API extern Eina_Error EFL_MODEL_ERROR_UNKNOWN;
+EFL_API extern Eina_Error EFL_MODEL_ERROR_NOT_SUPPORTED;
+EFL_API extern Eina_Error EFL_MODEL_ERROR_NOT_FOUND;
+EFL_API extern Eina_Error EFL_MODEL_ERROR_READ_ONLY;
+EFL_API extern Eina_Error EFL_MODEL_ERROR_INIT_FAILED;
+EFL_API extern Eina_Error EFL_MODEL_ERROR_INCORRECT_VALUE;
+EFL_API extern Eina_Error EFL_MODEL_ERROR_PERMISSION_DENIED;
+EFL_API extern Eina_Error EFL_MODEL_ERROR_INVALID_OBJECT; /**< @since 1.19 */
 
-EAPI extern Eina_Error EFL_PROPERTY_ERROR_INVALID_KEY; /**< Returned when the given key during a efl_ui_property_bind does not exist on the object. */
+EFL_API extern Eina_Error EFL_PROPERTY_ERROR_INVALID_KEY; /**< Returned when the given key during a efl_ui_property_bind does not exist on the object. */
 
-EAPI extern Eina_Error EFL_FACTORY_ERROR_NOT_SUPPORTED; /**< Returned error when factory got a request that it can't fullfil due to a set of unsupported parameters @since 1.22 */
+EFL_API extern Eina_Error EFL_FACTORY_ERROR_NOT_SUPPORTED; /**< Returned error when factory got a request that it can't fullfil due to a set of unsupported parameters @since 1.22 */
 
 #include "interfaces/efl_model.eo.h"
 
-EAPI int efl_model_init(void);
+EFL_API int efl_model_init(void);
 
 
 /**
@@ -29,7 +29,7 @@ EAPI int efl_model_init(void);
  *
  * @since 1.17
  */
-EAPI void _efl_model_properties_changed_internal(const Efl_Model *model, ...);
+EFL_API void _efl_model_properties_changed_internal(const Efl_Model *model, ...);
 
 #define efl_model_properties_changed(Model, ...) _efl_model_properties_changed_internal(Model, ##__VA_ARGS__, NULL)
 
@@ -41,7 +41,7 @@ EAPI void _efl_model_properties_changed_internal(const Efl_Model *model, ...);
  *
  * @since 1.17
  */
-EAPI void efl_model_property_invalidated_notify(Efl_Model *model, const char *property);
+EFL_API void efl_model_property_invalidated_notify(Efl_Model *model, const char *property);
 
 /**
  * @brief Callback to setup a member of @c Eina_Value_Struct
@@ -62,7 +62,7 @@ typedef void (*Efl_Model_Value_Struct_Member_Setup_Cb)(void *data, int index, Ei
  *
  * @since 1.17
  */
-EAPI Eina_Value_Struct_Desc *efl_model_value_struct_description_new(unsigned int member_count, Efl_Model_Value_Struct_Member_Setup_Cb setup_cb, void *data) EINA_ARG_NONNULL(2);
+EFL_API Eina_Value_Struct_Desc *efl_model_value_struct_description_new(unsigned int member_count, Efl_Model_Value_Struct_Member_Setup_Cb setup_cb, void *data) EINA_ARG_NONNULL(2);
 
 /**
  * @brief Frees the memory allocated to the struct description.
@@ -71,6 +71,6 @@ EAPI Eina_Value_Struct_Desc *efl_model_value_struct_description_new(unsigned int
  *
  * @since 1.17
  */
-EAPI void efl_model_value_struct_description_free(Eina_Value_Struct_Desc *desc);
+EFL_API void efl_model_value_struct_description_free(Eina_Value_Struct_Desc *desc);
 
 #endif

--- a/src/lib/efl/efl_main.c
+++ b/src/lib/efl/efl_main.c
@@ -1,0 +1,13 @@
+#ifdef _WIN32
+#include <windows.h>
+
+BOOL WINAPI
+DllMain(HINSTANCE const instance, DWORD const reason, LPVOID const reserved)
+{
+   (void) instance;
+   (void) reason;
+   (void) reserved;
+   return TRUE;
+}
+
+#endif

--- a/src/lib/efl/interfaces/efl_file.c
+++ b/src/lib/efl/interfaces/efl_file.c
@@ -167,7 +167,7 @@ _efl_file_efl_object_finalize(Eo *obj, Efl_File_Data *pd)
 
 ////////////////////////////////////////////////////////////////////////////
 
-EAPI Eina_Bool
+EFL_API Eina_Bool
 efl_file_simple_load(Eo *obj, const char *file, const char *key)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(obj, EINA_FALSE);
@@ -192,7 +192,7 @@ fail:
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EFL_API Eina_Bool
 efl_file_simple_mmap_load(Eo *obj, const Eina_File *file, const char *key)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(obj, EINA_FALSE);
@@ -213,7 +213,7 @@ fail:
    return EINA_FALSE;
 }
 
-EAPI void
+EFL_API void
 efl_file_simple_get(const Eo *obj, const char **file, const char **key)
 {
    efl_ref((Eo*)obj);
@@ -222,7 +222,7 @@ efl_file_simple_get(const Eo *obj, const char **file, const char **key)
    efl_unref((Eo*)obj);
 }
 
-EAPI void
+EFL_API void
 efl_file_simple_mmap_get(const Eo *obj, const Eina_File **file, const char **key)
 {
    efl_ref((Eo*)obj);

--- a/src/lib/efl/interfaces/efl_file.h
+++ b/src/lib/efl/interfaces/efl_file.h
@@ -2,9 +2,9 @@
 # define _EFL_FILE_H
 
 /* add doc note about needing ref/unref when passing efl_part to these functions */
-EAPI Eina_Bool efl_file_simple_load(Eo *obj, const char *file, const char *key);
-EAPI Eina_Bool efl_file_simple_mmap_load(Eo *obj, const Eina_File *file, const char *key);
-EAPI void efl_file_simple_get(const Eo *obj, const char **file, const char **key);
-EAPI void efl_file_simple_mmap_get(const Eo *obj, const Eina_File **file, const char **key);
+EFL_API Eina_Bool efl_file_simple_load(Eo *obj, const char *file, const char *key);
+EFL_API Eina_Bool efl_file_simple_mmap_load(Eo *obj, const Eina_File *file, const char *key);
+EFL_API void efl_file_simple_get(const Eo *obj, const char **file, const char **key);
+EFL_API void efl_file_simple_mmap_get(const Eo *obj, const Eina_File **file, const char **key);
 
 #endif

--- a/src/lib/efl/interfaces/efl_interfaces_main.c
+++ b/src/lib/efl/interfaces/efl_interfaces_main.c
@@ -85,7 +85,7 @@ _noref_death(void *data EINA_UNUSED, const Efl_Event *event)
    efl_del(event->object);
 }
 
-EAPI Efl_Object *
+EFL_API Efl_Object *
 efl_part(const Eo *obj, const char *name)
 {
    Efl_Object *r;
@@ -105,7 +105,7 @@ efl_part(const Eo *obj, const char *name)
    return efl_ref(r);
 }
 
-EAPI void
+EFL_API void
 __efl_internal_init(void)
 {
    efl_model_init();

--- a/src/lib/efl/interfaces/efl_mvvm_common.c
+++ b/src/lib/efl/interfaces/efl_mvvm_common.c
@@ -5,17 +5,17 @@
 #include "Efl.h"
 #include "Efl_MVVM_Common.h"
 
-EAPI Eina_Error EFL_MODEL_ERROR_UNKNOWN = 0;
-EAPI Eina_Error EFL_MODEL_ERROR_NOT_SUPPORTED = 0;
-EAPI Eina_Error EFL_MODEL_ERROR_NOT_FOUND = 0;
-EAPI Eina_Error EFL_MODEL_ERROR_READ_ONLY = 0;
-EAPI Eina_Error EFL_MODEL_ERROR_INIT_FAILED = 0;
-EAPI Eina_Error EFL_MODEL_ERROR_PERMISSION_DENIED = 0;
-EAPI Eina_Error EFL_MODEL_ERROR_INCORRECT_VALUE = 0;
-EAPI Eina_Error EFL_MODEL_ERROR_INVALID_OBJECT = 0;
+EFL_API Eina_Error EFL_MODEL_ERROR_UNKNOWN = 0;
+EFL_API Eina_Error EFL_MODEL_ERROR_NOT_SUPPORTED = 0;
+EFL_API Eina_Error EFL_MODEL_ERROR_NOT_FOUND = 0;
+EFL_API Eina_Error EFL_MODEL_ERROR_READ_ONLY = 0;
+EFL_API Eina_Error EFL_MODEL_ERROR_INIT_FAILED = 0;
+EFL_API Eina_Error EFL_MODEL_ERROR_PERMISSION_DENIED = 0;
+EFL_API Eina_Error EFL_MODEL_ERROR_INCORRECT_VALUE = 0;
+EFL_API Eina_Error EFL_MODEL_ERROR_INVALID_OBJECT = 0;
 
-EAPI Eina_Error EFL_FACTORY_ERROR_NOT_SUPPORTED = 0;
-EAPI Eina_Error EFL_PROPERTY_ERROR_INVALID_KEY = 0;
+EFL_API Eina_Error EFL_FACTORY_ERROR_NOT_SUPPORTED = 0;
+EFL_API Eina_Error EFL_PROPERTY_ERROR_INVALID_KEY = 0;
 
 static const char EFL_MODEL_ERROR_UNKNOWN_STR[]           = "Unknown Error";
 static const char EFL_MODEL_ERROR_NOT_SUPPORTED_STR[]     = "Operation not supported";
@@ -31,7 +31,7 @@ static const char EFL_FACTORY_ERROR_NOT_SUPPORTED_STR[]   = "Operation not suppo
 static const char EFL_PROPERTY_ERROR_INVALID_KEY_STR[]    = "Incorrect key provided";
 
 
-EAPI int
+EFL_API int
 efl_model_init(void)
 {
 #define _ERROR(Name) EFL_MODEL_ERROR_##Name = eina_error_msg_static_register(EFL_MODEL_ERROR_##Name##_STR);
@@ -57,7 +57,7 @@ efl_model_init(void)
 
 #undef _ERROR
 
-EAPI void
+EFL_API void
 _efl_model_properties_changed_internal(const Efl_Model *model, ...)
 {
    Efl_Model_Property_Event ev = { 0 };
@@ -84,7 +84,7 @@ _efl_model_properties_changed_internal(const Efl_Model *model, ...)
    eina_array_free(properties);
 }
 
-EAPI void
+EFL_API void
 efl_model_property_invalidated_notify(Efl_Model *model, const char *property)
 {
    Eina_Array *invalidated_properties = eina_array_new(1);
@@ -112,7 +112,7 @@ struct _Efl_Model_Value_Struct_Desc
    Eina_Value_Struct_Member members[];
 };
 
-EAPI Eina_Value_Struct_Desc *
+EFL_API Eina_Value_Struct_Desc *
 efl_model_value_struct_description_new(unsigned int member_count, Efl_Model_Value_Struct_Member_Setup_Cb setup_cb, void *data)
 {
    Efl_Model_Value_Struct_Desc *desc;
@@ -152,7 +152,7 @@ efl_model_value_struct_description_new(unsigned int member_count, Efl_Model_Valu
    return &desc->base;
 }
 
-EAPI void
+EFL_API void
 efl_model_value_struct_description_free(Eina_Value_Struct_Desc *desc)
 {
    size_t i;

--- a/src/lib/efl/interfaces/efl_observer.c
+++ b/src/lib/efl/interfaces/efl_observer.c
@@ -257,7 +257,7 @@ _efl_observable_iterator_tuple_new(Eo *obj, Efl_Observable_Data *pd)
    return &it->iterator;
 }
 
-EAPI void
+EFL_API void
 efl_observable_tuple_free(Efl_Observable_Tuple *tuple)
 {
    //key is not owned

--- a/src/lib/efl/meson.build
+++ b/src/lib/efl/meson.build
@@ -1,5 +1,5 @@
 efl_deps = []
-efl_pub_deps = [eo]
+efl_pub_deps = []
 
 efl_header_src = [
   'Efl.h',
@@ -8,17 +8,14 @@ efl_header_src = [
 
 efl_src = []
 
-subdir('interfaces')
-package_header_subdirs += 'interfaces'
-
-efl_lib_deps = [eina, eo]
+efl_lib_deps = [eina]
 
 if not sys_windows
   efl_lib_deps += m
 endif
 
 efl_lib = library('efl',
-    efl_src, pub_eo_file_target,
+    efl_src, 
     dependencies: efl_lib_deps,
     install: true,
     version : meson.project_version()
@@ -28,11 +25,9 @@ efl = declare_dependency(
   include_directories: [include_directories('.'), config_dir],
   link_with: efl_lib,
   dependencies: efl_deps + efl_pub_deps,
-  sources : pub_eo_file_target
 )
 
 install_headers(efl_header_src,
   install_dir : dir_package_include,
 )
 
-package_eo_subdirs += ['interfaces']

--- a/src/lib/efl/meson.build
+++ b/src/lib/efl/meson.build
@@ -15,10 +15,11 @@ if not sys_windows
 endif
 
 efl_lib = library('efl',
-    efl_src, 
-    dependencies: efl_lib_deps,
-    install: true,
-    version : meson.project_version()
+  efl_src,
+  c_args : ['-DEFL_BUILD'],
+  dependencies: efl_lib_deps,
+  install: true,
+  version : meson.project_version()
 )
 
 efl = declare_dependency(

--- a/src/lib/efl/meson.build
+++ b/src/lib/efl/meson.build
@@ -6,7 +6,7 @@ efl_header_src = [
   'Efl_MVVM_Common.h'
 ]
 
-efl_src = []
+efl_src = ['efl_main.c']
 
 efl_lib_deps = [eina]
 

--- a/src/lib/eolian/Eolian.h
+++ b/src/lib/eolian/Eolian.h
@@ -6,12 +6,8 @@
 #endif
 
 #ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EOLIAN_API __declspec(dllexport)
-#  else
-#   define EOLIAN_API
-#  endif
+# ifdef EOLIAN_BUILD
+#  define EOLIAN_API __declspec(dllexport)
 # else
 #  define EOLIAN_API __declspec(dllimport)
 # endif

--- a/src/lib/eolian/Eolian.h
+++ b/src/lib/eolian/Eolian.h
@@ -1,29 +1,29 @@
 #ifndef EOLIAN_H
 #define EOLIAN_H
 
-#ifdef EAPI
-# undef EAPI
+#ifdef EOLIAN_API
+# undef EOLIAN_API
 #endif
 
 #ifdef _WIN32
 # ifdef EFL_BUILD
 #  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
+#   define EOLIAN_API __declspec(dllexport)
 #  else
-#   define EAPI
+#   define EOLIAN_API
 #  endif
 # else
-#  define EAPI __declspec(dllimport)
+#  define EOLIAN_API __declspec(dllimport)
 # endif
 #else
 # ifdef __GNUC__
 #  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
+#   define EOLIAN_API __attribute__ ((visibility("default")))
 #  else
-#   define EAPI
+#   define EOLIAN_API
 #  endif
 # else
-#  define EAPI
+#  define EOLIAN_API
 # endif
 #endif
 
@@ -477,14 +477,14 @@ typedef struct _Eolian_Doc_Token
  *
  * @ingroup Eolian
  */
-EAPI int eolian_init(void);
+EOLIAN_API int eolian_init(void);
 
 /*
  * @brief Shutdown Eolian.
  *
  * @ingroup Eolian
  */
-EAPI int eolian_shutdown(void);
+EOLIAN_API int eolian_shutdown(void);
 
 /*
  * @brief Get the Eolian file format version.
@@ -493,7 +493,7 @@ EAPI int eolian_shutdown(void);
  * retrieval of the version at runtime, so it can be used by FFI based
  * bindings in dynamic languages to do runtime checks and so on.
  */
-EAPI unsigned short eolian_file_format_version_get(void);
+EOLIAN_API unsigned short eolian_file_format_version_get(void);
 
 /*
  * @brief Create a new Eolian state.
@@ -513,7 +513,7 @@ EAPI unsigned short eolian_file_format_version_get(void);
  *
  * @ingroup Eolian
  */
-EAPI Eolian_State *eolian_state_new(void);
+EOLIAN_API Eolian_State *eolian_state_new(void);
 
 /*
  * @brief Free an Eolian state.
@@ -525,7 +525,7 @@ EAPI Eolian_State *eolian_state_new(void);
  * @param[in] state the state to free
  *
  */
-EAPI void eolian_state_free(Eolian_State *state);
+EOLIAN_API void eolian_state_free(Eolian_State *state);
 
 /*
  * @brief Set the panic function for the state.
@@ -555,7 +555,7 @@ EAPI void eolian_state_free(Eolian_State *state);
  *
  * @see eolian_state_error_cb_set
  */
-EAPI Eolian_Panic_Cb eolian_state_panic_cb_set(Eolian_State *state, Eolian_Panic_Cb cb);
+EOLIAN_API Eolian_Panic_Cb eolian_state_panic_cb_set(Eolian_State *state, Eolian_Panic_Cb cb);
 
 /*
  * @brief Set the error function for the state.
@@ -572,7 +572,7 @@ EAPI Eolian_Panic_Cb eolian_state_panic_cb_set(Eolian_State *state, Eolian_Panic
  * @see eolian_state_panic_cb_set
  * @see eolian_state_error_data_set
  */
-EAPI Eolian_Error_Cb eolian_state_error_cb_set(Eolian_State *state, Eolian_Error_Cb cb);
+EOLIAN_API Eolian_Error_Cb eolian_state_error_cb_set(Eolian_State *state, Eolian_Error_Cb cb);
 
 /*
  * @brief Set a data pointer to be passed to the error function.
@@ -585,7 +585,7 @@ EAPI Eolian_Error_Cb eolian_state_error_cb_set(Eolian_State *state, Eolian_Error
  *
  * @see eolian_state_error_cb_set
  */
-EAPI void *eolian_state_error_data_set(Eolian_State *state, void *data);
+EOLIAN_API void *eolian_state_error_data_set(Eolian_State *state, void *data);
 
 /*
  * @brief Get the type of an Eolian object.
@@ -603,7 +603,7 @@ EAPI void *eolian_state_error_data_set(Eolian_State *state, void *data);
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Object_Type eolian_object_type_get(const Eolian_Object *obj);
+EOLIAN_API Eolian_Object_Type eolian_object_type_get(const Eolian_Object *obj);
 
 /*
  * @brief Get the unit the object comes from.
@@ -619,7 +619,7 @@ EAPI Eolian_Object_Type eolian_object_type_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Unit *eolian_object_unit_get(const Eolian_Object *obj);
+EOLIAN_API const Eolian_Unit *eolian_object_unit_get(const Eolian_Object *obj);
 
 /*
  * @brief Get the name of the file the object comes from.
@@ -636,7 +636,7 @@ EAPI const Eolian_Unit *eolian_object_unit_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_object_file_get(const Eolian_Object *obj);
+EOLIAN_API const char *eolian_object_file_get(const Eolian_Object *obj);
 
 /*
  * @brief Get the line the object was declared at.
@@ -652,7 +652,7 @@ EAPI const char *eolian_object_file_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI int eolian_object_line_get(const Eolian_Object *obj);
+EOLIAN_API int eolian_object_line_get(const Eolian_Object *obj);
 
 /*
  * @brief Get the column the object was declared at.
@@ -671,7 +671,7 @@ EAPI int eolian_object_line_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI int eolian_object_column_get(const Eolian_Object *obj);
+EOLIAN_API int eolian_object_column_get(const Eolian_Object *obj);
 
 /*
  * @brief Get the name of an object.
@@ -691,7 +691,7 @@ EAPI int eolian_object_column_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_object_name_get(const Eolian_Object *obj);
+EOLIAN_API const char *eolian_object_name_get(const Eolian_Object *obj);
 
 /*
  * @brief Get the C name of an object.
@@ -713,7 +713,7 @@ EAPI const char *eolian_object_name_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_object_c_name_get(const Eolian_Object *obj);
+EOLIAN_API const char *eolian_object_c_name_get(const Eolian_Object *obj);
 
 /*
  * @brief Get the short name of an object.
@@ -727,7 +727,7 @@ EAPI const char *eolian_object_c_name_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_object_short_name_get(const Eolian_Object *obj);
+EOLIAN_API const char *eolian_object_short_name_get(const Eolian_Object *obj);
 
 /*
  * @brief Get a list of namespaces for the object.
@@ -741,7 +741,7 @@ EAPI const char *eolian_object_short_name_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_object_namespaces_get(const Eolian_Object *obj);
+EOLIAN_API Eina_Iterator *eolian_object_namespaces_get(const Eolian_Object *obj);
 
 /*
  * @brief Get whether an object is beta.
@@ -754,7 +754,7 @@ EAPI Eina_Iterator *eolian_object_namespaces_get(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_object_is_beta(const Eolian_Object *obj);
+EOLIAN_API Eina_Bool eolian_object_is_beta(const Eolian_Object *obj);
 
 /*
  * @brief Scan the given directory for .eo and .eot files.
@@ -771,7 +771,7 @@ EAPI Eina_Bool eolian_object_is_beta(const Eolian_Object *obj);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_state_directory_add(Eolian_State *state, const char *dir);
+EOLIAN_API Eina_Bool eolian_state_directory_add(Eolian_State *state, const char *dir);
 
 /*
  * @brief Scan the system directory for .eo and .eot files.
@@ -788,7 +788,7 @@ EAPI Eina_Bool eolian_state_directory_add(Eolian_State *state, const char *dir);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_state_system_directory_add(Eolian_State *state);
+EOLIAN_API Eina_Bool eolian_state_system_directory_add(Eolian_State *state);
 
 /*
  * @brief Get an iterator to all .eo file names with paths.
@@ -801,7 +801,7 @@ EAPI Eina_Bool eolian_state_system_directory_add(Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_eo_file_paths_get(const Eolian_State *state);
+EOLIAN_API Eina_Iterator *eolian_state_eo_file_paths_get(const Eolian_State *state);
 
 /*
  * @brief Get an iterator to all .eot file names with paths.
@@ -814,7 +814,7 @@ EAPI Eina_Iterator *eolian_state_eo_file_paths_get(const Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_eot_file_paths_get(const Eolian_State *state);
+EOLIAN_API Eina_Iterator *eolian_state_eot_file_paths_get(const Eolian_State *state);
 
 /*
  * @brief Get an iterator to all .eo file names (without paths).
@@ -827,7 +827,7 @@ EAPI Eina_Iterator *eolian_state_eot_file_paths_get(const Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_eo_files_get(const Eolian_State *state);
+EOLIAN_API Eina_Iterator *eolian_state_eo_files_get(const Eolian_State *state);
 
 /*
  * @brief Get an iterator to all .eot file names (without paths).
@@ -840,7 +840,7 @@ EAPI Eina_Iterator *eolian_state_eo_files_get(const Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_eot_files_get(const Eolian_State *state);
+EOLIAN_API Eina_Iterator *eolian_state_eot_files_get(const Eolian_State *state);
 
 /*
  * @brief Parse the given .eo or .eot file and fill the database.
@@ -857,7 +857,7 @@ EAPI Eina_Iterator *eolian_state_eot_files_get(const Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Unit *eolian_state_file_parse(Eolian_State *state, const char *filename);
+EOLIAN_API const Eolian_Unit *eolian_state_file_parse(Eolian_State *state, const char *filename);
 
 /*
  * @brief Parse the given .eo or .eot file and fill the database.
@@ -873,7 +873,7 @@ EAPI const Eolian_Unit *eolian_state_file_parse(Eolian_State *state, const char 
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Unit *eolian_state_file_path_parse(Eolian_State *state, const char *filepath);
+EOLIAN_API const Eolian_Unit *eolian_state_file_path_parse(Eolian_State *state, const char *filepath);
 
 /*
  * @brief Parse all known eo files.
@@ -887,7 +887,7 @@ EAPI const Eolian_Unit *eolian_state_file_path_parse(Eolian_State *state, const 
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_state_all_eo_files_parse(Eolian_State *state);
+EOLIAN_API Eina_Bool eolian_state_all_eo_files_parse(Eolian_State *state);
 
 /*
  * @brief Parse all known eot files.
@@ -901,7 +901,7 @@ EAPI Eina_Bool eolian_state_all_eo_files_parse(Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_state_all_eot_files_parse(Eolian_State *state);
+EOLIAN_API Eina_Bool eolian_state_all_eot_files_parse(Eolian_State *state);
 
 /*
  * @brief Perform additional checks on the state.
@@ -918,7 +918,7 @@ EAPI Eina_Bool eolian_state_all_eot_files_parse(Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_state_check(const Eolian_State *state);
+EOLIAN_API Eina_Bool eolian_state_check(const Eolian_State *state);
 
 /*
  * @brief Get an Eolian unit by file name.
@@ -936,7 +936,7 @@ EAPI Eina_Bool eolian_state_check(const Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Unit *eolian_state_unit_by_file_get(const Eolian_State *state, const char *file_name);
+EOLIAN_API const Eolian_Unit *eolian_state_unit_by_file_get(const Eolian_State *state, const char *file_name);
 
 /*
  * @brief Get an iterator to all Eolian units in a state.
@@ -947,7 +947,7 @@ EAPI const Eolian_Unit *eolian_state_unit_by_file_get(const Eolian_State *state,
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_units_get(const Eolian_State *state);
+EOLIAN_API Eina_Iterator *eolian_state_units_get(const Eolian_State *state);
 
 /*
  * @brief Get the state associated with the unit.
@@ -961,7 +961,7 @@ EAPI Eina_Iterator *eolian_state_units_get(const Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_State *eolian_unit_state_get(const Eolian_Unit *unit);
+EOLIAN_API const Eolian_State *eolian_unit_state_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get the children (dependencies) of a unit.
@@ -972,7 +972,7 @@ EAPI const Eolian_State *eolian_unit_state_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_unit_children_get(const Eolian_Unit *unit);
+EOLIAN_API Eina_Iterator *eolian_unit_children_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get the file name a unit is associated with.
@@ -986,7 +986,7 @@ EAPI Eina_Iterator *eolian_unit_children_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_unit_file_get(const Eolian_Unit *unit);
+EOLIAN_API const char *eolian_unit_file_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get the full file path a unit is associated with.
@@ -1000,7 +1000,7 @@ EAPI const char *eolian_unit_file_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_unit_file_path_get(const Eolian_Unit *unit);
+EOLIAN_API const char *eolian_unit_file_path_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get the version of the unit.
@@ -1012,7 +1012,7 @@ EAPI const char *eolian_unit_file_path_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI unsigned short eolian_unit_version_get(const Eolian_Unit *unit);
+EOLIAN_API unsigned short eolian_unit_version_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get an object in a unit by name.
@@ -1025,7 +1025,7 @@ EAPI unsigned short eolian_unit_version_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Object *eolian_unit_object_by_name_get(const Eolian_Unit *unit, const char *name);
+EOLIAN_API const Eolian_Object *eolian_unit_object_by_name_get(const Eolian_Unit *unit, const char *name);
 
 /*
  * @brief Get all objects in the unit.
@@ -1038,7 +1038,7 @@ EAPI const Eolian_Object *eolian_unit_object_by_name_get(const Eolian_Unit *unit
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_unit_objects_get(const Eolian_Unit *unit);
+EOLIAN_API Eina_Iterator *eolian_unit_objects_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get a class within a unit by name.
@@ -1048,7 +1048,7 @@ EAPI Eina_Iterator *eolian_unit_objects_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_unit_class_by_name_get(const Eolian_Unit *unit, const char *class_name);
+EOLIAN_API const Eolian_Class *eolian_unit_class_by_name_get(const Eolian_Unit *unit, const char *class_name);
 
 /*
  * @brief Get an iterator to all the classes stored into a unit.
@@ -1057,7 +1057,7 @@ EAPI const Eolian_Class *eolian_unit_class_by_name_get(const Eolian_Unit *unit, 
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_unit_classes_get(const Eolian_Unit *unit);
+EOLIAN_API Eina_Iterator *eolian_unit_classes_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get a constant in a unit by name.
@@ -1067,7 +1067,7 @@ EAPI Eina_Iterator *eolian_unit_classes_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Constant *eolian_unit_constant_by_name_get(const Eolian_Unit *unit, const char *name);
+EOLIAN_API const Eolian_Constant *eolian_unit_constant_by_name_get(const Eolian_Unit *unit, const char *name);
 
 /*
  * @brief Get an error declaration in a unit by name.
@@ -1077,7 +1077,7 @@ EAPI const Eolian_Constant *eolian_unit_constant_by_name_get(const Eolian_Unit *
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Error *eolian_unit_error_by_name_get(const Eolian_Unit *unit, const char *name);
+EOLIAN_API const Eolian_Error *eolian_unit_error_by_name_get(const Eolian_Unit *unit, const char *name);
 
 /*
  * @brief Get an iterator to all constants in the Eolian database.
@@ -1088,7 +1088,7 @@ EAPI const Eolian_Error *eolian_unit_error_by_name_get(const Eolian_Unit *unit, 
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_unit_constants_get(const Eolian_Unit *unit);
+EOLIAN_API Eina_Iterator *eolian_unit_constants_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get an iterator to all error declarations in the Eolian database.
@@ -1099,7 +1099,7 @@ EAPI Eina_Iterator *eolian_unit_constants_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_unit_errors_get(const Eolian_Unit *unit);
+EOLIAN_API Eina_Iterator *eolian_unit_errors_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get an alias type declaration within a unit by name.
@@ -1109,7 +1109,7 @@ EAPI Eina_Iterator *eolian_unit_errors_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Typedecl *eolian_unit_alias_by_name_get(const Eolian_Unit *unit, const char *name);
+EOLIAN_API const Eolian_Typedecl *eolian_unit_alias_by_name_get(const Eolian_Unit *unit, const char *name);
 
 /*
  * @brief Get a struct declaration within a unit by name.
@@ -1119,7 +1119,7 @@ EAPI const Eolian_Typedecl *eolian_unit_alias_by_name_get(const Eolian_Unit *uni
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Typedecl *eolian_unit_struct_by_name_get(const Eolian_Unit *unit, const char *name);
+EOLIAN_API const Eolian_Typedecl *eolian_unit_struct_by_name_get(const Eolian_Unit *unit, const char *name);
 
 /*
  * @brief Get an enum declaration within a unit by name.
@@ -1129,7 +1129,7 @@ EAPI const Eolian_Typedecl *eolian_unit_struct_by_name_get(const Eolian_Unit *un
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Typedecl *eolian_unit_enum_by_name_get(const Eolian_Unit *unit, const char *name);
+EOLIAN_API const Eolian_Typedecl *eolian_unit_enum_by_name_get(const Eolian_Unit *unit, const char *name);
 
 /*
  * @brief Get an iterator to all aliases in the Eolian database.
@@ -1140,7 +1140,7 @@ EAPI const Eolian_Typedecl *eolian_unit_enum_by_name_get(const Eolian_Unit *unit
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_unit_aliases_get(const Eolian_Unit *unit);
+EOLIAN_API Eina_Iterator *eolian_unit_aliases_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get an iterator to all structs in the Eolian database.
@@ -1151,7 +1151,7 @@ EAPI Eina_Iterator *eolian_unit_aliases_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_unit_structs_get(const Eolian_Unit *unit);
+EOLIAN_API Eina_Iterator *eolian_unit_structs_get(const Eolian_Unit *unit);
 
 /*
  * @brief Get an iterator to all enums in the Eolian database.
@@ -1162,7 +1162,7 @@ EAPI Eina_Iterator *eolian_unit_structs_get(const Eolian_Unit *unit);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_unit_enums_get(const Eolian_Unit *unit);
+EOLIAN_API Eina_Iterator *eolian_unit_enums_get(const Eolian_Unit *unit);
 
 /*
  * @brief A helper function to get an object in a state by name.
@@ -1189,7 +1189,7 @@ eolian_state_object_by_name_get(const Eolian_State *state, const char *name)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_objects_by_file_get(const Eolian_State *state, const char *file_name);
+EOLIAN_API Eina_Iterator *eolian_state_objects_by_file_get(const Eolian_State *state, const char *file_name);
 
 /*
  * @brief A helper function to get all objects in a state.
@@ -1225,7 +1225,7 @@ eolian_state_class_by_name_get(const Eolian_State *state, const char *class_name
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_state_class_by_file_get(const Eolian_State *state, const char *file_name);
+EOLIAN_API const Eolian_Class *eolian_state_class_by_file_get(const Eolian_State *state, const char *file_name);
 
 /*
  * @brief A helper function to get all classes in a state.
@@ -1277,7 +1277,7 @@ eolian_state_error_by_name_get(const Eolian_State *state, const char *name)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_constants_by_file_get(const Eolian_State *state, const char *file_name);
+EOLIAN_API Eina_Iterator *eolian_state_constants_by_file_get(const Eolian_State *state, const char *file_name);
 
 /*
  * @brief Get an iterator to all error declarations contained in a file.
@@ -1290,7 +1290,7 @@ EAPI Eina_Iterator *eolian_state_constants_by_file_get(const Eolian_State *state
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_errors_by_file_get(const Eolian_State *state, const char *file_name);
+EOLIAN_API Eina_Iterator *eolian_state_errors_by_file_get(const Eolian_State *state, const char *file_name);
 
 /*
  * @brief A helper function to get all constants in a state.
@@ -1367,7 +1367,7 @@ eolian_state_enum_by_name_get(const Eolian_State *state, const char *name)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_aliases_by_file_get(const Eolian_State *state, const char *file_name);
+EOLIAN_API Eina_Iterator *eolian_state_aliases_by_file_get(const Eolian_State *state, const char *file_name);
 
 /*
  * @brief Get an iterator to all named structs contained in a file.
@@ -1379,7 +1379,7 @@ EAPI Eina_Iterator *eolian_state_aliases_by_file_get(const Eolian_State *state, 
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_structs_by_file_get(const Eolian_State *state, const char *file_name);
+EOLIAN_API Eina_Iterator *eolian_state_structs_by_file_get(const Eolian_State *state, const char *file_name);
 
 /*
  * @brief Get an iterator to all enums contained in a file.
@@ -1391,7 +1391,7 @@ EAPI Eina_Iterator *eolian_state_structs_by_file_get(const Eolian_State *state, 
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_state_enums_by_file_get(const Eolian_State *state, const char *file_name);
+EOLIAN_API Eina_Iterator *eolian_state_enums_by_file_get(const Eolian_State *state, const char *file_name);
 
 /*
  * @brief A helper function to get all aliases in a state.
@@ -1492,7 +1492,7 @@ eolian_class_namespaces_get(const Eolian_Class *klass)
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Class_Type eolian_class_type_get(const Eolian_Class *klass);
+EOLIAN_API Eolian_Class_Type eolian_class_type_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns the documentation of a class.
@@ -1502,7 +1502,7 @@ EAPI Eolian_Class_Type eolian_class_type_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_class_documentation_get(const Eolian_Class *klass);
+EOLIAN_API const Eolian_Documentation *eolian_class_documentation_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns the C function prefix of a class
@@ -1512,7 +1512,7 @@ EAPI const Eolian_Documentation *eolian_class_documentation_get(const Eolian_Cla
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_class_c_prefix_get(const Eolian_Class *klass);
+EOLIAN_API const char *eolian_class_c_prefix_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns the C event prefix of a class
@@ -1522,7 +1522,7 @@ EAPI const char *eolian_class_c_prefix_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_class_event_c_prefix_get(const Eolian_Class *klass);
+EOLIAN_API const char *eolian_class_event_c_prefix_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns the data type of a class
@@ -1532,7 +1532,7 @@ EAPI const char *eolian_class_event_c_prefix_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_class_data_type_get(const Eolian_Class *klass);
+EOLIAN_API const char *eolian_class_data_type_get(const Eolian_Class *klass);
 
 /*
  * @brief Get the parent class of a class
@@ -1548,7 +1548,7 @@ EAPI const char *eolian_class_data_type_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_class_parent_get(const Eolian_Class *klass);
+EOLIAN_API const Eolian_Class *eolian_class_parent_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns an iterator to the required classes of this mixin
@@ -1561,7 +1561,7 @@ EAPI const Eolian_Class *eolian_class_parent_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_class_requires_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Iterator *eolian_class_requires_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns an iterator to the class extensions
@@ -1577,7 +1577,7 @@ EAPI Eina_Iterator *eolian_class_requires_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_class_extensions_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Iterator *eolian_class_extensions_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns an iterator to functions of a class.
@@ -1590,7 +1590,7 @@ EAPI Eina_Iterator *eolian_class_extensions_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_class_functions_get(const Eolian_Class *klass, Eolian_Function_Type func_type);
+EOLIAN_API Eina_Iterator *eolian_class_functions_get(const Eolian_Class *klass, Eolian_Function_Type func_type);
 
 /*
  * @brief Returns the type of a function
@@ -1600,7 +1600,7 @@ EAPI Eina_Iterator *eolian_class_functions_get(const Eolian_Class *klass, Eolian
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Function_Type eolian_function_type_get(const Eolian_Function *function_id);
+EOLIAN_API Eolian_Function_Type eolian_function_type_get(const Eolian_Function *function_id);
 
 /*
  * @brief Returns the scope of a function
@@ -1613,7 +1613,7 @@ EAPI Eolian_Function_Type eolian_function_type_get(const Eolian_Function *functi
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Object_Scope eolian_function_scope_get(const Eolian_Function *function_id, Eolian_Function_Type ftype);
+EOLIAN_API Eolian_Object_Scope eolian_function_scope_get(const Eolian_Function *function_id, Eolian_Function_Type ftype);
 
 /*
  * @brief A helper function to get the name of a function.
@@ -1646,7 +1646,7 @@ eolian_function_name_get(const Eolian_Function *fid)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_function_full_c_name_get(const Eolian_Function *function_id, Eolian_Function_Type ftype);
+EOLIAN_API Eina_Stringshare *eolian_function_full_c_name_get(const Eolian_Function *function_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Get a function in a class by its name and type
@@ -1662,7 +1662,7 @@ EAPI Eina_Stringshare *eolian_function_full_c_name_get(const Eolian_Function *fu
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Function *eolian_class_function_by_name_get(const Eolian_Class *klass, const char *func_name, Eolian_Function_Type f_type);
+EOLIAN_API const Eolian_Function *eolian_class_function_by_name_get(const Eolian_Class *klass, const char *func_name, Eolian_Function_Type f_type);
 
 /*
  * @brief Returns the implement for a function.
@@ -1672,7 +1672,7 @@ EAPI const Eolian_Function *eolian_class_function_by_name_get(const Eolian_Class
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Implement *eolian_function_implement_get(const Eolian_Function *function_id);
+EOLIAN_API const Eolian_Implement *eolian_function_implement_get(const Eolian_Function *function_id);
 
 /*
  * @brief Get whether a function is a static method/property.
@@ -1682,7 +1682,7 @@ EAPI const Eolian_Implement *eolian_function_implement_get(const Eolian_Function
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_function_is_static(const Eolian_Function *function_id);
+EOLIAN_API Eina_Bool eolian_function_is_static(const Eolian_Function *function_id);
 
 /*
  * @brief Get whether a function is beta.
@@ -1706,7 +1706,7 @@ eolian_function_is_beta(const Eolian_Function *function_id)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_function_is_constructor(const Eolian_Function *function_id, const Eolian_Class *klass);
+EOLIAN_API Eina_Bool eolian_function_is_constructor(const Eolian_Function *function_id, const Eolian_Class *klass);
 
 /*
  * @brief Returns an iterator to the parameter handles for a method/ctor/dtor.
@@ -1716,7 +1716,7 @@ EAPI Eina_Bool eolian_function_is_constructor(const Eolian_Function *function_id
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_function_parameters_get(const Eolian_Function *function_id);
+EOLIAN_API Eina_Iterator *eolian_function_parameters_get(const Eolian_Function *function_id);
 
 /*
  * @brief Returns an iterator to the keys params of a given function.
@@ -1729,7 +1729,7 @@ EAPI Eina_Iterator *eolian_function_parameters_get(const Eolian_Function *functi
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_property_keys_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
+EOLIAN_API Eina_Iterator *eolian_property_keys_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Returns an iterator to the values params of a given function.
@@ -1742,7 +1742,7 @@ EAPI Eina_Iterator *eolian_property_keys_get(const Eolian_Function *foo_id, Eoli
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_property_values_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
+EOLIAN_API Eina_Iterator *eolian_property_values_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Get direction of a parameter
@@ -1752,7 +1752,7 @@ EAPI Eina_Iterator *eolian_property_values_get(const Eolian_Function *foo_id, Eo
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Parameter_Direction eolian_parameter_direction_get(const Eolian_Function_Parameter *param);
+EOLIAN_API Eolian_Parameter_Direction eolian_parameter_direction_get(const Eolian_Function_Parameter *param);
 
 /*
  * @brief Get type of a parameter
@@ -1762,7 +1762,7 @@ EAPI Eolian_Parameter_Direction eolian_parameter_direction_get(const Eolian_Func
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_parameter_type_get(const Eolian_Function_Parameter *param);
+EOLIAN_API const Eolian_Type *eolian_parameter_type_get(const Eolian_Function_Parameter *param);
 
 /*
  * @brief Get the default value of a parameter
@@ -1772,7 +1772,7 @@ EAPI const Eolian_Type *eolian_parameter_type_get(const Eolian_Function_Paramete
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Expression *eolian_parameter_default_value_get(const Eolian_Function_Parameter *param);
+EOLIAN_API const Eolian_Expression *eolian_parameter_default_value_get(const Eolian_Function_Parameter *param);
 
 /*
  * @brief A helper function to get the name of a function parameter.
@@ -1795,7 +1795,7 @@ eolian_parameter_name_get(const Eolian_Function_Parameter *param)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_parameter_documentation_get(const Eolian_Function_Parameter *param);
+EOLIAN_API const Eolian_Documentation *eolian_parameter_documentation_get(const Eolian_Function_Parameter *param);
 
 /*
  * @brief Indicates if a parameter is optional.
@@ -1805,7 +1805,7 @@ EAPI const Eolian_Documentation *eolian_parameter_documentation_get(const Eolian
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_parameter_is_optional(const Eolian_Function_Parameter *param_desc);
+EOLIAN_API Eina_Bool eolian_parameter_is_optional(const Eolian_Function_Parameter *param_desc);
 
 /*
  * @brief Get whether a parameter is by reference.
@@ -1815,7 +1815,7 @@ EAPI Eina_Bool eolian_parameter_is_optional(const Eolian_Function_Parameter *par
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_parameter_is_by_ref(const Eolian_Function_Parameter *param_desc);
+EOLIAN_API Eina_Bool eolian_parameter_is_by_ref(const Eolian_Function_Parameter *param_desc);
 
 /*
  * @brief Get whether a parameter is moved into the callee.
@@ -1825,7 +1825,7 @@ EAPI Eina_Bool eolian_parameter_is_by_ref(const Eolian_Function_Parameter *param
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_parameter_is_move(const Eolian_Function_Parameter *param_desc);
+EOLIAN_API Eina_Bool eolian_parameter_is_move(const Eolian_Function_Parameter *param_desc);
 
 /*
  * @brief Get the full C type name of the given parameter.
@@ -1842,7 +1842,7 @@ EAPI Eina_Bool eolian_parameter_is_move(const Eolian_Function_Parameter *param_d
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_parameter_c_type_get(const Eolian_Function_Parameter *param_desc, Eina_Bool as_return);
+EOLIAN_API Eina_Stringshare *eolian_parameter_c_type_get(const Eolian_Function_Parameter *param_desc, Eina_Bool as_return);
 
 /*
  * @brief Get the return type of a function.
@@ -1858,7 +1858,7 @@ EAPI Eina_Stringshare *eolian_parameter_c_type_get(const Eolian_Function_Paramet
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_function_return_type_get(const Eolian_Function *function_id, Eolian_Function_Type ftype);
+EOLIAN_API const Eolian_Type *eolian_function_return_type_get(const Eolian_Function *function_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Get the return default value of a function.
@@ -1875,7 +1875,7 @@ EAPI const Eolian_Type *eolian_function_return_type_get(const Eolian_Function *f
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Expression *
+EOLIAN_API const Eolian_Expression *
 eolian_function_return_default_value_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
 
 /*
@@ -1892,7 +1892,7 @@ eolian_function_return_default_value_get(const Eolian_Function *foo_id, Eolian_F
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_function_return_documentation_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
+EOLIAN_API const Eolian_Documentation *eolian_function_return_documentation_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Indicates if a function return should allow being unused.
@@ -1908,7 +1908,7 @@ EAPI const Eolian_Documentation *eolian_function_return_documentation_get(const 
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_function_return_allow_unused(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
+EOLIAN_API Eina_Bool eolian_function_return_allow_unused(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Get whether a parameter is by reference.
@@ -1924,7 +1924,7 @@ EAPI Eina_Bool eolian_function_return_allow_unused(const Eolian_Function *foo_id
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_function_return_is_by_ref(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
+EOLIAN_API Eina_Bool eolian_function_return_is_by_ref(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Get whether a parameter is moved into the callee.
@@ -1940,7 +1940,7 @@ EAPI Eina_Bool eolian_function_return_is_by_ref(const Eolian_Function *foo_id, E
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_function_return_is_move(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
+EOLIAN_API Eina_Bool eolian_function_return_is_move(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Get the full C type name of the return value.
@@ -1955,7 +1955,7 @@ EAPI Eina_Bool eolian_function_return_is_move(const Eolian_Function *foo_id, Eol
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_function_return_c_type_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
+EOLIAN_API Eina_Stringshare *eolian_function_return_c_type_get(const Eolian_Function *foo_id, Eolian_Function_Type ftype);
 
 /*
  * @brief Indicates if a function object is const.
@@ -1965,7 +1965,7 @@ EAPI Eina_Stringshare *eolian_function_return_c_type_get(const Eolian_Function *
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_function_object_is_const(const Eolian_Function *function_id);
+EOLIAN_API Eina_Bool eolian_function_object_is_const(const Eolian_Function *function_id);
 
 /*
  * @brief Return the Eolian class associated to the function.
@@ -1975,7 +1975,7 @@ EAPI Eina_Bool eolian_function_object_is_const(const Eolian_Function *function_i
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_function_class_get(const Eolian_Function *function_id);
+EOLIAN_API const Eolian_Class *eolian_function_class_get(const Eolian_Function *function_id);
 
 /*
  * @brief A helper function to get the full name of an implement.
@@ -2004,7 +2004,7 @@ eolian_implement_name_get(const Eolian_Implement *impl)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_implement_class_get(const Eolian_Implement *impl);
+EOLIAN_API const Eolian_Class *eolian_implement_class_get(const Eolian_Implement *impl);
 
 /*
  * @brief Get the implementing class of an overriding function (implement).
@@ -2020,7 +2020,7 @@ EAPI const Eolian_Class *eolian_implement_class_get(const Eolian_Implement *impl
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_implement_implementing_class_get(const Eolian_Implement *impl);
+EOLIAN_API const Eolian_Class *eolian_implement_implementing_class_get(const Eolian_Implement *impl);
 
 /*
  * @brief Get the function of an implement.
@@ -2031,7 +2031,7 @@ EAPI const Eolian_Class *eolian_implement_implementing_class_get(const Eolian_Im
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Function *eolian_implement_function_get(const Eolian_Implement *impl, Eolian_Function_Type *func_type);
+EOLIAN_API const Eolian_Function *eolian_implement_function_get(const Eolian_Implement *impl, Eolian_Function_Type *func_type);
 
 /*
  * @brief Returns a documentation for an implement.
@@ -2044,7 +2044,7 @@ EAPI const Eolian_Function *eolian_implement_function_get(const Eolian_Implement
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_implement_documentation_get(const Eolian_Implement *impl, Eolian_Function_Type f_type);
+EOLIAN_API const Eolian_Documentation *eolian_implement_documentation_get(const Eolian_Implement *impl, Eolian_Function_Type f_type);
 
 /*
  * @brief Get whether an implement is tagged with @auto.
@@ -2057,7 +2057,7 @@ EAPI const Eolian_Documentation *eolian_implement_documentation_get(const Eolian
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_implement_is_auto(const Eolian_Implement *impl, Eolian_Function_Type f_type);
+EOLIAN_API Eina_Bool eolian_implement_is_auto(const Eolian_Implement *impl, Eolian_Function_Type f_type);
 
 /*
  * @brief Get whether an implement is tagged with @empty.
@@ -2070,7 +2070,7 @@ EAPI Eina_Bool eolian_implement_is_auto(const Eolian_Implement *impl, Eolian_Fun
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_implement_is_empty(const Eolian_Implement *impl, Eolian_Function_Type f_type);
+EOLIAN_API Eina_Bool eolian_implement_is_empty(const Eolian_Implement *impl, Eolian_Function_Type f_type);
 
 /*
  * @brief Get whether an implement is pure virtual.
@@ -2083,7 +2083,7 @@ EAPI Eina_Bool eolian_implement_is_empty(const Eolian_Implement *impl, Eolian_Fu
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_implement_is_pure_virtual(const Eolian_Implement *impl, Eolian_Function_Type f_type);
+EOLIAN_API Eina_Bool eolian_implement_is_pure_virtual(const Eolian_Implement *impl, Eolian_Function_Type f_type);
 
 /*
  * @brief Get whether an implement references a property getter.
@@ -2093,7 +2093,7 @@ EAPI Eina_Bool eolian_implement_is_pure_virtual(const Eolian_Implement *impl, Eo
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_implement_is_prop_get(const Eolian_Implement *impl);
+EOLIAN_API Eina_Bool eolian_implement_is_prop_get(const Eolian_Implement *impl);
 
 /*
  * @brief Get whether an implement references a property setter.
@@ -2103,7 +2103,7 @@ EAPI Eina_Bool eolian_implement_is_prop_get(const Eolian_Implement *impl);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_implement_is_prop_set(const Eolian_Implement *impl);
+EOLIAN_API Eina_Bool eolian_implement_is_prop_set(const Eolian_Implement *impl);
 
 /*
  * @brief Get an iterator to implements of a class.
@@ -2118,7 +2118,7 @@ EAPI Eina_Bool eolian_implement_is_prop_set(const Eolian_Implement *impl);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_class_implements_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Iterator *eolian_class_implements_get(const Eolian_Class *klass);
 
 /*
  * @brief A helper function to get the full name of a constructor.
@@ -2141,7 +2141,7 @@ eolian_constructor_name_get(const Eolian_Constructor *ctor)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_constructor_class_get(const Eolian_Constructor *ctor);
+EOLIAN_API const Eolian_Class *eolian_constructor_class_get(const Eolian_Constructor *ctor);
 
 /*
  * @brief Get the function of a constructing function.
@@ -2151,7 +2151,7 @@ EAPI const Eolian_Class *eolian_constructor_class_get(const Eolian_Constructor *
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Function *eolian_constructor_function_get(const Eolian_Constructor *ctor);
+EOLIAN_API const Eolian_Function *eolian_constructor_function_get(const Eolian_Constructor *ctor);
 
 /*
  * @brief Checks if a constructor is tagged optional.
@@ -2161,7 +2161,7 @@ EAPI const Eolian_Function *eolian_constructor_function_get(const Eolian_Constru
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_constructor_is_optional(const Eolian_Constructor *ctor);
+EOLIAN_API Eina_Bool eolian_constructor_is_optional(const Eolian_Constructor *ctor);
 
 /*
  * @brief Get an iterator to the constructing functions defined in a class.
@@ -2171,7 +2171,7 @@ EAPI Eina_Bool eolian_constructor_is_optional(const Eolian_Constructor *ctor);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_class_constructors_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Iterator *eolian_class_constructors_get(const Eolian_Class *klass);
 
 /*
  * @brief Get an iterator to the events defined in a class.
@@ -2181,7 +2181,7 @@ EAPI Eina_Iterator *eolian_class_constructors_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_class_events_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Iterator *eolian_class_events_get(const Eolian_Class *klass);
 
 /*
  * @brief A helper function to get the name of an event.
@@ -2204,7 +2204,7 @@ eolian_event_name_get(const Eolian_Event *event)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_event_type_get(const Eolian_Event *event);
+EOLIAN_API const Eolian_Type *eolian_event_type_get(const Eolian_Event *event);
 
 /*
  * @brief Get the class of an event.
@@ -2214,7 +2214,7 @@ EAPI const Eolian_Type *eolian_event_type_get(const Eolian_Event *event);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_event_class_get(const Eolian_Event *event);
+EOLIAN_API const Eolian_Class *eolian_event_class_get(const Eolian_Event *event);
 
 /*
  * @brief Get the documentation of an event.
@@ -2224,7 +2224,7 @@ EAPI const Eolian_Class *eolian_event_class_get(const Eolian_Event *event);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_event_documentation_get(const Eolian_Event *event);
+EOLIAN_API const Eolian_Documentation *eolian_event_documentation_get(const Eolian_Event *event);
 
 /*
  * @brief Returns the scope of an event
@@ -2234,7 +2234,7 @@ EAPI const Eolian_Documentation *eolian_event_documentation_get(const Eolian_Eve
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Object_Scope eolian_event_scope_get(const Eolian_Event *event);
+EOLIAN_API Eolian_Object_Scope eolian_event_scope_get(const Eolian_Event *event);
 
 /*
  * @brief Get whether an event is beta.
@@ -2257,7 +2257,7 @@ eolian_event_is_beta(const Eolian_Event *event)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_event_is_hot(const Eolian_Event *event);
+EOLIAN_API Eina_Bool eolian_event_is_hot(const Eolian_Event *event);
 
 /*
  * @brief Get whether an event is a restartable event.
@@ -2271,7 +2271,7 @@ EAPI Eina_Bool eolian_event_is_hot(const Eolian_Event *event);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_event_is_restart(const Eolian_Event *event);
+EOLIAN_API Eina_Bool eolian_event_is_restart(const Eolian_Event *event);
 
 /*
  * @brief Get an iterator to the parts defined in a class.
@@ -2281,7 +2281,7 @@ EAPI Eina_Bool eolian_event_is_restart(const Eolian_Event *event);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_class_parts_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Iterator *eolian_class_parts_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns the C macro name used to refer to an event
@@ -2293,7 +2293,7 @@ EAPI Eina_Iterator *eolian_class_parts_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_event_c_macro_get(const Eolian_Event *event);
+EOLIAN_API Eina_Stringshare *eolian_event_c_macro_get(const Eolian_Event *event);
 
 /*
  * @brief A helper function to get the name of a part.
@@ -2316,7 +2316,7 @@ eolian_part_name_get(const Eolian_Part *part)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_part_class_get(const Eolian_Part *part);
+EOLIAN_API const Eolian_Class *eolian_part_class_get(const Eolian_Part *part);
 
 /*
  * @brief Get the documentation of an part.
@@ -2326,7 +2326,7 @@ EAPI const Eolian_Class *eolian_part_class_get(const Eolian_Part *part);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_part_documentation_get(const Eolian_Part *part);
+EOLIAN_API const Eolian_Documentation *eolian_part_documentation_get(const Eolian_Part *part);
 
 /*
  * @brief Get whether a part is beta.
@@ -2350,7 +2350,7 @@ eolian_part_is_beta(const Eolian_Part *part)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Event *eolian_class_event_by_name_get(const Eolian_Class *klass, const char *event_name);
+EOLIAN_API const Eolian_Event *eolian_class_event_by_name_get(const Eolian_Class *klass, const char *event_name);
 
 /*
  * @brief Indicates if the class constructor has to invoke
@@ -2361,7 +2361,7 @@ EAPI const Eolian_Event *eolian_class_event_by_name_get(const Eolian_Class *klas
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_class_ctor_enable_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Bool eolian_class_ctor_enable_get(const Eolian_Class *klass);
 
 /*
  * @brief Indicates if the class destructor has to invoke
@@ -2372,7 +2372,7 @@ EAPI Eina_Bool eolian_class_ctor_enable_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_class_dtor_enable_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Bool eolian_class_dtor_enable_get(const Eolian_Class *klass);
 
 /*
  * @brief Returns the name of the C function used to get the Efl_Class pointer.
@@ -2386,7 +2386,7 @@ EAPI Eina_Bool eolian_class_dtor_enable_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_class_c_get_function_name_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Stringshare *eolian_class_c_get_function_name_get(const Eolian_Class *klass);
 
 /*
  * @brief Get the C macro of the class.
@@ -2402,7 +2402,7 @@ EAPI Eina_Stringshare *eolian_class_c_get_function_name_get(const Eolian_Class *
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_class_c_macro_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Stringshare *eolian_class_c_macro_get(const Eolian_Class *klass);
 
 /*
  * @brief Get the C data type of the class.
@@ -2420,7 +2420,7 @@ EAPI Eina_Stringshare *eolian_class_c_macro_get(const Eolian_Class *klass);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_class_c_data_type_get(const Eolian_Class *klass);
+EOLIAN_API Eina_Stringshare *eolian_class_c_data_type_get(const Eolian_Class *klass);
 
 /*
  * @brief Get whether a class is beta.
@@ -2443,7 +2443,7 @@ eolian_class_is_beta(const Eolian_Class *klass)
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Typedecl_Type eolian_typedecl_type_get(const Eolian_Typedecl *tp);
+EOLIAN_API Eolian_Typedecl_Type eolian_typedecl_type_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get an iterator to all fields of a struct type.
@@ -2453,7 +2453,7 @@ EAPI Eolian_Typedecl_Type eolian_typedecl_type_get(const Eolian_Typedecl *tp);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_typedecl_struct_fields_get(const Eolian_Typedecl *tp);
+EOLIAN_API Eina_Iterator *eolian_typedecl_struct_fields_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get a field of a struct type.
@@ -2465,7 +2465,7 @@ EAPI Eina_Iterator *eolian_typedecl_struct_fields_get(const Eolian_Typedecl *tp)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Struct_Type_Field *eolian_typedecl_struct_field_get(const Eolian_Typedecl *tp, const char *field);
+EOLIAN_API const Eolian_Struct_Type_Field *eolian_typedecl_struct_field_get(const Eolian_Typedecl *tp, const char *field);
 
 /*
  * @brief A helper function to get the name of a struct field.
@@ -2488,7 +2488,7 @@ eolian_typedecl_struct_field_name_get(const Eolian_Struct_Type_Field *field)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_typedecl_struct_field_documentation_get(const Eolian_Struct_Type_Field *fl);
+EOLIAN_API const Eolian_Documentation *eolian_typedecl_struct_field_documentation_get(const Eolian_Struct_Type_Field *fl);
 
 /*
  * @brief Get the type of a field of a struct type.
@@ -2498,7 +2498,7 @@ EAPI const Eolian_Documentation *eolian_typedecl_struct_field_documentation_get(
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_typedecl_struct_field_type_get(const Eolian_Struct_Type_Field *fl);
+EOLIAN_API const Eolian_Type *eolian_typedecl_struct_field_type_get(const Eolian_Struct_Type_Field *fl);
 
 /*
  * @brief Get whether a struct field is by reference.
@@ -2508,7 +2508,7 @@ EAPI const Eolian_Type *eolian_typedecl_struct_field_type_get(const Eolian_Struc
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_typedecl_struct_field_is_by_ref(const Eolian_Struct_Type_Field *fl);
+EOLIAN_API Eina_Bool eolian_typedecl_struct_field_is_by_ref(const Eolian_Struct_Type_Field *fl);
 
 /*
  * @brief Get whether a struct field is moved with the struct.
@@ -2518,7 +2518,7 @@ EAPI Eina_Bool eolian_typedecl_struct_field_is_by_ref(const Eolian_Struct_Type_F
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_typedecl_struct_field_is_move(const Eolian_Struct_Type_Field *fl);
+EOLIAN_API Eina_Bool eolian_typedecl_struct_field_is_move(const Eolian_Struct_Type_Field *fl);
 
 /*
  * @brief Get the full C type name of the struct field.
@@ -2532,7 +2532,7 @@ EAPI Eina_Bool eolian_typedecl_struct_field_is_move(const Eolian_Struct_Type_Fie
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_typedecl_struct_field_c_type_get(const Eolian_Struct_Type_Field *fl);
+EOLIAN_API Eina_Stringshare *eolian_typedecl_struct_field_c_type_get(const Eolian_Struct_Type_Field *fl);
 
 /*
  * @brief Get an iterator to all fields of an enum type.
@@ -2542,7 +2542,7 @@ EAPI Eina_Stringshare *eolian_typedecl_struct_field_c_type_get(const Eolian_Stru
  *
  * @ingroup Eolian
  */
-EAPI Eina_Iterator *eolian_typedecl_enum_fields_get(const Eolian_Typedecl *tp);
+EOLIAN_API Eina_Iterator *eolian_typedecl_enum_fields_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get a field of an enum type.
@@ -2557,7 +2557,7 @@ EAPI Eina_Iterator *eolian_typedecl_enum_fields_get(const Eolian_Typedecl *tp);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Enum_Type_Field *eolian_typedecl_enum_field_get(const Eolian_Typedecl *tp, const char *field);
+EOLIAN_API const Eolian_Enum_Type_Field *eolian_typedecl_enum_field_get(const Eolian_Typedecl *tp, const char *field);
 
 /*
  * @brief A helper function to get the name of an enum field.
@@ -2582,7 +2582,7 @@ eolian_typedecl_enum_field_name_get(const Eolian_Enum_Type_Field *field)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_typedecl_enum_field_c_constant_get(const Eolian_Enum_Type_Field *fl);
+EOLIAN_API Eina_Stringshare *eolian_typedecl_enum_field_c_constant_get(const Eolian_Enum_Type_Field *fl);
 
 /*
  * @brief Get the documentation of a field of an enum type.
@@ -2592,7 +2592,7 @@ EAPI Eina_Stringshare *eolian_typedecl_enum_field_c_constant_get(const Eolian_En
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_typedecl_enum_field_documentation_get(const Eolian_Enum_Type_Field *fl);
+EOLIAN_API const Eolian_Documentation *eolian_typedecl_enum_field_documentation_get(const Eolian_Enum_Type_Field *fl);
 
 /*
  * @brief Get the value of a field of an enum type.
@@ -2607,7 +2607,7 @@ EAPI const Eolian_Documentation *eolian_typedecl_enum_field_documentation_get(co
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Expression *eolian_typedecl_enum_field_value_get(const Eolian_Enum_Type_Field *fl, Eina_Bool force);
+EOLIAN_API const Eolian_Expression *eolian_typedecl_enum_field_value_get(const Eolian_Enum_Type_Field *fl, Eina_Bool force);
 
 /*
  * @brief Get the documentation of a struct/alias type.
@@ -2618,7 +2618,7 @@ EAPI const Eolian_Expression *eolian_typedecl_enum_field_value_get(const Eolian_
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_typedecl_documentation_get(const Eolian_Typedecl *tp);
+EOLIAN_API const Eolian_Documentation *eolian_typedecl_documentation_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get the base type of an alias declaration.
@@ -2628,7 +2628,7 @@ EAPI const Eolian_Documentation *eolian_typedecl_documentation_get(const Eolian_
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_typedecl_base_type_get(const Eolian_Typedecl *tp);
+EOLIAN_API const Eolian_Type *eolian_typedecl_base_type_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get the lowest base type of an alias stack.
@@ -2641,7 +2641,7 @@ EAPI const Eolian_Type *eolian_typedecl_base_type_get(const Eolian_Typedecl *tp)
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_typedecl_aliased_base_get(const Eolian_Typedecl *tp);
+EOLIAN_API const Eolian_Type *eolian_typedecl_aliased_base_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Check if a struct or alias type declaration is extern.
@@ -2651,7 +2651,7 @@ EAPI const Eolian_Type *eolian_typedecl_aliased_base_get(const Eolian_Typedecl *
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_typedecl_is_extern(const Eolian_Typedecl *tp);
+EOLIAN_API Eina_Bool eolian_typedecl_is_extern(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get whether a typedecl is beta.
@@ -2678,7 +2678,7 @@ eolian_typedecl_is_beta(const Eolian_Typedecl *tp)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_typedecl_c_type_get(const Eolian_Typedecl *tp);
+EOLIAN_API Eina_Stringshare *eolian_typedecl_c_type_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief A helper function to get the full name of a typedecl.
@@ -2740,7 +2740,7 @@ eolian_typedecl_namespaces_get(const Eolian_Typedecl *tp)
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_typedecl_free_func_get(const Eolian_Typedecl *tp);
+EOLIAN_API const char *eolian_typedecl_free_func_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get the function object for this function pointer type.
@@ -2750,7 +2750,7 @@ EAPI const char *eolian_typedecl_free_func_get(const Eolian_Typedecl *tp);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Function *eolian_typedecl_function_pointer_get(const Eolian_Typedecl *tp);
+EOLIAN_API const Eolian_Function *eolian_typedecl_function_pointer_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get the type of a type.
@@ -2760,7 +2760,7 @@ EAPI const Eolian_Function *eolian_typedecl_function_pointer_get(const Eolian_Ty
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Type_Type eolian_type_type_get(const Eolian_Type *tp);
+EOLIAN_API Eolian_Type_Type eolian_type_type_get(const Eolian_Type *tp);
 
 /*
  * @brief Get the builtin type of a type.
@@ -2773,7 +2773,7 @@ EAPI Eolian_Type_Type eolian_type_type_get(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Type_Builtin_Type eolian_type_builtin_type_get(const Eolian_Type *tp);
+EOLIAN_API Eolian_Type_Builtin_Type eolian_type_builtin_type_get(const Eolian_Type *tp);
 
 /*
  * @brief Get the base type of a type.
@@ -2786,7 +2786,7 @@ EAPI Eolian_Type_Builtin_Type eolian_type_builtin_type_get(const Eolian_Type *tp
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_type_base_type_get(const Eolian_Type *tp);
+EOLIAN_API const Eolian_Type *eolian_type_base_type_get(const Eolian_Type *tp);
 
 /*
  * @brief Get the next inner type of a complex type.
@@ -2801,7 +2801,7 @@ EAPI const Eolian_Type *eolian_type_base_type_get(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_type_next_type_get(const Eolian_Type *tp);
+EOLIAN_API const Eolian_Type *eolian_type_next_type_get(const Eolian_Type *tp);
 
 /*
  * @brief Get the declaration a regular type points to.
@@ -2813,7 +2813,7 @@ EAPI const Eolian_Type *eolian_type_next_type_get(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Typedecl *eolian_type_typedecl_get(const Eolian_Type *tp);
+EOLIAN_API const Eolian_Typedecl *eolian_type_typedecl_get(const Eolian_Type *tp);
 
 /*
  * @brief Get the lowest base type of an alias stack.
@@ -2830,7 +2830,7 @@ EAPI const Eolian_Typedecl *eolian_type_typedecl_get(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_type_aliased_base_get(const Eolian_Type *tp);
+EOLIAN_API const Eolian_Type *eolian_type_aliased_base_get(const Eolian_Type *tp);
 
 /*
  * @brief Get the class associated with an EOLIAN_TYPE_CLASS type.
@@ -2840,7 +2840,7 @@ EAPI const Eolian_Type *eolian_type_aliased_base_get(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Class *eolian_type_class_get(const Eolian_Type *tp);
+EOLIAN_API const Eolian_Class *eolian_type_class_get(const Eolian_Type *tp);
 
 /*
  * @brief Get the error declaration associated with an EOLIAN_TYPE_ERROR type.
@@ -2850,7 +2850,7 @@ EAPI const Eolian_Class *eolian_type_class_get(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Error *eolian_type_error_get(const Eolian_Type *tp);
+EOLIAN_API const Eolian_Error *eolian_type_error_get(const Eolian_Type *tp);
 
 /*
  * @brief Get whether the given type is moved with its parent type.
@@ -2865,7 +2865,7 @@ EAPI const Eolian_Error *eolian_type_error_get(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_type_is_move(const Eolian_Type *tp);
+EOLIAN_API Eina_Bool eolian_type_is_move(const Eolian_Type *tp);
 
 /*
  * @brief Get whether the given type is const.
@@ -2875,7 +2875,7 @@ EAPI Eina_Bool eolian_type_is_move(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_type_is_const(const Eolian_Type *tp);
+EOLIAN_API Eina_Bool eolian_type_is_const(const Eolian_Type *tp);
 
 /*
  * @brief Get the full C type name of the given type.
@@ -2889,7 +2889,7 @@ EAPI Eina_Bool eolian_type_is_const(const Eolian_Type *tp);
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_type_c_type_get(const Eolian_Type *tp);
+EOLIAN_API Eina_Stringshare *eolian_type_c_type_get(const Eolian_Type *tp);
 
 /*
  * @brief A helper function to get the full name of a type.
@@ -2955,7 +2955,7 @@ eolian_type_namespaces_get(const Eolian_Type *tp)
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Value eolian_expression_eval(const Eolian_Expression *expr, Eolian_Expression_Mask m);
+EOLIAN_API Eolian_Value eolian_expression_eval(const Eolian_Expression *expr, Eolian_Expression_Mask m);
 
 /*
  * @brief Convert the result of expression evaluation to a literal as in how
@@ -2973,7 +2973,7 @@ EAPI Eolian_Value eolian_expression_eval(const Eolian_Expression *expr, Eolian_E
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_expression_value_to_literal(const Eolian_Value *v);
+EOLIAN_API Eina_Stringshare *eolian_expression_value_to_literal(const Eolian_Value *v);
 
 /*
  * @brief Serialize an expression.
@@ -2989,7 +2989,7 @@ EAPI Eina_Stringshare *eolian_expression_value_to_literal(const Eolian_Value *v)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Stringshare *eolian_expression_serialize(const Eolian_Expression *expr);
+EOLIAN_API Eina_Stringshare *eolian_expression_serialize(const Eolian_Expression *expr);
 
 /*
  * @brief Get the type of an expression.
@@ -2999,7 +2999,7 @@ EAPI Eina_Stringshare *eolian_expression_serialize(const Eolian_Expression *expr
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Expression_Type eolian_expression_type_get(const Eolian_Expression *expr);
+EOLIAN_API Eolian_Expression_Type eolian_expression_type_get(const Eolian_Expression *expr);
 
 /*
  * @brief Get the binary operator of an expression.
@@ -3012,7 +3012,7 @@ EAPI Eolian_Expression_Type eolian_expression_type_get(const Eolian_Expression *
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Binary_Operator eolian_expression_binary_operator_get(const Eolian_Expression *expr);
+EOLIAN_API Eolian_Binary_Operator eolian_expression_binary_operator_get(const Eolian_Expression *expr);
 
 /*
  * @brief Get the lhs (left hand side) of a binary expression.
@@ -3024,7 +3024,7 @@ EAPI Eolian_Binary_Operator eolian_expression_binary_operator_get(const Eolian_E
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Expression *eolian_expression_binary_lhs_get(const Eolian_Expression *expr);
+EOLIAN_API const Eolian_Expression *eolian_expression_binary_lhs_get(const Eolian_Expression *expr);
 
 /*
  * @brief Get the rhs (right hand side) of a binary expression.
@@ -3036,7 +3036,7 @@ EAPI const Eolian_Expression *eolian_expression_binary_lhs_get(const Eolian_Expr
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Expression *eolian_expression_binary_rhs_get(const Eolian_Expression *expr);
+EOLIAN_API const Eolian_Expression *eolian_expression_binary_rhs_get(const Eolian_Expression *expr);
 
 /*
  * @brief Get the unary operator of an expression.
@@ -3049,7 +3049,7 @@ EAPI const Eolian_Expression *eolian_expression_binary_rhs_get(const Eolian_Expr
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Unary_Operator eolian_expression_unary_operator_get(const Eolian_Expression *expr);
+EOLIAN_API Eolian_Unary_Operator eolian_expression_unary_operator_get(const Eolian_Expression *expr);
 
 /*
  * @brief Get the expression of an unary expression.
@@ -3061,7 +3061,7 @@ EAPI Eolian_Unary_Operator eolian_expression_unary_operator_get(const Eolian_Exp
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Expression *eolian_expression_unary_expression_get(const Eolian_Expression *expr);
+EOLIAN_API const Eolian_Expression *eolian_expression_unary_expression_get(const Eolian_Expression *expr);
 
 /*
  * @brief Get the value of an expression.
@@ -3077,7 +3077,7 @@ EAPI const Eolian_Expression *eolian_expression_unary_expression_get(const Eolia
  *
  * @ingroup Eolian
  */
-EAPI Eolian_Value eolian_expression_value_get(const Eolian_Expression *expr);
+EOLIAN_API Eolian_Value eolian_expression_value_get(const Eolian_Expression *expr);
 
 /*
  * @brief Get the documentation of a constant.
@@ -3087,7 +3087,7 @@ EAPI Eolian_Value eolian_expression_value_get(const Eolian_Expression *expr);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_constant_documentation_get(const Eolian_Constant *var);
+EOLIAN_API const Eolian_Documentation *eolian_constant_documentation_get(const Eolian_Constant *var);
 
 /*
  * @brief Get the base type of a constant.
@@ -3097,7 +3097,7 @@ EAPI const Eolian_Documentation *eolian_constant_documentation_get(const Eolian_
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Type *eolian_constant_type_get(const Eolian_Constant *var);
+EOLIAN_API const Eolian_Type *eolian_constant_type_get(const Eolian_Constant *var);
 
 /*
  * @brief Get the value of a constant.
@@ -3107,7 +3107,7 @@ EAPI const Eolian_Type *eolian_constant_type_get(const Eolian_Constant *var);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Expression *eolian_constant_value_get(const Eolian_Constant *var);
+EOLIAN_API const Eolian_Expression *eolian_constant_value_get(const Eolian_Constant *var);
 
 /*
  * @brief A helper function to get the full name of a constant.
@@ -3169,7 +3169,7 @@ eolian_constant_namespaces_get(const Eolian_Constant *tp)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_constant_is_extern(const Eolian_Constant *var);
+EOLIAN_API Eina_Bool eolian_constant_is_extern(const Eolian_Constant *var);
 
 /*
  * @brief Get whether a constant is beta.
@@ -3192,7 +3192,7 @@ eolian_constant_is_beta(const Eolian_Constant *var)
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_error_message_get(const Eolian_Error *err);
+EOLIAN_API const char *eolian_error_message_get(const Eolian_Error *err);
 
 /*
  * @brief Get the documentation of an error declaration.
@@ -3202,7 +3202,7 @@ EAPI const char *eolian_error_message_get(const Eolian_Error *err);
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_error_documentation_get(const Eolian_Error *err);
+EOLIAN_API const Eolian_Documentation *eolian_error_documentation_get(const Eolian_Error *err);
 
 /*
  * @brief A helper function to get the full name of an error declaration.
@@ -3277,7 +3277,7 @@ eolian_error_is_beta(const Eolian_Error *err)
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_error_is_extern(const Eolian_Error *err);
+EOLIAN_API Eina_Bool eolian_error_is_extern(const Eolian_Error *err);
 
 /*
  * @brief Get the summary of the documentation.
@@ -3289,7 +3289,7 @@ EAPI Eina_Bool eolian_error_is_extern(const Eolian_Error *err);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_documentation_summary_get(const Eolian_Documentation *doc);
+EOLIAN_API const char *eolian_documentation_summary_get(const Eolian_Documentation *doc);
 
 /*
  * @brief Get the description of the documentation.
@@ -3302,7 +3302,7 @@ EAPI const char *eolian_documentation_summary_get(const Eolian_Documentation *do
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_documentation_description_get(const Eolian_Documentation *doc);
+EOLIAN_API const char *eolian_documentation_description_get(const Eolian_Documentation *doc);
 
 /*
  * @brief Get the "since" tag of the documentation.
@@ -3315,7 +3315,7 @@ EAPI const char *eolian_documentation_description_get(const Eolian_Documentation
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_documentation_since_get(const Eolian_Documentation *doc);
+EOLIAN_API const char *eolian_documentation_since_get(const Eolian_Documentation *doc);
 
 /*
  * @brief Split a documentation string into individual paragraphs.
@@ -3327,7 +3327,7 @@ EAPI const char *eolian_documentation_since_get(const Eolian_Documentation *doc)
  *
  * @ingroup Eolian
  */
-EAPI Eina_List *eolian_documentation_string_split(const char *doc);
+EOLIAN_API Eina_List *eolian_documentation_string_split(const char *doc);
 
 /*
  * @brief Tokenize a documentation paragraph.
@@ -3352,7 +3352,7 @@ EAPI Eina_List *eolian_documentation_string_split(const char *doc);
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_documentation_tokenize(const char *doc, Eolian_Doc_Token *ret);
+EOLIAN_API const char *eolian_documentation_tokenize(const char *doc, Eolian_Doc_Token *ret);
 
 /*
  * @brief Initialize a documentation token into an empty state.
@@ -3360,7 +3360,7 @@ EAPI const char *eolian_documentation_tokenize(const char *doc, Eolian_Doc_Token
  * @param[in] tok the token
  * @return the token type
  */
-EAPI void eolian_doc_token_init(Eolian_Doc_Token *tok);
+EOLIAN_API void eolian_doc_token_init(Eolian_Doc_Token *tok);
 
 /*
  * @brief Get the type of a documentation token.
@@ -3368,7 +3368,7 @@ EAPI void eolian_doc_token_init(Eolian_Doc_Token *tok);
  * @param[in] tok the token
  * @return the token type
  */
-EAPI Eolian_Doc_Token_Type eolian_doc_token_type_get(const Eolian_Doc_Token *tok);
+EOLIAN_API Eolian_Doc_Token_Type eolian_doc_token_type_get(const Eolian_Doc_Token *tok);
 
 /*
  * @brief Get the text of a documentation token.
@@ -3381,7 +3381,7 @@ EAPI Eolian_Doc_Token_Type eolian_doc_token_type_get(const Eolian_Doc_Token *tok
  * @param[in] tok the token
  * @return the token text
  */
-EAPI char *eolian_doc_token_text_get(const Eolian_Doc_Token *tok);
+EOLIAN_API char *eolian_doc_token_text_get(const Eolian_Doc_Token *tok);
 
 /*
  * @brief Get the thing that a reference token references.
@@ -3401,7 +3401,7 @@ EAPI char *eolian_doc_token_text_get(const Eolian_Doc_Token *tok);
  * @param[out] data2 the secondary data
  * @return the kind of reference this is
  */
-EAPI Eolian_Object_Type eolian_doc_token_ref_resolve(const Eolian_Doc_Token *tok, const Eolian_State *state, const Eolian_Object **data, const Eolian_Object **data2);
+EOLIAN_API Eolian_Object_Type eolian_doc_token_ref_resolve(const Eolian_Doc_Token *tok, const Eolian_State *state, const Eolian_Object **data, const Eolian_Object **data2);
 
 #ifdef EFL_BETA_API_SUPPORT
 
@@ -3414,7 +3414,7 @@ EAPI Eolian_Object_Type eolian_doc_token_ref_resolve(const Eolian_Doc_Token *tok
  *
  * @ingroup Eolian
  */
-EAPI const char *eolian_typedecl_enum_legacy_prefix_get(const Eolian_Typedecl *tp);
+EOLIAN_API const char *eolian_typedecl_enum_legacy_prefix_get(const Eolian_Typedecl *tp);
 
 /*
  * @brief Get whether the given type is a reference.
@@ -3424,7 +3424,7 @@ EAPI const char *eolian_typedecl_enum_legacy_prefix_get(const Eolian_Typedecl *t
  *
  * @ingroup Eolian
  */
-EAPI Eina_Bool eolian_type_is_ptr(const Eolian_Type *tp);
+EOLIAN_API Eina_Bool eolian_type_is_ptr(const Eolian_Type *tp);
 
 #endif /* EFL_BETA_API_SUPPORT */
 
@@ -3436,7 +3436,7 @@ EAPI Eina_Bool eolian_type_is_ptr(const Eolian_Type *tp);
 } // extern "C" {
 #endif
 
-#undef EAPI
-#define EAPI
+#undef EOLIAN_API
+#define EOLIAN_API
 
 #endif

--- a/src/lib/eolian/Eolian_Aux.h
+++ b/src/lib/eolian/Eolian_Aux.h
@@ -3,29 +3,29 @@
 
 #include <Eolian.h>
 
-#ifdef EAPI
-# undef EAPI
+#ifdef EOLIAN_API
+# undef EOLIAN_API
 #endif
 
 #ifdef _WIN32
 # ifdef EFL_BUILD
 #  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
+#   define EOLIAN_API __declspec(dllexport)
 #  else
-#   define EAPI
+#   define EOLIAN_API
 #  endif
 # else
-#  define EAPI __declspec(dllimport)
+#  define EOLIAN_API __declspec(dllimport)
 # endif
 #else
 # ifdef __GNUC__
 #  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
+#   define EOLIAN_API __attribute__ ((visibility("default")))
 #  else
-#   define EAPI
+#   define EOLIAN_API
 #  endif
 # else
-#  define EAPI
+#  define EOLIAN_API
 # endif
 #endif
 
@@ -73,7 +73,7 @@ extern "C" {
  *
  * @ingroup Eolian
  */
-EAPI Eina_Hash *eolian_aux_state_class_children_find(const Eolian_State *state);
+EOLIAN_API Eina_Hash *eolian_aux_state_class_children_find(const Eolian_State *state);
 
 /**
  * @brief Get all APIs that are usable on the class.
@@ -100,7 +100,7 @@ EAPI Eina_Hash *eolian_aux_state_class_children_find(const Eolian_State *state);
  *
  * @ingroup Eolian
  */
-EAPI size_t eolian_aux_class_callables_get(const Eolian_Class *klass, Eina_List **funcs, Eina_List **events, size_t *ownfuncs, size_t *ownevs);
+EOLIAN_API size_t eolian_aux_class_callables_get(const Eolian_Class *klass, Eina_List **funcs, Eina_List **events, size_t *ownfuncs, size_t *ownevs);
 
 /**
  * @brief Get all implementations of a function in a state.
@@ -117,7 +117,7 @@ EAPI size_t eolian_aux_class_callables_get(const Eolian_Class *klass, Eina_List 
  *
  * @ingroup Eolian
  */
-EAPI Eina_List *eolian_aux_function_all_implements_get(const Eolian_Function *func, Eina_Hash *class_children);
+EOLIAN_API Eina_List *eolian_aux_function_all_implements_get(const Eolian_Function *func, Eina_Hash *class_children);
 
 /**
  * @brief Get previous implementation in the inheritance hierarchy.
@@ -131,7 +131,7 @@ EAPI Eina_List *eolian_aux_function_all_implements_get(const Eolian_Function *fu
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Implement *eolian_aux_implement_parent_get(const Eolian_Implement *impl);
+EOLIAN_API const Eolian_Implement *eolian_aux_implement_parent_get(const Eolian_Implement *impl);
 
 /**
  * @brief Get documentation for an implementation.
@@ -147,7 +147,7 @@ EAPI const Eolian_Implement *eolian_aux_implement_parent_get(const Eolian_Implem
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_aux_implement_documentation_get(const Eolian_Implement *impl, Eolian_Function_Type ftype);
+EOLIAN_API const Eolian_Documentation *eolian_aux_implement_documentation_get(const Eolian_Implement *impl, Eolian_Function_Type ftype);
 
 /**
  * @brief Get documentation fallback for an implementation.
@@ -162,7 +162,7 @@ EAPI const Eolian_Documentation *eolian_aux_implement_documentation_get(const Eo
  *
  * @ingroup Eolian
  */
-EAPI const Eolian_Documentation *eolian_aux_implement_documentation_fallback_get(const Eolian_Implement *impl);
+EOLIAN_API const Eolian_Documentation *eolian_aux_implement_documentation_fallback_get(const Eolian_Implement *impl);
 
 #endif
 
@@ -174,7 +174,7 @@ EAPI const Eolian_Documentation *eolian_aux_implement_documentation_fallback_get
 } // extern "C" {
 #endif
 
-#undef EAPI
-#define EAPI
+#undef EOLIAN_API
+#define EOLIAN_API
 
 #endif

--- a/src/lib/eolian/database_class_api.c
+++ b/src/lib/eolian/database_class_api.c
@@ -6,76 +6,76 @@
 #include "eolian_database.h"
 #include "eolian_priv.h"
 
-EAPI Eolian_Class_Type
+EOLIAN_API Eolian_Class_Type
 eolian_class_type_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, EOLIAN_CLASS_UNKNOWN_TYPE);
    return cl->type;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_class_documentation_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return cl->doc;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_class_c_prefix_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return cl->c_prefix;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_class_event_c_prefix_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return cl->ev_prefix;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_class_data_type_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return cl->data_type;
 }
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_class_parent_get(const Eolian_Class *cl)
 {
   EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
   return cl->parent;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_class_requires_get(const Eolian_Class *cl)
 {
    return eina_list_iterator_new(cl->requires);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_class_extensions_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return (cl->extends ? eina_list_iterator_new(cl->extends) : NULL);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_class_implements_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return (cl->implements ? eina_list_iterator_new(cl->implements) : NULL);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_class_constructors_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return (cl->constructors ? eina_list_iterator_new(cl->constructors) : NULL);
 }
 
-EAPI const Eolian_Function *
+EOLIAN_API const Eolian_Function *
 eolian_class_function_by_name_get(const Eolian_Class *cl, const char *func_name, Eolian_Function_Type f_type)
 {
    Eina_List *itr;
@@ -106,7 +106,7 @@ eolian_class_function_by_name_get(const Eolian_Class *cl, const char *func_name,
    return NULL;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_class_functions_get(const Eolian_Class *cl, Eolian_Function_Type foo_type)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
@@ -120,35 +120,35 @@ eolian_class_functions_get(const Eolian_Class *cl, Eolian_Function_Type foo_type
      }
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_class_events_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return (cl->events ? eina_list_iterator_new(cl->events) : NULL);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_class_parts_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
    return (cl->parts ? eina_list_iterator_new(cl->parts) : NULL);
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_class_ctor_enable_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, EINA_FALSE);
    return cl->class_ctor_enable;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_class_dtor_enable_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, EINA_FALSE);
    return cl->class_dtor_enable;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_class_c_get_function_name_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
@@ -176,7 +176,7 @@ eolian_class_c_get_function_name_get(const Eolian_Class *cl)
    return ret;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_class_c_macro_get(const Eolian_Class *cl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(cl, NULL);
@@ -204,7 +204,7 @@ eolian_class_c_macro_get(const Eolian_Class *cl)
    return ret;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_class_c_data_type_get(const Eolian_Class *cl)
 {
    char buf[512];

--- a/src/lib/eolian/database_constructor_api.c
+++ b/src/lib/eolian/database_constructor_api.c
@@ -5,14 +5,14 @@
 #include <Eina.h>
 #include "eolian_database.h"
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_constructor_class_get(const Eolian_Constructor *ctor)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(ctor, NULL);
    return ctor->klass;
 }
 
-EAPI const Eolian_Function *
+EOLIAN_API const Eolian_Function *
 eolian_constructor_function_get(const Eolian_Constructor *ctor)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(ctor, NULL);
@@ -23,7 +23,7 @@ eolian_constructor_function_get(const Eolian_Constructor *ctor)
        ctor->base.name + strlen(klass->base.name) + 1, EOLIAN_UNRESOLVED);
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_constructor_is_optional(const Eolian_Constructor *ctor)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(ctor, EINA_FALSE);

--- a/src/lib/eolian/database_event_api.c
+++ b/src/lib/eolian/database_event_api.c
@@ -5,7 +5,7 @@
 #include <Eina.h>
 #include "eolian_database.h"
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_event_type_get(const Eolian_Event *event)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(event, NULL);
@@ -14,42 +14,42 @@ eolian_event_type_get(const Eolian_Event *event)
    return event->type;
 }
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_event_class_get(const Eolian_Event *event)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(event, NULL);
    return event->klass;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_event_documentation_get(const Eolian_Event *event)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(event, NULL);
    return event->doc;
 }
 
-EAPI Eolian_Object_Scope
+EOLIAN_API Eolian_Object_Scope
 eolian_event_scope_get(const Eolian_Event *event)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(event, EOLIAN_SCOPE_UNKNOWN);
    return event->scope;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_event_is_hot(const Eolian_Event *event)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(event, EINA_FALSE);
    return event->is_hot;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_event_is_restart(const Eolian_Event *event)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(event, EINA_FALSE);
    return event->is_restart;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_event_c_macro_get(const Eolian_Event *event)
 {
     char  buf[512];
@@ -63,7 +63,7 @@ eolian_event_c_macro_get(const Eolian_Event *event)
     return eina_stringshare_add(buf);
 }
 
-EAPI const Eolian_Event *
+EOLIAN_API const Eolian_Event *
 eolian_class_event_by_name_get(const Eolian_Class *klass, const char *event_name)
 {
    Eina_List *itr;

--- a/src/lib/eolian/database_expr_api.c
+++ b/src/lib/eolian/database_expr_api.c
@@ -6,7 +6,7 @@
 
 #include "eolian_database.h"
 
-EAPI Eolian_Value
+EOLIAN_API Eolian_Value
 eolian_expression_eval(const Eolian_Expression *expr, Eolian_Expression_Mask m)
 {
    Eolian_Value err;
@@ -67,7 +67,7 @@ _number_to_str(const Eolian_Value *v, Eina_Strbuf *buf)
      }
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_expression_value_to_literal(const Eolian_Value *val)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(val, NULL);
@@ -192,7 +192,7 @@ _expr_serialize(const Eolian_Expression *expr, Eina_Strbuf *buf, Eina_Bool outer
    return EINA_TRUE;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_expression_serialize(const Eolian_Expression *expr)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(expr, NULL);
@@ -207,14 +207,14 @@ eolian_expression_serialize(const Eolian_Expression *expr)
    return ret;
 }
 
-EAPI Eolian_Expression_Type
+EOLIAN_API Eolian_Expression_Type
 eolian_expression_type_get(const Eolian_Expression *expr)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(expr, EOLIAN_EXPR_UNKNOWN);
    return expr->type;
 }
 
-EAPI Eolian_Binary_Operator
+EOLIAN_API Eolian_Binary_Operator
 eolian_expression_binary_operator_get(const Eolian_Expression *expr)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(expr, EOLIAN_BINOP_INVALID);
@@ -223,7 +223,7 @@ eolian_expression_binary_operator_get(const Eolian_Expression *expr)
    return expr->binop;
 }
 
-EAPI const Eolian_Expression *
+EOLIAN_API const Eolian_Expression *
 eolian_expression_binary_lhs_get(const Eolian_Expression *expr)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(expr, NULL);
@@ -231,7 +231,7 @@ eolian_expression_binary_lhs_get(const Eolian_Expression *expr)
    return expr->lhs;
 }
 
-EAPI const Eolian_Expression *
+EOLIAN_API const Eolian_Expression *
 eolian_expression_binary_rhs_get(const Eolian_Expression *expr)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(expr, NULL);
@@ -239,7 +239,7 @@ eolian_expression_binary_rhs_get(const Eolian_Expression *expr)
    return expr->rhs;
 }
 
-EAPI Eolian_Unary_Operator
+EOLIAN_API Eolian_Unary_Operator
 eolian_expression_unary_operator_get(const Eolian_Expression *expr)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(expr, EOLIAN_UNOP_INVALID);
@@ -248,7 +248,7 @@ eolian_expression_unary_operator_get(const Eolian_Expression *expr)
    return expr->unop;
 }
 
-EAPI const Eolian_Expression *
+EOLIAN_API const Eolian_Expression *
 eolian_expression_unary_expression_get(const Eolian_Expression *expr)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(expr, NULL);
@@ -256,7 +256,7 @@ eolian_expression_unary_expression_get(const Eolian_Expression *expr)
    return expr->expr;
 }
 
-EAPI Eolian_Value
+EOLIAN_API Eolian_Value
 eolian_expression_value_get(const Eolian_Expression *expr)
 {
    Eolian_Value v;

--- a/src/lib/eolian/database_function_api.c
+++ b/src/lib/eolian/database_function_api.c
@@ -5,7 +5,7 @@
 #include <Eina.h>
 #include "eolian_database.h"
 
-EAPI Eolian_Object_Scope
+EOLIAN_API Eolian_Object_Scope
 eolian_function_scope_get(const Eolian_Function *fid, Eolian_Function_Type ftype)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, EOLIAN_SCOPE_UNKNOWN);
@@ -30,7 +30,7 @@ eolian_function_scope_get(const Eolian_Function *fid, Eolian_Function_Type ftype
      }
 }
 
-EAPI Eolian_Function_Type
+EOLIAN_API Eolian_Function_Type
 eolian_function_type_get(const Eolian_Function *fid)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, EOLIAN_UNRESOLVED);
@@ -80,7 +80,7 @@ _get_abbreviated_name(const char *prefix, const char *fname)
    return ret;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_function_full_c_name_get(const Eolian_Function *foo_id,
                                 Eolian_Function_Type ftype)
 {
@@ -109,21 +109,21 @@ eolian_function_full_c_name_get(const Eolian_Function *foo_id,
    return ret;
 }
 
-EAPI const Eolian_Implement *
+EOLIAN_API const Eolian_Implement *
 eolian_function_implement_get(const Eolian_Function *fid)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, NULL);
    return fid->impl;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_function_is_static(const Eolian_Function *fid)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, EINA_FALSE);
    return fid->is_static;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_function_is_constructor(const Eolian_Function *fid, const Eolian_Class *klass)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, EINA_FALSE);
@@ -152,7 +152,7 @@ _get_prop_values(const Eolian_Function *fid, Eolian_Function_Type ftype)
    return l;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_property_keys_get(const Eolian_Function *fid, Eolian_Function_Type ftype)
 {
    Eina_List *l = NULL;
@@ -163,7 +163,7 @@ eolian_property_keys_get(const Eolian_Function *fid, Eolian_Function_Type ftype)
    return (l ? eina_list_iterator_new(l) : NULL);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_property_values_get(const Eolian_Function *fid, Eolian_Function_Type ftype)
 {
    Eina_List *l = NULL;
@@ -174,7 +174,7 @@ eolian_property_values_get(const Eolian_Function *fid, Eolian_Function_Type ftyp
    return (l ? eina_list_iterator_new(l) : NULL);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_function_parameters_get(const Eolian_Function *fid)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, NULL);
@@ -183,7 +183,7 @@ eolian_function_parameters_get(const Eolian_Function *fid)
    return (fid->params ? eina_list_iterator_new(fid->params) : NULL);
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_function_return_type_get(const Eolian_Function *fid, Eolian_Function_Type ftype)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, NULL);
@@ -209,7 +209,7 @@ eolian_function_return_type_get(const Eolian_Function *fid, Eolian_Function_Type
      }
 }
 
-EAPI const Eolian_Expression *
+EOLIAN_API const Eolian_Expression *
 eolian_function_return_default_value_get(const Eolian_Function *fid, Eolian_Function_Type ftype)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, NULL);
@@ -235,7 +235,7 @@ eolian_function_return_default_value_get(const Eolian_Function *fid, Eolian_Func
      }
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_function_return_documentation_get(const Eolian_Function *fid, Eolian_Function_Type ftype)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, NULL);
@@ -261,7 +261,7 @@ eolian_function_return_documentation_get(const Eolian_Function *fid, Eolian_Func
      }
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_function_return_allow_unused(const Eolian_Function *fid,
       Eolian_Function_Type ftype)
 {
@@ -288,7 +288,7 @@ eolian_function_return_allow_unused(const Eolian_Function *fid,
      }
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_function_return_is_by_ref(const Eolian_Function *fid,
       Eolian_Function_Type ftype)
 {
@@ -315,7 +315,7 @@ eolian_function_return_is_by_ref(const Eolian_Function *fid,
      }
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_function_return_is_move(const Eolian_Function *fid,
       Eolian_Function_Type ftype)
 {
@@ -342,7 +342,7 @@ eolian_function_return_is_move(const Eolian_Function *fid,
      }
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_function_return_c_type_get(const Eolian_Function *fid,
                                   Eolian_Function_Type ftype)
 {
@@ -382,14 +382,14 @@ eolian_function_return_c_type_get(const Eolian_Function *fid,
    return ret;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_function_object_is_const(const Eolian_Function *fid)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, EINA_FALSE);
    return fid->obj_is_const;
 }
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_function_class_get(const Eolian_Function *fid)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fid, NULL);

--- a/src/lib/eolian/database_function_parameter_api.c
+++ b/src/lib/eolian/database_function_parameter_api.c
@@ -5,56 +5,56 @@
 #include <Eina.h>
 #include "eolian_database.h"
 
-EAPI Eolian_Parameter_Direction
+EOLIAN_API Eolian_Parameter_Direction
 eolian_parameter_direction_get(const Eolian_Function_Parameter *param)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(param, EOLIAN_PARAMETER_UNKNOWN);
    return param->param_dir;
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_parameter_type_get(const Eolian_Function_Parameter *param)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(param, NULL);
    return param->type;
 }
 
-EAPI const Eolian_Expression *
+EOLIAN_API const Eolian_Expression *
 eolian_parameter_default_value_get(const Eolian_Function_Parameter *param)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(param, NULL);
    return param->value;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_parameter_documentation_get(const Eolian_Function_Parameter *param)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(param, NULL);
    return param->doc;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_parameter_is_optional(const Eolian_Function_Parameter *param)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(param, EINA_FALSE);
    return param->optional;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_parameter_is_move(const Eolian_Function_Parameter *param)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(param, EINA_FALSE);
    return param->move;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_parameter_is_by_ref(const Eolian_Function_Parameter *param)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(param, EINA_FALSE);
    return param->by_ref;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_parameter_c_type_get(const Eolian_Function_Parameter *param_desc,
                             Eina_Bool as_return)
 {

--- a/src/lib/eolian/database_implement_api.c
+++ b/src/lib/eolian/database_implement_api.c
@@ -5,21 +5,21 @@
 #include <Eina.h>
 #include "eolian_database.h"
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_implement_class_get(const Eolian_Implement *impl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(impl, NULL);
    return impl->klass;
 }
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_implement_implementing_class_get(const Eolian_Implement *impl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(impl, NULL);
    return impl->implklass;
 }
 
-EAPI const Eolian_Function *
+EOLIAN_API const Eolian_Function *
 eolian_implement_function_get(const Eolian_Implement *impl,
                               Eolian_Function_Type   *func_type)
 {
@@ -43,7 +43,7 @@ eolian_implement_function_get(const Eolian_Implement *impl,
    return impl->foo_id;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_implement_documentation_get(const Eolian_Implement *impl,
                                    Eolian_Function_Type ftype)
 {
@@ -56,7 +56,7 @@ eolian_implement_documentation_get(const Eolian_Implement *impl,
      }
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_implement_is_auto(const Eolian_Implement *impl, Eolian_Function_Type ftype)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(impl, EINA_FALSE);
@@ -75,7 +75,7 @@ eolian_implement_is_auto(const Eolian_Implement *impl, Eolian_Function_Type ftyp
      }
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_implement_is_empty(const Eolian_Implement *impl, Eolian_Function_Type ftype)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(impl, EINA_FALSE);
@@ -94,7 +94,7 @@ eolian_implement_is_empty(const Eolian_Implement *impl, Eolian_Function_Type fty
      }
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_implement_is_pure_virtual(const Eolian_Implement *impl, Eolian_Function_Type ftype)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(impl, EINA_FALSE);
@@ -113,14 +113,14 @@ eolian_implement_is_pure_virtual(const Eolian_Implement *impl, Eolian_Function_T
      }
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_implement_is_prop_get(const Eolian_Implement *impl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(impl, EINA_FALSE);
    return impl->is_prop_get;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_implement_is_prop_set(const Eolian_Implement *impl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(impl, EINA_FALSE);

--- a/src/lib/eolian/database_part_api.c
+++ b/src/lib/eolian/database_part_api.c
@@ -5,14 +5,14 @@
 #include <Eina.h>
 #include "eolian_database.h"
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_part_class_get(const Eolian_Part *part)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(part, NULL);
    return part->klass;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_part_documentation_get(const Eolian_Part *part)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(part, NULL);

--- a/src/lib/eolian/database_type_api.c
+++ b/src/lib/eolian/database_type_api.c
@@ -6,28 +6,28 @@
 #include "eolian_database.h"
 #include "eo_lexer.h"
 
-EAPI Eolian_Type_Type
+EOLIAN_API Eolian_Type_Type
 eolian_type_type_get(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, EOLIAN_TYPE_UNKNOWN_TYPE);
    return tp->type;
 }
 
-EAPI Eolian_Type_Builtin_Type
+EOLIAN_API Eolian_Type_Builtin_Type
 eolian_type_builtin_type_get(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, EOLIAN_TYPE_BUILTIN_INVALID);
    return tp->btype;
 }
 
-EAPI Eolian_Typedecl_Type
+EOLIAN_API Eolian_Typedecl_Type
 eolian_typedecl_type_get(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, EOLIAN_TYPEDECL_UNKNOWN);
    return tp->type;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_typedecl_struct_fields_get(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
@@ -36,7 +36,7 @@ eolian_typedecl_struct_fields_get(const Eolian_Typedecl *tp)
    return eina_list_iterator_new(tp->field_list);
 }
 
-EAPI const Eolian_Struct_Type_Field *
+EOLIAN_API const Eolian_Struct_Type_Field *
 eolian_typedecl_struct_field_get(const Eolian_Typedecl *tp, const char *field)
 {
    Eolian_Struct_Type_Field *sf = NULL;
@@ -49,35 +49,35 @@ eolian_typedecl_struct_field_get(const Eolian_Typedecl *tp, const char *field)
    return sf;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_typedecl_struct_field_documentation_get(const Eolian_Struct_Type_Field *fl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fl, NULL);
    return fl->doc;
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_typedecl_struct_field_type_get(const Eolian_Struct_Type_Field *fl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fl, NULL);
    return fl->type;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_typedecl_struct_field_is_by_ref(const Eolian_Struct_Type_Field *fl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fl, EINA_FALSE);
    return fl->by_ref;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_typedecl_struct_field_is_move(const Eolian_Struct_Type_Field *fl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fl, EINA_FALSE);
    return fl->move;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_typedecl_struct_field_c_type_get(const Eolian_Struct_Type_Field *fl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fl, NULL);
@@ -88,7 +88,7 @@ eolian_typedecl_struct_field_c_type_get(const Eolian_Struct_Type_Field *fl)
    return ret;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_typedecl_enum_fields_get(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
@@ -97,7 +97,7 @@ eolian_typedecl_enum_fields_get(const Eolian_Typedecl *tp)
    return eina_list_iterator_new(tp->field_list);
 }
 
-EAPI const Eolian_Enum_Type_Field *
+EOLIAN_API const Eolian_Enum_Type_Field *
 eolian_typedecl_enum_field_get(const Eolian_Typedecl *tp, const char *field)
 {
    Eolian_Enum_Type_Field *ef = NULL;
@@ -110,7 +110,7 @@ eolian_typedecl_enum_field_get(const Eolian_Typedecl *tp, const char *field)
    return ef;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_typedecl_enum_field_c_constant_get(const Eolian_Enum_Type_Field *fl)
 {
    Eina_Stringshare *ret;
@@ -133,14 +133,14 @@ eolian_typedecl_enum_field_c_constant_get(const Eolian_Enum_Type_Field *fl)
    return ret;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_typedecl_enum_field_documentation_get(const Eolian_Enum_Type_Field *fl)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fl, NULL);
    return fl->doc;
 }
 
-EAPI const Eolian_Expression *
+EOLIAN_API const Eolian_Expression *
 eolian_typedecl_enum_field_value_get(const Eolian_Enum_Type_Field *fl, Eina_Bool force)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fl, NULL);
@@ -148,7 +148,7 @@ eolian_typedecl_enum_field_value_get(const Eolian_Enum_Type_Field *fl, Eina_Bool
    return fl->value;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_typedecl_enum_legacy_prefix_get(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
@@ -157,28 +157,28 @@ eolian_typedecl_enum_legacy_prefix_get(const Eolian_Typedecl *tp)
    return tp->legacy;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_typedecl_documentation_get(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
    return tp->doc;
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_type_base_type_get(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
    return tp->base_type;
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_type_next_type_get(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
    return tp->next_type;
 }
 
-EAPI const Eolian_Typedecl *
+EOLIAN_API const Eolian_Typedecl *
 eolian_type_typedecl_get(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
@@ -187,14 +187,14 @@ eolian_type_typedecl_get(const Eolian_Type *tp)
    return tp->tdecl;
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_typedecl_base_type_get(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
    return tp->base_type;
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_type_aliased_base_get(const Eolian_Type *tp)
 {
    if (!tp || tp->type != EOLIAN_TYPE_REGULAR || tp->is_ptr)
@@ -205,7 +205,7 @@ eolian_type_aliased_base_get(const Eolian_Type *tp)
    return tp;
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_typedecl_aliased_base_get(const Eolian_Typedecl *tp)
 {
    if (!tp || tp->type != EOLIAN_TYPEDECL_ALIAS)
@@ -213,7 +213,7 @@ eolian_typedecl_aliased_base_get(const Eolian_Typedecl *tp)
    return eolian_type_aliased_base_get(tp->base_type);
 }
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_type_class_get(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
@@ -222,7 +222,7 @@ eolian_type_class_get(const Eolian_Type *tp)
    return tp->klass;
 }
 
-EAPI const Eolian_Error *
+EOLIAN_API const Eolian_Error *
 eolian_type_error_get(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
@@ -231,35 +231,35 @@ eolian_type_error_get(const Eolian_Type *tp)
    return tp->error;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_type_is_move(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, EINA_FALSE);
    return tp->move;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_type_is_const(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, EINA_FALSE);
    return tp->is_const;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_type_is_ptr(const Eolian_Type *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, EINA_FALSE);
    return tp->is_ptr;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_typedecl_is_extern(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, EINA_FALSE);
    return tp->is_extern;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_type_c_type_get(const Eolian_Type *tp)
 {
    Eina_Stringshare *ret;
@@ -272,7 +272,7 @@ eolian_type_c_type_get(const Eolian_Type *tp)
    return ret;
 }
 
-EAPI Eina_Stringshare *
+EOLIAN_API Eina_Stringshare *
 eolian_typedecl_c_type_get(const Eolian_Typedecl *tp)
 {
    Eina_Stringshare *ret;
@@ -285,14 +285,14 @@ eolian_typedecl_c_type_get(const Eolian_Typedecl *tp)
    return ret;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_typedecl_free_func_get(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);
    return tp->freefunc;
 }
 
-EAPI const Eolian_Function *
+EOLIAN_API const Eolian_Function *
 eolian_typedecl_function_pointer_get(const Eolian_Typedecl *tp)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tp, NULL);

--- a/src/lib/eolian/database_var_api.c
+++ b/src/lib/eolian/database_var_api.c
@@ -5,28 +5,28 @@
 #include <Eina.h>
 #include "eolian_database.h"
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_constant_documentation_get(const Eolian_Constant *var)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(var, NULL);
    return var->doc;
 }
 
-EAPI const Eolian_Type *
+EOLIAN_API const Eolian_Type *
 eolian_constant_type_get(const Eolian_Constant *var)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(var, NULL);
    return var->base_type;
 }
 
-EAPI const Eolian_Expression *
+EOLIAN_API const Eolian_Expression *
 eolian_constant_value_get(const Eolian_Constant *var)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(var, NULL);
    return var->value;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_constant_is_extern(const Eolian_Constant *var)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(var, EINA_FALSE);

--- a/src/lib/eolian/eolian.c
+++ b/src/lib/eolian/eolian.c
@@ -9,7 +9,7 @@ static int _eolian_init_counter = 0;
 int _eolian_log_dom = -1;
 Eina_Prefix *_eolian_prefix = NULL;
 
-EAPI int eolian_init(void)
+EOLIAN_API int eolian_init(void)
 {
    const char *log_dom = "eolian";
    if (_eolian_init_counter > 0) return ++_eolian_init_counter;
@@ -40,7 +40,7 @@ EAPI int eolian_init(void)
    return ++_eolian_init_counter;
 }
 
-EAPI int eolian_shutdown(void)
+EOLIAN_API int eolian_shutdown(void)
 {
    if (_eolian_init_counter <= 0)
      {
@@ -68,7 +68,7 @@ EAPI int eolian_shutdown(void)
    return _eolian_init_counter;
 }
 
-EAPI unsigned short eolian_file_format_version_get(void)
+EOLIAN_API unsigned short eolian_file_format_version_get(void)
 {
    return EOLIAN_FILE_FORMAT_VERSION;
 }

--- a/src/lib/eolian/eolian_aux.c
+++ b/src/lib/eolian/eolian_aux.c
@@ -10,7 +10,7 @@ _hashlist_free(void *ptr)
    eina_list_free((Eina_List *)ptr);
 }
 
-EAPI Eina_Hash *
+EOLIAN_API Eina_Hash *
 eolian_aux_state_class_children_find(const Eolian_State *state)
 {
    if (!state)
@@ -105,7 +105,7 @@ _callables_find(const Eolian_Class *cl, Eina_List **funcs,
    return total;
 }
 
-EAPI size_t
+EOLIAN_API size_t
 eolian_aux_class_callables_get(const Eolian_Class *klass,
                                Eina_List **funcs, Eina_List **events,
                                size_t *ownfuncs, size_t *ownevs)
@@ -178,7 +178,7 @@ _all_impls_find(Eina_List **l, const Eolian_Class *cl,
      _all_impls_find(l, icl, func, got, children);
 }
 
-EAPI Eina_List *
+EOLIAN_API Eina_List *
 eolian_aux_function_all_implements_get(const Eolian_Function *func,
                                        Eina_Hash *class_children)
 {
@@ -239,7 +239,7 @@ _parent_impl_find(const char *fulln, const Eolian_Class *cl)
    return NULL;
 }
 
-EAPI const Eolian_Implement *
+EOLIAN_API const Eolian_Implement *
 eolian_aux_implement_parent_get(const Eolian_Implement *impl)
 {
    return _parent_impl_find(eolian_implement_name_get(impl),
@@ -262,7 +262,7 @@ _parent_documentation_find(const Eolian_Implement *impl,
    return pdoc;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_aux_implement_documentation_get(const Eolian_Implement *impl,
                                     Eolian_Function_Type ftype)
 {
@@ -286,7 +286,7 @@ eolian_aux_implement_documentation_get(const Eolian_Implement *impl,
    return _parent_documentation_find(impl, ftype);
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_aux_implement_documentation_fallback_get(const Eolian_Implement *impl)
 {
    Eina_Bool ig = eolian_implement_is_prop_get(impl),

--- a/src/lib/eolian/eolian_database.c
+++ b/src/lib/eolian/eolian_database.c
@@ -18,49 +18,49 @@ database_object_add(Eolian_Unit *unit, const Eolian_Object *obj)
                  ((Eina_List *)eina_hash_find(unit->state->staging.objects_f, obj->file), obj));
 }
 
-EAPI Eolian_Object_Type
+EOLIAN_API Eolian_Object_Type
 eolian_object_type_get(const Eolian_Object *obj)
 {
    if (!obj) return EOLIAN_OBJECT_UNKNOWN;
    return obj->type;
 }
 
-EAPI const Eolian_Unit *
+EOLIAN_API const Eolian_Unit *
 eolian_object_unit_get(const Eolian_Object *obj)
 {
    if (!obj) return NULL;
    return obj->unit;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_object_file_get(const Eolian_Object *obj)
 {
    if (!obj) return NULL;
    return obj->file;
 }
 
-EAPI int
+EOLIAN_API int
 eolian_object_line_get(const Eolian_Object *obj)
 {
    if (!obj) return 0;
    return obj->line;
 }
 
-EAPI int
+EOLIAN_API int
 eolian_object_column_get(const Eolian_Object *obj)
 {
    if (!obj) return 0;
    return obj->column;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_object_name_get(const Eolian_Object *obj)
 {
    if (!obj) return NULL;
    return obj->name;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_object_c_name_get(const Eolian_Object *obj)
 {
    if (!obj) return NULL;
@@ -95,7 +95,7 @@ _nmsp_container_get(Eina_Iterator *it EINA_UNUSED)
    return NULL;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_object_short_name_get(const Eolian_Object *obj)
 {
    if (!obj || !obj->name) return NULL;
@@ -105,7 +105,7 @@ eolian_object_short_name_get(const Eolian_Object *obj)
    return obj->name;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_object_namespaces_get(const Eolian_Object *obj)
 {
    if (!obj || !obj->name || !strchr(obj->name, '.')) return NULL;
@@ -126,7 +126,7 @@ eolian_object_namespaces_get(const Eolian_Object *obj)
    return &it->itr;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_object_is_beta(const Eolian_Object *obj)
 {
    if (!obj) return EINA_FALSE;
@@ -143,28 +143,28 @@ void database_doc_del(Eolian_Documentation *doc)
    free(doc);
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_documentation_summary_get(const Eolian_Documentation *doc)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(doc, NULL);
    return doc->summary;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_documentation_description_get(const Eolian_Documentation *doc)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(doc, NULL);
    return doc->description;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_documentation_since_get(const Eolian_Documentation *doc)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(doc, NULL);
    return doc->since;
 }
 
-EAPI Eina_List *
+EOLIAN_API Eina_List *
 eolian_documentation_string_split(const char *doc)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(doc, NULL);
@@ -259,7 +259,7 @@ _get_ref_token(const char *doc, const char **doc_end)
    return EOLIAN_DOC_TOKEN_REF;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_documentation_tokenize(const char *doc, Eolian_Doc_Token *ret)
 {
    /* token is used for statekeeping, so force it */
@@ -393,7 +393,7 @@ mloop:
    return ret->text_end;
 }
 
-EAPI void
+EOLIAN_API void
 eolian_doc_token_init(Eolian_Doc_Token *tok)
 {
    if (!tok)
@@ -402,14 +402,14 @@ eolian_doc_token_init(Eolian_Doc_Token *tok)
    tok->text = tok->text_end = NULL;
 }
 
-EAPI Eolian_Doc_Token_Type
+EOLIAN_API Eolian_Doc_Token_Type
 eolian_doc_token_type_get(const Eolian_Doc_Token *tok)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tok, EOLIAN_DOC_TOKEN_UNKNOWN);
    return tok->type;
 }
 
-EAPI char *
+EOLIAN_API char *
 eolian_doc_token_text_get(const Eolian_Doc_Token *tok)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(tok, NULL);
@@ -574,7 +574,7 @@ database_doc_token_ref_resolve(const Eolian_Doc_Token *tok,
    return EOLIAN_OBJECT_FUNCTION;
 }
 
-EAPI Eolian_Object_Type
+EOLIAN_API Eolian_Object_Type
 eolian_doc_token_ref_resolve(const Eolian_Doc_Token *tok, const Eolian_State *state,
                              const Eolian_Object **data, const Eolian_Object **data2)
 {
@@ -704,7 +704,7 @@ _default_error_cb(const Eolian_Object *obj, const char *msg, void *data EINA_UNU
      _eolian_log(msg);
 }
 
-EAPI Eolian_State *
+EOLIAN_API Eolian_State *
 eolian_state_new(void)
 {
    Eolian_State *state = calloc(1, sizeof(Eolian_State));
@@ -733,7 +733,7 @@ eolian_state_new(void)
    return state;
 }
 
-EAPI void
+EOLIAN_API void
 eolian_state_free(Eolian_State *state)
 {
    if (!state)
@@ -750,7 +750,7 @@ eolian_state_free(Eolian_State *state)
    free(state);
 }
 
-EAPI Eolian_Panic_Cb
+EOLIAN_API Eolian_Panic_Cb
 eolian_state_panic_cb_set(Eolian_State *state, Eolian_Panic_Cb cb)
 {
    Eolian_Panic_Cb old_cb = state->panic;
@@ -758,7 +758,7 @@ eolian_state_panic_cb_set(Eolian_State *state, Eolian_Panic_Cb cb)
    return old_cb;
 }
 
-EAPI Eolian_Error_Cb
+EOLIAN_API Eolian_Error_Cb
 eolian_state_error_cb_set(Eolian_State *state, Eolian_Error_Cb cb)
 {
    Eolian_Error_Cb old_cb = state->error;
@@ -766,7 +766,7 @@ eolian_state_error_cb_set(Eolian_State *state, Eolian_Error_Cb cb)
    return old_cb;
 }
 
-EAPI void *
+EOLIAN_API void *
 eolian_state_error_data_set(Eolian_State *state, void *data)
 {
    void *old_data = state->error_data;
@@ -822,7 +822,7 @@ _scan_cb(const char *name, const char *path, void *data)
      eina_hash_add(fh, name, newpath);
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_state_directory_add(Eolian_State *state, const char *dir)
 {
    if (!dir || !state) return EINA_FALSE;
@@ -830,7 +830,7 @@ eolian_state_directory_add(Eolian_State *state, const char *dir)
    return eina_file_dir_list(dir, EINA_TRUE, _scan_cb, &sst) && sst.succ;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_state_system_directory_add(Eolian_State *state)
 {
    Eina_Bool ret;
@@ -842,28 +842,28 @@ eolian_state_system_directory_add(Eolian_State *state)
    return ret;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_eot_files_get(const Eolian_State *state)
 {
    if (!state) return NULL;
    return eina_hash_iterator_key_new(state->filenames_eot);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_eo_files_get(const Eolian_State *state)
 {
    if (!state) return NULL;
    return eina_hash_iterator_key_new(state->filenames_eo);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_eot_file_paths_get(const Eolian_State *state)
 {
    if (!state) return NULL;
    return eina_hash_iterator_data_new(state->filenames_eot);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_eo_file_paths_get(const Eolian_State *state)
 {
    if (!state) return NULL;
@@ -1074,7 +1074,7 @@ _merge_staging(Eolian_State *state)
    _state_clean(state);
 }
 
-EAPI const Eolian_Unit *
+EOLIAN_API const Eolian_Unit *
 eolian_state_file_parse(Eolian_State *state, const char *filename)
 {
    if (!state)
@@ -1093,7 +1093,7 @@ eolian_state_file_parse(Eolian_State *state, const char *filename)
    return ret;
 }
 
-EAPI const Eolian_Unit *
+EOLIAN_API const Eolian_Unit *
 eolian_state_file_path_parse(Eolian_State *state, const char *filepath)
 {
    const Eolian_Unit *unit;
@@ -1146,7 +1146,7 @@ static Eina_Bool _tfile_parse(const Eina_Hash *hash EINA_UNUSED, const void *key
    return pd->ret;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_state_all_eot_files_parse(Eolian_State *state)
 {
    Parse_Data pd = { state, EINA_TRUE };
@@ -1177,7 +1177,7 @@ static Eina_Bool _file_parse(const Eina_Hash *hash EINA_UNUSED, const void *key 
    return pd->ret;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_state_all_eo_files_parse(Eolian_State *state)
 {
    Parse_Data pd = { state, EINA_TRUE };
@@ -1196,13 +1196,13 @@ eolian_state_all_eo_files_parse(Eolian_State *state)
    return pd.ret;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_state_check(const Eolian_State *state)
 {
    return database_check(state);
 }
 
-EAPI const Eolian_Unit *
+EOLIAN_API const Eolian_Unit *
 eolian_state_unit_by_file_get(const Eolian_State *state, const char *file_name)
 {
    if (!state) return NULL;
@@ -1212,14 +1212,14 @@ eolian_state_unit_by_file_get(const Eolian_State *state, const char *file_name)
    return unit;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_units_get(const Eolian_State *state)
 {
    if (!state) return NULL;
    return eina_hash_iterator_data_new(state->main.units);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_objects_by_file_get(const Eolian_State *state, const char *file_name)
 {
    if (!state) return NULL;
@@ -1230,7 +1230,7 @@ eolian_state_objects_by_file_get(const Eolian_State *state, const char *file_nam
    return eina_list_iterator_new(l);
 }
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_state_class_by_file_get(const Eolian_State *state, const char *file_name)
 {
    if (!state) return NULL;
@@ -1240,7 +1240,7 @@ eolian_state_class_by_file_get(const Eolian_State *state, const char *file_name)
    return cl;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_constants_by_file_get(const Eolian_State *state, const char *file_name)
 {
    if (!state) return NULL;
@@ -1251,7 +1251,7 @@ eolian_state_constants_by_file_get(const Eolian_State *state, const char *file_n
    return eina_list_iterator_new(l);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_errors_by_file_get(const Eolian_State *state, const char *file_name)
 {
    if (!state) return NULL;
@@ -1262,7 +1262,7 @@ eolian_state_errors_by_file_get(const Eolian_State *state, const char *file_name
    return eina_list_iterator_new(l);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_aliases_by_file_get(const Eolian_State *state, const char *file_name)
 {
    if (!state) return NULL;
@@ -1273,7 +1273,7 @@ eolian_state_aliases_by_file_get(const Eolian_State *state, const char *file_nam
    return eina_list_iterator_new(l);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_structs_by_file_get(const Eolian_State *state, const char *file_name)
 {
    if (!state) return NULL;
@@ -1284,7 +1284,7 @@ eolian_state_structs_by_file_get(const Eolian_State *state, const char *file_nam
    return eina_list_iterator_new(l);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_state_enums_by_file_get(const Eolian_State *state, const char *file_name)
 {
    if (!state) return NULL;
@@ -1295,28 +1295,28 @@ eolian_state_enums_by_file_get(const Eolian_State *state, const char *file_name)
    return eina_list_iterator_new(l);
 }
 
-EAPI const Eolian_State *
+EOLIAN_API const Eolian_State *
 eolian_unit_state_get(const Eolian_Unit *unit)
 {
    if (!unit) return NULL;
    return unit->state;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_unit_children_get(const Eolian_Unit *unit)
 {
    if (!unit) return NULL;
    return eina_hash_iterator_data_new(unit->children);
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_unit_file_get(const Eolian_Unit *unit)
 {
    if (!unit) return NULL;
    return unit->file;
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_unit_file_path_get(const Eolian_Unit *unit)
 {
    if (!unit || !unit->file) return NULL;
@@ -1326,14 +1326,14 @@ eolian_unit_file_path_get(const Eolian_Unit *unit)
      : unit->state->filenames_eot, unit->file);
 }
 
-EAPI unsigned short
+EOLIAN_API unsigned short
 eolian_unit_version_get(const Eolian_Unit *unit)
 {
    if (!unit) return 0;
    return unit->version;
 }
 
-EAPI const Eolian_Object *
+EOLIAN_API const Eolian_Object *
 eolian_unit_object_by_name_get(const Eolian_Unit *unit, const char *name)
 {
    if (!unit) return NULL;
@@ -1343,12 +1343,12 @@ eolian_unit_object_by_name_get(const Eolian_Unit *unit, const char *name)
    return o;
 }
 
-EAPI Eina_Iterator *eolian_unit_objects_get(const Eolian_Unit *unit)
+EOLIAN_API Eina_Iterator *eolian_unit_objects_get(const Eolian_Unit *unit)
 {
    return (unit ? eina_hash_iterator_data_new(unit->objects) : NULL);
 }
 
-EAPI const Eolian_Class *
+EOLIAN_API const Eolian_Class *
 eolian_unit_class_by_name_get(const Eolian_Unit *unit, const char *class_name)
 {
    if (!unit) return NULL;
@@ -1358,13 +1358,13 @@ eolian_unit_class_by_name_get(const Eolian_Unit *unit, const char *class_name)
    return cl;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_unit_classes_get(const Eolian_Unit *unit)
 {
    return (unit ? eina_hash_iterator_data_new(unit->classes) : NULL);
 }
 
-EAPI const Eolian_Constant *
+EOLIAN_API const Eolian_Constant *
 eolian_unit_constant_by_name_get(const Eolian_Unit *unit, const char *name)
 {
    if (!unit) return NULL;
@@ -1374,7 +1374,7 @@ eolian_unit_constant_by_name_get(const Eolian_Unit *unit, const char *name)
    return v;
 }
 
-EAPI const Eolian_Error *
+EOLIAN_API const Eolian_Error *
 eolian_unit_error_by_name_get(const Eolian_Unit *unit, const char *name)
 {
    if (!unit) return NULL;
@@ -1384,19 +1384,19 @@ eolian_unit_error_by_name_get(const Eolian_Unit *unit, const char *name)
    return v;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_unit_constants_get(const Eolian_Unit *unit)
 {
    return (unit ? eina_hash_iterator_data_new(unit->constants) : NULL);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_unit_errors_get(const Eolian_Unit *unit)
 {
    return (unit ? eina_hash_iterator_data_new(unit->errors) : NULL);
 }
 
-EAPI const Eolian_Typedecl *
+EOLIAN_API const Eolian_Typedecl *
 eolian_unit_alias_by_name_get(const Eolian_Unit *unit, const char *name)
 {
    if (!unit) return NULL;
@@ -1407,7 +1407,7 @@ eolian_unit_alias_by_name_get(const Eolian_Unit *unit, const char *name)
    return tp;
 }
 
-EAPI const Eolian_Typedecl *
+EOLIAN_API const Eolian_Typedecl *
 eolian_unit_struct_by_name_get(const Eolian_Unit *unit, const char *name)
 {
    if (!unit) return NULL;
@@ -1418,7 +1418,7 @@ eolian_unit_struct_by_name_get(const Eolian_Unit *unit, const char *name)
    return tp;
 }
 
-EAPI const Eolian_Typedecl *
+EOLIAN_API const Eolian_Typedecl *
 eolian_unit_enum_by_name_get(const Eolian_Unit *unit, const char *name)
 {
    if (!unit) return NULL;
@@ -1429,39 +1429,39 @@ eolian_unit_enum_by_name_get(const Eolian_Unit *unit, const char *name)
    return tp;
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_unit_aliases_get(const Eolian_Unit *unit)
 {
    return (unit ? eina_hash_iterator_data_new(unit->aliases) : NULL);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_unit_structs_get(const Eolian_Unit *unit)
 {
    return (unit ? eina_hash_iterator_data_new(unit->structs) : NULL);
 }
 
-EAPI Eina_Iterator *
+EOLIAN_API Eina_Iterator *
 eolian_unit_enums_get(const Eolian_Unit *unit)
 {
    return (unit ? eina_hash_iterator_data_new(unit->enums) : NULL);
 }
 
-EAPI const char *
+EOLIAN_API const char *
 eolian_error_message_get(const Eolian_Error *err)
 {
    if (!err) return NULL;
    return err->msg;
 }
 
-EAPI Eina_Bool
+EOLIAN_API Eina_Bool
 eolian_error_is_extern(const Eolian_Error *err)
 {
    if (!err) return EINA_FALSE;
    return err->is_extern;
 }
 
-EAPI const Eolian_Documentation *
+EOLIAN_API const Eolian_Documentation *
 eolian_error_documentation_get(const Eolian_Error *err)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(err, NULL);

--- a/src/lib/eolian/meson.build
+++ b/src/lib/eolian/meson.build
@@ -39,7 +39,7 @@ eolian_lib = library('eolian', eolian_src,
     include_directories: config_dir,
     dependencies: eina,
     install: true,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DEOLIAN_BUILD'],
     version : meson.project_version()
 )
 

--- a/src/tests/eolian/meson.build
+++ b/src/tests/eolian/meson.build
@@ -27,7 +27,7 @@ endforeach
 
 eolian_suite = executable('eolian_suite',
   eolian_test_src, priv_eo_file_target,
-  dependencies: [eolian, check, eo],
+  dependencies: [eolian, check_dep, eo],
   c_args : [
   '-DEOLIAN_GEN="'+eolian_gen_path+'"',
   '-DTESTS_BUILD_DIR="'+meson.current_build_dir()+'"',


### PR DESCRIPTION
This PR aims to compile lib `Efl` but:
- `Efl` tests are turned off;
- `Eo` and everything that needs it, is not compiled, as `Eo` is still a work in progress;

This PR changes every `EAPI` to `EOLIAN_API` to resolve linking issues.
It uses `-DEFL_BUILD`, defined at `src/lib/efl/meson.build`, to
correctly set `EFL_API` as `__declspec(dllexport)` or
`__declspec(dllimport)` at `src/lib/efl/Efl.h`.
It also creates an stub of `DLLMain` at `src/lib/efl/efl_main.c` to solve
missing symbol `_DllMainCRTStartup`:
```
  [192/261] Linking target src/lib/efl/efl-1.dll
  FAILED: src/lib/efl/efl-1.dll src/lib/efl/efl-1.pdb
  lld-link @src/lib/efl/efl-1.dll.rsp
  lld-link: error: <root>: undefined symbol: _DllMainCRTStartup
```
Because of the stub and not having `Eo` this PR will stay as a draft.

This PR depends on #85.