### PR TITLE
windows: fix eina_thread_equal

### DIFF
--- a/src/lib/eina/eina_inline_thread_win32.x
+++ b/src/lib/eina/eina_inline_thread_win32.x
@@ -85,6 +85,7 @@ _eina_thread_create(Eina_Thread *t, int affinity, void *(*func)(void *data), Ein
                    , t->data, 0, NULL);
    if (t->handle)
      {
+        t->id = GetThreadId(t->handle);
         _eina_thread_set_priority(c->prio, t);
 
         #ifdef EINA_HAVE_WIN32_THREAD_AFFINITY
@@ -106,10 +107,7 @@ _eina_thread_create(Eina_Thread *t, int affinity, void *(*func)(void *data), Ein
 static inline Eina_Bool
 _eina_thread_equal(Eina_Thread t1, Eina_Thread t2)
 {
-   DWORD t1_thread_id = GetThreadId(t1.handle);
-   DWORD t2_thread_id = GetThreadId(t2.handle);
-
-   return (t1_thread_id == t2_thread_id) ? EINA_TRUE : EINA_FALSE;
+   return (t1.id == t2.id) ? EINA_TRUE : EINA_FALSE;
 }
 
 static inline Eina_Thread
@@ -117,6 +115,7 @@ _eina_thread_self(void)
 {
    Eina_Thread ret;
    ret.handle = GetCurrentThread();
+   ret.id = GetCurrentThreadId();
    ret.data = NULL;
    return ret;
 }

--- a/src/lib/eina/eina_thread_win32.h
+++ b/src/lib/eina/eina_thread_win32.h
@@ -55,6 +55,7 @@ struct _Eina_ThreadData
 typedef struct _Eina_Thread
 {
    HANDLE handle;
+   DWORD id;
    struct _Eina_ThreadData *data;
 } Eina_Thread;
 


### PR DESCRIPTION
`GetCurrentThread` API returns a pseudo-handle that identifies the current
thread. It returns the same value independent of the calling thread.
This affects thread indentifier comparison as comparing two identifiers
obtained from `eina_thread_self` may compare equal although they are
from different thread.

The correct way to compare thread identifiers in Windows are with values
returned from `GetCurrentThreadId` and `GetThreadId`.