### PR TITLE
Fixing some windows includes with WIN32_LEAN_AND_MEAN

### DIFF
--- a/src/generic/evas/common/timeout.c
+++ b/src/generic/evas/common/timeout.c
@@ -1,7 +1,12 @@
 #ifdef _WIN32
 # include <stdio.h>
+
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <windows.h>
 # include <process.h>
+# undef WIN32_LEAN_AND_MEAN
 
 unsigned int
 _timeout(void *arg)

--- a/src/lib/ecore/ecore.c
+++ b/src/lib/ecore/ecore.c
@@ -16,7 +16,7 @@
 #endif
 
 #ifdef _WIN32
-# include <evil_private.h> /* mmap */
+# include <evil_private.h> /* mmap, evil_init/shutdown */
 #else
 # include <sys/mman.h>
 #endif
@@ -25,9 +25,6 @@
 # include <systemd/sd-daemon.h>
 #endif
 
-#ifdef _WIN32
-# include <evil_private.h> /* evil_init/shutdown */
-#endif
 #include <Eina.h>
 #include <Efl.h>
 

--- a/src/lib/ecore/ecore_exe_win32.c
+++ b/src/lib/ecore/ecore_exe_win32.c
@@ -2,12 +2,13 @@
 # include <config.h>
 #endif
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
-#include <process.h>
-
 #include <evil_private.h> /* evil_last_error_get */
+
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
+#include <process.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include "Ecore.h"
 #include "ecore_private.h"

--- a/src/lib/ecore/ecore_pipe.c
+++ b/src/lib/ecore/ecore_pipe.c
@@ -38,8 +38,8 @@
 #define PIPE_FD_INVALID -1
 
 #ifdef _WIN32
-# include <winsock2.h>
 # include <evil_private.h> /* pipe fcntl */
+# include <winsock2.h>
 # define pipe_write(fd, buffer, size) send((fd), (char *)(buffer), size, 0)
 # define pipe_read(fd, buffer, size)  recv((fd), (char *)(buffer), size, 0)
 # define pipe_close(fd)               closesocket(fd)

--- a/src/lib/ecore/efl_thread.c
+++ b/src/lib/ecore/efl_thread.c
@@ -9,6 +9,7 @@
 #ifdef _WIN32
 # include <evil_private.h> /* pipe fcntl */
 #endif
+
 #include <Ecore.h>
 
 #include "ecore_private.h"

--- a/src/lib/ecore_con/ecore_con.c
+++ b/src/lib/ecore_con/ecore_con.c
@@ -39,8 +39,8 @@
 #endif
 
 #ifdef _WIN32
-# include <ws2tcpip.h>
 # include <evil_private.h> /* evil_init|shutdown */
+# include <ws2tcpip.h>
 #endif
 
 #include "Ecore.h"

--- a/src/lib/ecore_con/ecore_con_local.c
+++ b/src/lib/ecore_con/ecore_con_local.c
@@ -10,19 +10,17 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <libgen.h>
+
 #ifdef _WIN32
 # include <evil_private.h> /* mkdir */
+# include <ws2tcpip.h>
 #else
 # include <pwd.h>
 #endif
-#include <libgen.h>
 
 #ifdef HAVE_SYSTEMD
 # include <systemd/sd-daemon.h>
-#endif
-
-#ifdef _WIN32
-# include <ws2tcpip.h>
 #endif
 
 #include <Ecore.h>

--- a/src/lib/ecore_file/ecore_file.c
+++ b/src/lib/ecore_file/ecore_file.c
@@ -9,8 +9,8 @@
 #include <libgen.h>
 
 #ifdef _WIN32
-# include <direct.h>
 # include <evil_private.h> /* mkdir realpath */
+# include <direct.h>
 #endif
 
 #ifdef HAVE_FEATURES_H

--- a/src/lib/ecore_file/ecore_file_monitor_win32.c
+++ b/src/lib/ecore_file/ecore_file_monitor_win32.c
@@ -6,12 +6,13 @@
 # include <config.h>
 #endif
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
-#include <process.h>
-
 #include <evil_private.h> /* evil_wchar_to_char */
+
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
+#include <process.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include "ecore_file_private.h"
 

--- a/src/lib/ecore_win32/ecore_win32.c
+++ b/src/lib/ecore_win32/ecore_win32.c
@@ -4,11 +4,13 @@
 
 #include <stdlib.h>
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
 #include <windowsx.h>
 #include <dbt.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include <Eina.h>
 #include <Ecore.h>

--- a/src/lib/ecore_win32/ecore_win32_clipboard.c
+++ b/src/lib/ecore_win32/ecore_win32_clipboard.c
@@ -2,10 +2,6 @@
 # include <config.h>
 #endif
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
-
 #include <evil_private.h> /* utf-8 and utf-16 conversion */
 #include <Eina.h>
 

--- a/src/lib/ecore_win32/ecore_win32_cursor.c
+++ b/src/lib/ecore_win32/ecore_win32_cursor.c
@@ -6,7 +6,7 @@
 # define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-#include <windowsx.h>
+#include <winuser.h>
 #undef WIN32_LEAN_AND_MEAN
 
 #include <Eina.h>

--- a/src/lib/ecore_win32/ecore_win32_cursor.c
+++ b/src/lib/ecore_win32/ecore_win32_cursor.c
@@ -2,8 +2,11 @@
 # include <config.h>
 #endif
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
+#include <windowsx.h>
 #undef WIN32_LEAN_AND_MEAN
 
 #include <Eina.h>

--- a/src/lib/ecore_win32/ecore_win32_dnd.c
+++ b/src/lib/ecore_win32/ecore_win32_dnd.c
@@ -2,7 +2,11 @@
 # include <config.h>
 #endif
 
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include "Ecore_Win32.h"
 #include "ecore_win32_private.h"

--- a/src/lib/ecore_win32/ecore_win32_dnd_data_object.h
+++ b/src/lib/ecore_win32/ecore_win32_dnd_data_object.h
@@ -1,10 +1,12 @@
 #ifndef __ECORE_WIN32_DND_DATA_OBJECT_H__
 #define __ECORE_WIN32_DND_DATA_OBJECT_H__
 
-
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
+
 #include <objbase.h>
 
 

--- a/src/lib/ecore_win32/ecore_win32_dnd_data_object.h
+++ b/src/lib/ecore_win32/ecore_win32_dnd_data_object.h
@@ -5,9 +5,8 @@
 # define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
-
 #include <objbase.h>
+#undef WIN32_LEAN_AND_MEAN
 
 
 class DataObject : public IDataObject

--- a/src/lib/ecore_win32/ecore_win32_dnd_drop_source.h
+++ b/src/lib/ecore_win32/ecore_win32_dnd_drop_source.h
@@ -2,10 +2,12 @@
 #define __ECORE_WIN32_DND_DROP_SOURCE_H__
 
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
 #include <ole2.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include "Ecore_Win32.h"
 

--- a/src/lib/ecore_win32/ecore_win32_dnd_drop_target.h
+++ b/src/lib/ecore_win32/ecore_win32_dnd_drop_target.h
@@ -1,11 +1,12 @@
 #ifndef __ECORE_WIN32_DND_DROP_TARGET_H__
 #define __ECORE_WIN32_DND_DROP_TARGET_H__
 
-
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
 #include <ole2.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include "Ecore_Win32.h"
 

--- a/src/lib/ecore_win32/ecore_win32_dnd_enumformatetc.h
+++ b/src/lib/ecore_win32/ecore_win32_dnd_enumformatetc.h
@@ -5,9 +5,8 @@
 # define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
-
 #include <objbase.h>
+#undef WIN32_LEAN_AND_MEAN
 
 
 class CEnumFormatEtc : public IEnumFORMATETC

--- a/src/lib/ecore_win32/ecore_win32_dnd_enumformatetc.h
+++ b/src/lib/ecore_win32/ecore_win32_dnd_enumformatetc.h
@@ -1,10 +1,12 @@
 #ifndef __ECORE_WIN32_DND_ENUMFORMATETC_H__
 #define __ECORE_WIN32_DND_ENUMFORMATETC_H__
 
-
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
+
 #include <objbase.h>
 
 

--- a/src/lib/ecore_win32/ecore_win32_event.c
+++ b/src/lib/ecore_win32/ecore_win32_event.c
@@ -4,10 +4,11 @@
 
 #include <stdlib.h>
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windowsx.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include <evil_private.h> /* evil_utf16_to_utf8() */
 #include <Eina.h>

--- a/src/lib/ecore_win32/ecore_win32_monitor.c
+++ b/src/lib/ecore_win32/ecore_win32_monitor.c
@@ -4,10 +4,12 @@
 
 #include <stdlib.h>
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
 #include <dbt.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include <Eina.h>
 

--- a/src/lib/ecore_win32/ecore_win32_window.c
+++ b/src/lib/ecore_win32/ecore_win32_window.c
@@ -4,7 +4,9 @@
 
 #include <stdlib.h>
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
 

--- a/src/lib/efreet/efreet_trash.c
+++ b/src/lib/efreet/efreet_trash.c
@@ -13,6 +13,8 @@
 # endif
 # include <windows.h> /* GetCurrentProcessId */
 # undef WIN32_LEAN_AND_MEAN
+
+# define getuid() GetCurrentProcessId()
 #endif
 
 #include <Ecore_File.h>
@@ -27,10 +29,6 @@ static int _efreet_trash_log_dom = -1;
 
 static unsigned int _efreet_trash_init_count = 0;
 static const char *efreet_trash_dir = NULL;
-
-#ifdef _WIN32
-# define getuid() GetCurrentProcessId()
-#endif
 
 EAPI int
 efreet_trash_init(void)

--- a/src/lib/eina/eina_log.c
+++ b/src/lib/eina/eina_log.c
@@ -21,10 +21,6 @@
 # include "config.h"
 #endif
 
-#ifdef _WIN32
-# include <evil_private.h> /* vasprintf */
-#endif /* _WIN32 */
-
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -36,7 +32,6 @@
 #endif
 
 #ifdef _WIN32
-# include <windows.h>
 # include <evil_private.h>
 #endif
 

--- a/src/lib/eina/eina_prefix.c
+++ b/src/lib/eina/eina_prefix.c
@@ -42,8 +42,8 @@
 #endif
 
 #ifdef _WIN32
-# include <direct.h> /* getcwd */
 # include <evil_private.h> /* path_is_absolute realpath dladdr */
+# include <direct.h> /* getcwd */
 #endif
 
 #include "eina_config.h"

--- a/src/lib/eina/eina_sched_win32.c
+++ b/src/lib/eina/eina_sched_win32.c
@@ -20,7 +20,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 # define WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
 
 EINA_API void

--- a/src/lib/eina/eina_thread_win32.h
+++ b/src/lib/eina/eina_thread_win32.h
@@ -23,15 +23,16 @@
 # include "config.h"
 #endif
 
-
 #include "eina_thread.h"
 #include "unimplemented.h"
 #include <errno.h>
+
 #ifndef WIN32_LEAN_AND_MEAN
 # define WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
-#undef _WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+
 #define EINA_THREAD_CANCEL_ENABLE 0
 #define EINA_THREAD_CANCEL_DISABLE 1
 #define EINA_THREAD_CANCEL_DEFERRED 0

--- a/src/lib/elementary/elm_main.c
+++ b/src/lib/elementary/elm_main.c
@@ -8,9 +8,9 @@
 
 #ifdef _WIN32
 # include <evil_private.h> /* dlopen,dlclose,etc */
-# include <dlfcn.h> /* dlopen,dlclose,etc */
 # include <direct.h> /* getcwd */
 #else
+# include <dlfcn.h> /* dlopen,dlclose,etc */
 # include <unistd.h>
 #endif
 

--- a/src/lib/elementary/elm_main.c
+++ b/src/lib/elementary/elm_main.c
@@ -2,17 +2,14 @@
 # include "elementary_config.h"
 #endif
 
-#ifndef _WIN32
-# include <dlfcn.h> /* dlopen,dlclose,etc */
-#endif
-
 #ifdef HAVE_CRT_EXTERNS_H
 # include <crt_externs.h>
 #endif
 
 #ifdef _WIN32
-# include <direct.h> /* getcwd */
 # include <evil_private.h> /* dlopen,dlclose,etc */
+# include <dlfcn.h> /* dlopen,dlclose,etc */
+# include <direct.h> /* getcwd */
 #else
 # include <unistd.h>
 #endif

--- a/src/lib/evas/canvas/evas_async_events.c
+++ b/src/lib/evas/canvas/evas_async_events.c
@@ -6,8 +6,8 @@
 #include <errno.h>
 
 #ifdef _WIN32
-# include <winsock2.h>
 # include <evil_private.h> /* fcntl */
+# include <winsock2.h>
 #endif
 
 #include <fcntl.h>

--- a/src/lib/evas/common/evas_image_scalecache.c
+++ b/src/lib/evas/common/evas_image_scalecache.c
@@ -3,7 +3,11 @@
 #endif
 
 #ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <windows.h>
+# undef WIN32_LEAN_AND_MEAN
 #endif
 
 #include <assert.h>

--- a/src/lib/evil/evil_fcntl.c
+++ b/src/lib/evil/evil_fcntl.c
@@ -3,7 +3,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include "evil_private.h"
-#include <winsock.h>
+#include <winsock2.h>
 
 #include <stdio.h>
 #include <sys/locking.h>

--- a/src/lib/evil/evil_fcntl.c
+++ b/src/lib/evil/evil_fcntl.c
@@ -2,14 +2,14 @@
 # include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <evil_windows.h>
+#include "evil_private.h"
+#include <winsock.h>
 
 #include <stdio.h>
 #include <sys/locking.h>
 
 #include <io.h>
 
-#include "evil_private.h"
 
 /* SOCKET is defined as a uintptr_t, so passing a fd (int) is not a problem */
 static int

--- a/src/lib/evil/evil_locale.c
+++ b/src/lib/evil/evil_locale.c
@@ -8,8 +8,6 @@
 #include <locale.h>
 #include <errno.h>
 
-#include <evil_windows.h>
-
 /*
  * LOCALE_SISO639LANGNAME and LOCALE_SISO3166CTRYNAME need at least a buffer
  * of 9 char each (including NULL char). So we need 2*8 + the trailing NULL

--- a/src/lib/evil/evil_strings.h
+++ b/src/lib/evil/evil_strings.h
@@ -7,10 +7,10 @@
 # ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN
 # endif
-# include <Windows.h>
+# include <windows.h>
 # undef WIN32_LEAN_AND_MEAN
 #else
-# include<string.h>
+# include <string.h>
 #endif
 
 #define strncasecmp _strnicmp

--- a/src/lib/evil/evil_time.c
+++ b/src/lib/evil/evil_time.c
@@ -7,14 +7,6 @@
 #include <ctype.h>
 #include <time.h>
 
-#ifdef _WIN32
-# ifndef WIN32_LEAN_AND_MEAN
-#  define WIN32_LEAN_AND_MEAN
-# endif
-# include <Windows.h>
-# undef WIN32_LEAN_AND_MEAN
-#endif
-
 #include "evil_private.h"
 
 inline struct tm *localtime_r(const time_t * time, struct tm * result)

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -4,7 +4,6 @@
 
 #include "evil_private.h"
 
-#include <evil_windows.h>
 #include <errno.h>
 #include <direct.h>
 #include <sys/time.h>

--- a/src/lib/evil/evil_windows.h
+++ b/src/lib/evil/evil_windows.h
@@ -8,11 +8,9 @@
 #ifndef WIN32_LEAN_AND_MEAN
 # define WIN32_LEAN_AND_MEAN
 #endif
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
 
 #include <evil_api.h>
-
-#include <windows.h>
-#include <winsock2.h>
-
 
 #endif

--- a/src/lib/evil/unposix/sys/time.h
+++ b/src/lib/evil/unposix/sys/time.h
@@ -15,6 +15,8 @@
 #include <../ucrt/time.h>
 #include <sys/types.h>
 
+#undef WIN32_LEAN_AND_MEAN
+
 // typedef unsigned short u_short;
 
 // struct timezone {

--- a/src/modules/ecore_evas/engines/win32/ecore_evas_win32.c
+++ b/src/modules/ecore_evas/engines/win32/ecore_evas_win32.c
@@ -17,9 +17,12 @@
 #include "ecore_evas_private.h"
 #include "ecore_evas_win32.h"
 
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
+#endif
 
 #ifdef BUILD_ECORE_EVAS_SOFTWARE_GDI
 # include <Evas_Engine_Software_Gdi.h>

--- a/src/modules/evas/engines/software_ddraw/Evas_Engine_Software_DDraw.h
+++ b/src/modules/evas/engines/software_ddraw/Evas_Engine_Software_DDraw.h
@@ -1,11 +1,11 @@
 #ifndef __EVAS_ENGINE_SOFTWARE_DDRAW_H__
 #define __EVAS_ENGINE_SOFTWARE_DDRAW_H__
 
-
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
-
 
 typedef struct _Evas_Engine_Info_Software_DDraw Evas_Engine_Info_Software_DDraw;
 

--- a/src/modules/evas/engines/software_ddraw/evas_engine.h
+++ b/src/modules/evas/engines/software_ddraw/evas_engine.h
@@ -1,8 +1,9 @@
 #ifndef __EVAS_ENGINE_H__
 #define __EVAS_ENGINE_H__
 
-
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
 

--- a/src/modules/evas/engines/software_gdi/Evas_Engine_Software_Gdi.h
+++ b/src/modules/evas/engines/software_gdi/Evas_Engine_Software_Gdi.h
@@ -1,11 +1,11 @@
 #ifndef __EVAS_ENGINE_SOFTWARE_GDI_H__
 #define __EVAS_ENGINE_SOFTWARE_GDI_H__
 
-
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
-
 
 typedef struct _Evas_Engine_Info_Software_Gdi Evas_Engine_Info_Software_Gdi;
 

--- a/src/modules/evas/engines/software_gdi/evas_engine.h
+++ b/src/modules/evas/engines/software_gdi/evas_engine.h
@@ -1,8 +1,9 @@
 #ifndef EVAS_ENGINE_H
 #define EVAS_ENGINE_H
 
-
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
 

--- a/src/tests/edje/edje_test_edje.c
+++ b/src/tests/edje/edje_test_edje.c
@@ -9,9 +9,15 @@
 #define EFL_CANVAS_LAYOUT_BETA
 
 #include "edje_suite.h"
+
 #ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <windows.h>
+# undef WIN32_LEAN_AND_MEAN
 #endif
+
 #define EVAS_DATA_DIR TESTS_SRC_DIR "/../../lib/evas"
 
 EFL_START_TEST(edje_test_edje_init)

--- a/src/tests/evil/evil_suite.c
+++ b/src/tests/evil/evil_suite.c
@@ -23,7 +23,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h> /* putenv */
+#undef WIN32_LEAN_AND_MEAN
 
 #include "evil_suite.h"
 #include "../efl_check.h"

--- a/src/tests/timeout.c
+++ b/src/tests/timeout.c
@@ -1,7 +1,11 @@
 #ifndef _MSC_VER
-#include <unistd.h>
+# include <unistd.h>
 #else
-#include <windows.h>
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+# undef WIN32_LEAN_AND_MEAN
 #endif
 
 #if defined(__clang__)


### PR DESCRIPTION
Today some sources are including `<windows.h>` without defining `WIN32_LEAN_AND_MEAN`, which in our case is leading to the [well known problem about winsock vs winsock2](https://stackoverflow.com/a/9168850). This PR fixes all `<Windows.h>`, following the recommendations of #33.
