### PR TITLE
Use ECORE_WIN32_API instead of EAPI

### DIFF
--- a/src/lib/ecore_win32/Ecore_Win32.h
+++ b/src/lib/ecore_win32/Ecore_Win32.h
@@ -20,29 +20,25 @@
 
 #include <Eina.h>
 
-#ifdef EAPI
-# undef EAPI
+#ifdef ECORE_WIN32_API
+# undef ECORE_WIN32_API
 #endif
 
 #ifdef _WIN32
 # ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
+#  define ECORE_WIN32_API __declspec(dllexport)
 # else
-#  define EAPI __declspec(dllimport)
+#  define ECORE_WIN32_API __declspec(dllimport)
 # endif
 #else
 # ifdef __GNUC__
 #  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
+#   define ECORE_WIN32_API __attribute__ ((visibility("default")))
 #  else
-#   define EAPI
+#   define ECORE_WIN32_API
 #  endif
 # else
-#  define EAPI
+#  define ECORE_WIN32_API
 # endif
 #endif
 
@@ -504,176 +500,176 @@ struct _Ecore_Win32_Event_Selection_Notify
  */
 typedef int (*Ecore_Win32_Dnd_DropTarget_Callback)(void *window, int event, int pt_x, int pt_y, void *data, int size);
 
-EAPI extern int ECORE_WIN32_EVENT_MOUSE_IN; /**< Ecore_Event for the #Ecore_Win32_Event_Mouse_In event */
-EAPI extern int ECORE_WIN32_EVENT_MOUSE_OUT; /**< Ecore_Event for the #Ecore_Win32_Event_Mouse_Out event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_FOCUS_IN; /**< Ecore_Event for the #Ecore_Win32_Event_Window_Focus_In event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_FOCUS_OUT; /**< Ecore_Event for the #Ecore_Win32_Event_Window_Focus_Out event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_DAMAGE; /**< Ecore_Event for the Ecore_Win32_Event_Damage event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_CREATE; /**< Ecore_Event for the Ecore_Win32_Event_Create event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_DESTROY; /**< Ecore_Event for the Ecore_Win32_Event_Destroy event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_HIDE; /**< Ecore_Event for the Ecore_Win32_Event_Hide event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_SHOW; /**< Ecore_Event for the Ecore_Win32_Event_Show event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_CONFIGURE; /**< Ecore_Event for the Ecore_Win32_Event_Configure event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_RESIZE; /**< Ecore_Event for the Ecore_Win32_Event_Resize event */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_PROPERTY; /**< Ecore_Event for the Ecore_Win32_Event_Property event @since 1.20 */
-EAPI extern int ECORE_WIN32_EVENT_WINDOW_DELETE_REQUEST; /**< Ecore_Event for the #Ecore_Win32_Event_Window_Delete_Request event */
-EAPI extern int ECORE_WIN32_EVENT_SELECTION_CLEAR; /**< Ecore_Event for the #Ecore_Win32_Event_Selection_Clear event @since 1.16 */
-EAPI extern int ECORE_WIN32_EVENT_SELECTION_NOTIFY; /**< Ecore_Event for the #Ecore_Win32_Event_Selection_Notify event @since 1.16 */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_MOUSE_IN; /**< Ecore_Event for the #Ecore_Win32_Event_Mouse_In event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_MOUSE_OUT; /**< Ecore_Event for the #Ecore_Win32_Event_Mouse_Out event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_FOCUS_IN; /**< Ecore_Event for the #Ecore_Win32_Event_Window_Focus_In event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_FOCUS_OUT; /**< Ecore_Event for the #Ecore_Win32_Event_Window_Focus_Out event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_DAMAGE; /**< Ecore_Event for the Ecore_Win32_Event_Damage event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_CREATE; /**< Ecore_Event for the Ecore_Win32_Event_Create event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_DESTROY; /**< Ecore_Event for the Ecore_Win32_Event_Destroy event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_HIDE; /**< Ecore_Event for the Ecore_Win32_Event_Hide event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_SHOW; /**< Ecore_Event for the Ecore_Win32_Event_Show event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_CONFIGURE; /**< Ecore_Event for the Ecore_Win32_Event_Configure event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_RESIZE; /**< Ecore_Event for the Ecore_Win32_Event_Resize event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_PROPERTY; /**< Ecore_Event for the Ecore_Win32_Event_Property event @since 1.20 */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_WINDOW_DELETE_REQUEST; /**< Ecore_Event for the #Ecore_Win32_Event_Window_Delete_Request event */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_SELECTION_CLEAR; /**< Ecore_Event for the #Ecore_Win32_Event_Selection_Clear event @since 1.16 */
+ECORE_WIN32_API extern int ECORE_WIN32_EVENT_SELECTION_NOTIFY; /**< Ecore_Event for the #Ecore_Win32_Event_Selection_Notify event @since 1.16 */
 
 
 /* Core */
 
-EAPI int           ecore_win32_init();
-EAPI int           ecore_win32_shutdown();
-EAPI int           ecore_win32_screen_depth_get();
-EAPI void          ecore_win32_double_click_time_set(double t);
-EAPI double        ecore_win32_double_click_time_get(void);
-EAPI unsigned long ecore_win32_current_time_get(void);
+ECORE_WIN32_API int           ecore_win32_init();
+ECORE_WIN32_API int           ecore_win32_shutdown();
+ECORE_WIN32_API int           ecore_win32_screen_depth_get();
+ECORE_WIN32_API void          ecore_win32_double_click_time_set(double t);
+ECORE_WIN32_API double        ecore_win32_double_click_time_get(void);
+ECORE_WIN32_API unsigned long ecore_win32_current_time_get(void);
 
 /* Window */
 
-EAPI Ecore_Win32_Window *ecore_win32_window_new(Ecore_Win32_Window *parent,
+ECORE_WIN32_API Ecore_Win32_Window *ecore_win32_window_new(Ecore_Win32_Window *parent,
                                                 int                 x,
                                                 int                 y,
                                                 int                 width,
                                                 int                 height);
-EAPI Ecore_Win32_Window *ecore_win32_window_override_new(Ecore_Win32_Window *parent,
+ECORE_WIN32_API Ecore_Win32_Window *ecore_win32_window_override_new(Ecore_Win32_Window *parent,
                                                          int                 x,
                                                          int                 y,
                                                          int                 width,
                                                          int                 height);
 
-EAPI void ecore_win32_window_free(Ecore_Win32_Window *window);
+ECORE_WIN32_API void ecore_win32_window_free(Ecore_Win32_Window *window);
 
-EAPI void *ecore_win32_window_hwnd_get(Ecore_Win32_Window *window);
+ECORE_WIN32_API void *ecore_win32_window_hwnd_get(Ecore_Win32_Window *window);
 
-EAPI void ecore_win32_window_move(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_move(Ecore_Win32_Window *window,
                                   int                 x,
                                   int                 y);
 
-EAPI void ecore_win32_window_resize(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_resize(Ecore_Win32_Window *window,
                                     int                 width,
                                     int                 height);
 
-EAPI void ecore_win32_window_move_resize(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_move_resize(Ecore_Win32_Window *window,
                                          int                 x,
                                          int                 y,
                                          int                 width,
                                          int                 height);
 
-EAPI void ecore_win32_window_geometry_get(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_geometry_get(Ecore_Win32_Window *window,
                                           int                *x,
                                           int                *y,
                                           int                *width,
                                           int                *height);
 
-EAPI void ecore_win32_window_size_get(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_get(Ecore_Win32_Window *window,
                                       int                *width,
                                       int                *height);
 
-EAPI void ecore_win32_window_size_min_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_min_set(Ecore_Win32_Window *window,
                                           int                 min_width,
                                           int                 min_height);
 
-EAPI void ecore_win32_window_size_min_get(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_min_get(Ecore_Win32_Window *window,
                                           int                *min_width,
                                           int                *min_height);
 
-EAPI void ecore_win32_window_size_max_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_max_set(Ecore_Win32_Window *window,
                                           int                 max_width,
                                           int                 max_height);
 
-EAPI void ecore_win32_window_size_max_get(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_max_get(Ecore_Win32_Window *window,
                                           int                *max_width,
                                           int                *max_height);
 
-EAPI void ecore_win32_window_size_base_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_base_set(Ecore_Win32_Window *window,
                                            int                 base_width,
                                            int                 base_height);
 
-EAPI void ecore_win32_window_size_base_get(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_base_get(Ecore_Win32_Window *window,
                                            int                *base_width,
                                            int                *base_height);
 
-EAPI void ecore_win32_window_size_step_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_step_set(Ecore_Win32_Window *window,
                                            int                 step_width,
                                            int                 step_height);
 
-EAPI void ecore_win32_window_size_step_get(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_size_step_get(Ecore_Win32_Window *window,
                                            int                *step_width,
                                            int                *step_height);
 
-EAPI void ecore_win32_window_show(Ecore_Win32_Window *window);
+ECORE_WIN32_API void ecore_win32_window_show(Ecore_Win32_Window *window);
 
-EAPI void ecore_win32_window_hide(Ecore_Win32_Window *window);
+ECORE_WIN32_API void ecore_win32_window_hide(Ecore_Win32_Window *window);
 
-EAPI void ecore_win32_window_raise(Ecore_Win32_Window *window);
+ECORE_WIN32_API void ecore_win32_window_raise(Ecore_Win32_Window *window);
 
-EAPI void ecore_win32_window_lower(Ecore_Win32_Window *window);
+ECORE_WIN32_API void ecore_win32_window_lower(Ecore_Win32_Window *window);
 
-EAPI void ecore_win32_window_title_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_title_set(Ecore_Win32_Window *window,
                                        const char         *title);
 
-EAPI void ecore_win32_window_focus(Ecore_Win32_Window *window);
+ECORE_WIN32_API void ecore_win32_window_focus(Ecore_Win32_Window *window);
 
-EAPI void *ecore_win32_window_focus_get(void);
+ECORE_WIN32_API void *ecore_win32_window_focus_get(void);
 
-EAPI void ecore_win32_window_iconified_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_iconified_set(Ecore_Win32_Window *window,
                                            Eina_Bool           on);
 
-EAPI void ecore_win32_window_borderless_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_borderless_set(Ecore_Win32_Window *window,
                                             Eina_Bool           on);
 
-EAPI void ecore_win32_window_fullscreen_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_fullscreen_set(Ecore_Win32_Window *window,
                                             Eina_Bool           on);
 
-EAPI void ecore_win32_window_cursor_set(Ecore_Win32_Window *window,
+ECORE_WIN32_API void ecore_win32_window_cursor_set(Ecore_Win32_Window *window,
                                         Ecore_Win32_Cursor *cursor);
 
-EAPI void ecore_win32_window_state_set(Ecore_Win32_Window       *window,
+ECORE_WIN32_API void ecore_win32_window_state_set(Ecore_Win32_Window       *window,
                                        Ecore_Win32_Window_State *state,
                                        unsigned int              num);
 
-EAPI void ecore_win32_window_state_get(Ecore_Win32_Window        *window,
+ECORE_WIN32_API void ecore_win32_window_state_get(Ecore_Win32_Window        *window,
                                        Ecore_Win32_Window_State **state,
                                        unsigned int              *num);
 
-EAPI void ecore_win32_window_state_request_send(Ecore_Win32_Window      *window,
+ECORE_WIN32_API void ecore_win32_window_state_request_send(Ecore_Win32_Window      *window,
                                                 Ecore_Win32_Window_State state,
                                                 unsigned int             set);
 
-EAPI void ecore_win32_window_type_set(Ecore_Win32_Window      *window,
+ECORE_WIN32_API void ecore_win32_window_type_set(Ecore_Win32_Window      *window,
                                       Ecore_Win32_Window_Type  type);
 
 /* Cursor */
 
-EAPI Ecore_Win32_Cursor *ecore_win32_cursor_new(const void *pixels_and,
+ECORE_WIN32_API Ecore_Win32_Cursor *ecore_win32_cursor_new(const void *pixels_and,
                                                 const void *pixels_xor,
                                                 int         width,
                                                 int         height,
                                                 int         hot_x,
                                                 int         hot_y);
 
-EAPI void                ecore_win32_cursor_free(Ecore_Win32_Cursor *cursor);
+ECORE_WIN32_API void                ecore_win32_cursor_free(Ecore_Win32_Cursor *cursor);
 
-EAPI Ecore_Win32_Cursor *ecore_win32_cursor_shaped_new(Ecore_Win32_Cursor_Shape shape);
+ECORE_WIN32_API Ecore_Win32_Cursor *ecore_win32_cursor_shaped_new(Ecore_Win32_Cursor_Shape shape);
 
-EAPI const Ecore_Win32_Cursor *ecore_win32_cursor_x11_shaped_get(Ecore_Win32_Cursor_X11_Shape shape);
+ECORE_WIN32_API const Ecore_Win32_Cursor *ecore_win32_cursor_x11_shaped_get(Ecore_Win32_Cursor_X11_Shape shape);
 
-EAPI void                ecore_win32_cursor_size_get(int *width, int *height);
+ECORE_WIN32_API void                ecore_win32_cursor_size_get(int *width, int *height);
 
-EAPI void                ecore_win32_cursor_show(Eina_Bool show);
+ECORE_WIN32_API void                ecore_win32_cursor_show(Eina_Bool show);
 
 
 
 /* Drag and drop */
-EAPI int       ecore_win32_dnd_init();
-EAPI int       ecore_win32_dnd_shutdown();
-EAPI Eina_Bool ecore_win32_dnd_begin(const char *data,
+ECORE_WIN32_API int       ecore_win32_dnd_init();
+ECORE_WIN32_API int       ecore_win32_dnd_shutdown();
+ECORE_WIN32_API Eina_Bool ecore_win32_dnd_begin(const char *data,
                                      int         size);
-EAPI Eina_Bool ecore_win32_dnd_register_drop_target(Ecore_Win32_Window                 *window,
+ECORE_WIN32_API Eina_Bool ecore_win32_dnd_register_drop_target(Ecore_Win32_Window                 *window,
                                                     Ecore_Win32_Dnd_DropTarget_Callback callback);
-EAPI void      ecore_win32_dnd_unregister_drop_target(Ecore_Win32_Window *window);
+ECORE_WIN32_API void      ecore_win32_dnd_unregister_drop_target(Ecore_Win32_Window *window);
 
 /* Clipboard */
 
@@ -693,7 +689,7 @@ EAPI void      ecore_win32_dnd_unregister_drop_target(Ecore_Win32_Window *window
  *
  * @since 1.24
  */
-EAPI Eina_Bool ecore_win32_clipboard_set(const Ecore_Win32_Window *window,
+ECORE_WIN32_API Eina_Bool ecore_win32_clipboard_set(const Ecore_Win32_Window *window,
                                          const void *data,
                                          size_t size,
                                          const char *mime_type);
@@ -714,7 +710,7 @@ EAPI Eina_Bool ecore_win32_clipboard_set(const Ecore_Win32_Window *window,
  *
  * @since 1.24
  */
-EAPI void * ecore_win32_clipboard_get(const Ecore_Win32_Window *window,
+ECORE_WIN32_API void * ecore_win32_clipboard_get(const Ecore_Win32_Window *window,
                                          size_t *size,
                                          const char *mime_type);
 
@@ -729,7 +725,7 @@ EAPI void * ecore_win32_clipboard_get(const Ecore_Win32_Window *window,
  *
  * @since 1.24
  */
-EAPI void ecore_win32_clipboard_clear(const Ecore_Win32_Window *window);
+ECORE_WIN32_API void ecore_win32_clipboard_clear(const Ecore_Win32_Window *window);
 
 /**
  * @typedef Ecore_Win32_Monitor
@@ -758,7 +754,7 @@ typedef struct
  *
  * @since 1.20
  */
-EAPI Eina_Iterator *ecore_win32_monitors_get(void);
+ECORE_WIN32_API Eina_Iterator *ecore_win32_monitors_get(void);
 
 /**
  * @}
@@ -768,7 +764,7 @@ EAPI Eina_Iterator *ecore_win32_monitors_get(void);
 }
 #endif
 
-#undef EAPI
-#define EAPI
+#undef ECORE_WIN32_API
+#define ECORE_WIN32_API
 
 #endif /* __ECORE_WIN32_H__ */

--- a/src/lib/ecore_win32/ecore_win32.c
+++ b/src/lib/ecore_win32/ecore_win32.c
@@ -13,8 +13,8 @@
 #undef WIN32_LEAN_AND_MEAN
 
 #include <Eina.h>
-#include <Ecore.h>
-#include <Ecore_Input.h>
+//#include <Ecore.h>
+//#include <Ecore_Input.h>
 
 #include "Ecore_Win32.h"
 #include "ecore_win32_private.h"
@@ -472,7 +472,7 @@ int ECORE_WIN32_EVENT_SELECTION_NOTIFY      = 0;
  * When Ecore_Win32 is not used anymore, call ecore_win32_shutdown()
  * to shut down the Ecore_Win32 library.
  */
-EAPI int
+ECORE_WIN32_API int
 ecore_win32_init()
 {
    WNDCLASSEX wc;
@@ -597,7 +597,7 @@ ecore_win32_init()
  * been called the same number of times than ecore_win32_init(). In that case
  * it shuts down all the Windows graphic system.
  */
-EAPI int
+ECORE_WIN32_API int
 ecore_win32_shutdown()
 {
    int i;
@@ -652,7 +652,7 @@ ecore_win32_shutdown()
  * This function returns the depth of the screen. If an error occurs,
  * it returns 0.
  */
-EAPI int
+ECORE_WIN32_API int
 ecore_win32_screen_depth_get()
 {
    HDC dc;
@@ -685,7 +685,7 @@ ecore_win32_screen_depth_get()
  * double_click flag is set in a button down event. If 3 clicks occur
  * within double this time, the triple_click flag is also set.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_double_click_time_set(double t)
 {
    if (t < 0.0) t = 0.0;
@@ -702,7 +702,7 @@ ecore_win32_double_click_time_set(double t)
  * default value is returned. See ecore_win32_double_click_time_set()
  * for more informations.
  */
-EAPI double
+ECORE_WIN32_API double
 ecore_win32_double_click_time_get(void)
 {
    return _ecore_win32_double_click_time;
@@ -715,7 +715,7 @@ ecore_win32_double_click_time_get(void)
  *
  * This function returns the last event time.
  */
-EAPI unsigned long
+ECORE_WIN32_API unsigned long
 ecore_win32_current_time_get(void)
 {
    return _ecore_win32_event_last_time;

--- a/src/lib/ecore_win32/ecore_win32_clipboard.c
+++ b/src/lib/ecore_win32/ecore_win32_clipboard.c
@@ -33,7 +33,7 @@
  *============================================================================*/
 
 
-EAPI Eina_Bool
+ECORE_WIN32_API Eina_Bool
 ecore_win32_clipboard_set(const Ecore_Win32_Window *window,
                           const void *data,
                           size_t size,
@@ -117,7 +117,7 @@ ecore_win32_clipboard_set(const Ecore_Win32_Window *window,
    return res;
 }
 
-EAPI void *
+ECORE_WIN32_API void *
 ecore_win32_clipboard_get(const Ecore_Win32_Window *window,
                           size_t *size,
                           const char *mime_type)
@@ -221,7 +221,7 @@ ecore_win32_clipboard_get(const Ecore_Win32_Window *window,
    return NULL;
 }
 
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_clipboard_clear(const Ecore_Win32_Window *window)
 {
    INF("clearing the clipboard");

--- a/src/lib/ecore_win32/ecore_win32_cursor.c
+++ b/src/lib/ecore_win32/ecore_win32_cursor.c
@@ -184,7 +184,7 @@ _ecore_win32_cursor_x11_shaped_new(Ecore_Win32_Cursor_X11_Shape shape)
  * @see ecore_win32_cursor_free()
  * @see ecore_win32_window_cursor_set()
  */
-EAPI Ecore_Win32_Cursor *
+ECORE_WIN32_API Ecore_Win32_Cursor *
 ecore_win32_cursor_new(const void *pixels_and,
                        const void *pixels_xor,
                        int         width,
@@ -229,7 +229,7 @@ ecore_win32_cursor_new(const void *pixels_and,
  * @see ecore_win32_cursor_new()
  * @see ecore_win32_cursor_x11_shaped_new()
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_cursor_free(Ecore_Win32_Cursor *cursor)
 {
    INF("destroying cursor");
@@ -250,7 +250,7 @@ ecore_win32_cursor_free(Ecore_Win32_Cursor *cursor)
  * @p shape. This cursor does not need to be freed, as it is loaded
  * from an existing resource. On error @c NULL is returned.
  */
-EAPI Ecore_Win32_Cursor *
+ECORE_WIN32_API Ecore_Win32_Cursor *
 ecore_win32_cursor_shaped_new(Ecore_Win32_Cursor_Shape shape)
 {
    Ecore_Win32_Cursor *cursor = NULL;
@@ -327,7 +327,7 @@ ecore_win32_cursor_shaped_new(Ecore_Win32_Cursor_Shape shape)
  *
  * @since 1.16
  */
-EAPI const Ecore_Win32_Cursor *
+ECORE_WIN32_API const Ecore_Win32_Cursor *
 ecore_win32_cursor_x11_shaped_get(Ecore_Win32_Cursor_X11_Shape shape)
 {
    INF("getting X11 shaped cursor");
@@ -349,7 +349,7 @@ ecore_win32_cursor_x11_shaped_get(Ecore_Win32_Cursor_X11_Shape shape)
  * ecore_win32_cursor_new(). @p width and @p height are buffers that
  * will be filled with the correct size. They can be @c NULL.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_cursor_size_get(int *width, int *height)
 {
    INF("geting size cursor");
@@ -358,7 +358,7 @@ ecore_win32_cursor_size_get(int *width, int *height)
    if (*height) *height = GetSystemMetrics(SM_CYCURSOR);
 }
 
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_cursor_show(Eina_Bool show)
 {
    INF("show cursor");

--- a/src/lib/ecore_win32/ecore_win32_dnd.c
+++ b/src/lib/ecore_win32/ecore_win32_dnd.c
@@ -62,7 +62,7 @@ static HANDLE DataToHandle(const char *data, int size)
  * When the Drag and Drop module is not used anymore, call
  * ecore_win32_dnd_shutdown() to shut down the module.
  */
-EAPI int
+ECORE_WIN32_API int
 ecore_win32_dnd_init()
 {
    HRESULT res;
@@ -95,7 +95,7 @@ ecore_win32_dnd_init()
  * been called the same number of times than ecore_win32_dnd_init(). In that case
  * it shut down the module.
  */
-EAPI int
+ECORE_WIN32_API int
 ecore_win32_dnd_shutdown()
 {
    _ecore_win32_dnd_init_count--;
@@ -120,7 +120,7 @@ ecore_win32_dnd_shutdown()
  * @c 0, it is set to the length (as strlen()) of @p data. On success the
  * function returns @c EINA_TRUE, otherwise it returns @c EINA_FALSE.
  */
-EAPI Eina_Bool
+ECORE_WIN32_API Eina_Bool
 ecore_win32_dnd_begin(const char *data,
                       int         size)
 {
@@ -191,7 +191,7 @@ ecore_win32_dnd_begin(const char *data,
  * the function returns @c EINA_FALSE. On success, it returns @c EINA_TRUE,
  * otherwise it returns @c EINA_FALSE.
  */
-EAPI Eina_Bool
+ECORE_WIN32_API Eina_Bool
 ecore_win32_dnd_register_drop_target(Ecore_Win32_Window                 *window,
                                      Ecore_Win32_Dnd_DropTarget_Callback callback)
 {
@@ -214,7 +214,7 @@ ecore_win32_dnd_register_drop_target(Ecore_Win32_Window                 *window,
  * This function unregister a Drop operation on @p window. If
  * @p window is @c NULL, the function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_dnd_unregister_drop_target(Ecore_Win32_Window *window)
 {
    Ecore_Win32_Window *wnd = (Ecore_Win32_Window *)window;

--- a/src/lib/ecore_win32/ecore_win32_event.c
+++ b/src/lib/ecore_win32/ecore_win32_event.c
@@ -12,8 +12,8 @@
 
 #include <evil_private.h> /* evil_utf16_to_utf8() */
 #include <Eina.h>
-#include <Ecore.h>
-#include <Ecore_Input.h>
+//#include <Ecore.h>
+//#include <Ecore_Input.h>
 
 #include "Ecore_Win32.h"
 #include "ecore_win32_private.h"

--- a/src/lib/ecore_win32/ecore_win32_monitor.c
+++ b/src/lib/ecore_win32/ecore_win32_monitor.c
@@ -219,7 +219,7 @@ ecore_win32_monitor_update(int d)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI Eina_Iterator *
+ECORE_WIN32_API Eina_Iterator *
 ecore_win32_monitors_get(void)
 {
    return eina_list_iterator_new(ecore_win32_monitors);

--- a/src/lib/ecore_win32/ecore_win32_window.c
+++ b/src/lib/ecore_win32/ecore_win32_window.c
@@ -447,7 +447,7 @@ ecore_win32_window_drag(Ecore_Win32_Window *w, int ptx, int pty)
  * title bar). This function returns a newly created window on
  * success, and @c NULL on failure.
  */
-EAPI Ecore_Win32_Window *
+ECORE_WIN32_API Ecore_Win32_Window *
 ecore_win32_window_new(Ecore_Win32_Window *parent,
                        int                 x,
                        int                 y,
@@ -475,7 +475,7 @@ ecore_win32_window_new(Ecore_Win32_Window *parent,
  * This function is the same than ecore_win32_window_override_new()
  * but the returned window is borderless.
  */
-EAPI Ecore_Win32_Window *
+ECORE_WIN32_API Ecore_Win32_Window *
 ecore_win32_window_override_new(Ecore_Win32_Window *parent,
                                 int                 x,
                                 int                 y,
@@ -498,7 +498,7 @@ ecore_win32_window_override_new(Ecore_Win32_Window *parent,
  * This function frees @p window. If @p window is @c NULL, this
  * function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_free(Ecore_Win32_Window *window)
 {
    if (!window) return;
@@ -522,7 +522,7 @@ ecore_win32_window_free(Ecore_Win32_Window *window)
  *
  * @note The returned value is of type HWND.
  */
-EAPI void *
+ECORE_WIN32_API void *
 ecore_win32_window_hwnd_get(Ecore_Win32_Window *window)
 {
    if (!window) return NULL;
@@ -573,7 +573,7 @@ ecore_win32_window_configure(Ecore_Win32_Window        *window,
  * and @p y. If @p window is @c NULL, or if it is fullscreen, or on
  * error, this function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_move(Ecore_Win32_Window *window,
                         int                 x,
                         int                 y)
@@ -611,7 +611,7 @@ ecore_win32_window_move(Ecore_Win32_Window *window,
  * If @p window is @c NULL, or if it is fullscreen, or on error, this
  * function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_resize(Ecore_Win32_Window *window,
                           int                 width,
                           int                 height)
@@ -675,7 +675,7 @@ ecore_win32_window_resize(Ecore_Win32_Window *window,
  * and @p y and the new @p width and @p height. If @p window is @c NULL,
  * or if it is fullscreen, or on error, this function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_move_resize(Ecore_Win32_Window *window,
                                int                 x,
                                int                 y,
@@ -734,7 +734,7 @@ ecore_win32_window_move_resize(Ecore_Win32_Window *window,
  * buffers are not @c NULL, they will be filled with respectively 0,
  * 0, the size of the screen and the height of the screen.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_geometry_get(Ecore_Win32_Window *window,
                                 int                *x,
                                 int                *y,
@@ -804,7 +804,7 @@ ecore_win32_window_geometry_get(Ecore_Win32_Window *window,
  * @c NULL, they will be filled with respectively the size of the screen
  * and the height of the screen.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_get(Ecore_Win32_Window *window,
                             int                *width,
                             int                *height)
@@ -844,7 +844,7 @@ ecore_win32_window_size_get(Ecore_Win32_Window *window,
  * and *p min_height. If @p window is @c NULL, this functions does
  * nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_min_set(Ecore_Win32_Window *window,
                                 int                 min_width,
                                 int                 min_height)
@@ -880,7 +880,7 @@ ecore_win32_window_size_min_set(Ecore_Win32_Window *window,
  * @p min_width and *p min_height. They both can be @c NULL. If
  * @p window is @c NULL, this functions does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_min_get(Ecore_Win32_Window *window,
                                 int                *min_width,
                                 int                *min_height)
@@ -909,7 +909,7 @@ ecore_win32_window_size_min_get(Ecore_Win32_Window *window,
  * and *p max_height. If @p window is @c NULL, this functions does
  * nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_max_set(Ecore_Win32_Window *window,
                                 int                 max_width,
                                 int                 max_height)
@@ -937,7 +937,7 @@ ecore_win32_window_size_max_set(Ecore_Win32_Window *window,
  * @p max_width and *p max_height. They both can be @c NULL. If
  * @p window is @c NULL, this functions does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_max_get(Ecore_Win32_Window *window,
                                 int                *max_width,
                                 int                *max_height)
@@ -966,7 +966,7 @@ ecore_win32_window_size_max_get(Ecore_Win32_Window *window,
  * and *p base_height. If @p window is @c NULL, this functions does
  * nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_base_set(Ecore_Win32_Window *window,
                                  int                 base_width,
                                  int                 base_height)
@@ -994,7 +994,7 @@ ecore_win32_window_size_base_set(Ecore_Win32_Window *window,
  * @p base_width and *p base_height. They both can be @c NULL. If
  * @p window is @c NULL, this functions does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_base_get(Ecore_Win32_Window *window,
                                  int                *base_width,
                                  int                *base_height)
@@ -1023,7 +1023,7 @@ ecore_win32_window_size_base_get(Ecore_Win32_Window *window,
  * and *p step_height. If @p window is @c NULL, this functions does
  * nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_step_set(Ecore_Win32_Window *window,
                                  int                 step_width,
                                  int                 step_height)
@@ -1051,7 +1051,7 @@ ecore_win32_window_size_step_set(Ecore_Win32_Window *window,
  * @p step_width and *p step_height. They both can be @c NULL. If
  * @p window is @c NULL, this functions does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_size_step_get(Ecore_Win32_Window *window,
                                  int                *step_width,
                                  int                *step_height)
@@ -1077,7 +1077,7 @@ ecore_win32_window_size_step_get(Ecore_Win32_Window *window,
  * This function shows @p window. If @p window is @c NULL, or on
  * error, this function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_show(Ecore_Win32_Window *window)
 {
    if (!window) return;
@@ -1100,7 +1100,7 @@ ecore_win32_window_show(Ecore_Win32_Window *window)
  * This function hides @p window. If @p window is @c NULL, or on
  * error, this function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_hide(Ecore_Win32_Window *window)
 {
    if (!window) return;
@@ -1118,7 +1118,7 @@ ecore_win32_window_hide(Ecore_Win32_Window *window)
  * This function places @p window at the top of the Z order. If
  * @p window is @c NULL, this function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_raise(Ecore_Win32_Window *window)
 {
    if (!window) return;
@@ -1141,7 +1141,7 @@ ecore_win32_window_raise(Ecore_Win32_Window *window)
  * This function places @p window at the bottom of the Z order. If
  * @p window is @c NULL, this function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_lower(Ecore_Win32_Window *window)
 {
    if (!window) return;
@@ -1166,7 +1166,7 @@ ecore_win32_window_lower(Ecore_Win32_Window *window)
  * is @c NULL, or if @p title is @c NULL or empty, or on error, this
  * function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_title_set(Ecore_Win32_Window *window,
                              const char         *title)
 {
@@ -1190,7 +1190,7 @@ ecore_win32_window_title_set(Ecore_Win32_Window *window,
  * This function gives the focus to @p window. If @p window is
  * @c NULL, this function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_focus(Ecore_Win32_Window *window)
 {
    if (!window) return;
@@ -1217,7 +1217,7 @@ ecore_win32_window_focus(Ecore_Win32_Window *window)
  *
  * @note The returned value is of type HWND.
  */
-EAPI void *
+ECORE_WIN32_API void *
 ecore_win32_window_focus_get(void)
 {
    HWND focused;
@@ -1246,7 +1246,7 @@ ecore_win32_window_focus_get(void)
  * (like iconifying the window while it is already iconified), this function
  * does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_iconified_set(Ecore_Win32_Window *window,
                                  Eina_Bool           on)
 {
@@ -1274,7 +1274,7 @@ ecore_win32_window_iconified_set(Ecore_Win32_Window *window,
  * change (like setting to borderless while the window has no border), this
  * function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_borderless_set(Ecore_Win32_Window *window,
                                   Eina_Bool           on)
 {
@@ -1350,7 +1350,7 @@ ecore_win32_window_borderless_set(Ecore_Win32_Window *window,
  * does not change (like setting to fullscreen while the window is already
  * fullscreen), this function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_fullscreen_set(Ecore_Win32_Window *window,
                                   Eina_Bool           on)
 {
@@ -1449,7 +1449,7 @@ ecore_win32_window_fullscreen_set(Ecore_Win32_Window *window,
  * @see ecore_win32_cursor_shaped_new()
  * @see ecore_win32_cursor_x11_shaped_new()
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_cursor_set(Ecore_Win32_Window *window,
                               Ecore_Win32_Cursor *cursor)
 {
@@ -1472,7 +1472,7 @@ ecore_win32_window_cursor_set(Ecore_Win32_Window *window,
  * states of size @p num. If @p window or @p state are @c NULL, or if
  * @p num is less or equal than 0, the function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_state_set(Ecore_Win32_Window       *window,
                              Ecore_Win32_Window_State *state,
                              unsigned int              num)
@@ -1545,7 +1545,7 @@ ecore_win32_window_state_set(Ecore_Win32_Window       *window,
  *
  * @since 1.20
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_state_get(Ecore_Win32_Window        *window,
                              Ecore_Win32_Window_State **state,
                              unsigned int              *num)
@@ -1636,7 +1636,7 @@ ecore_win32_window_state_get(Ecore_Win32_Window        *window,
  * #ECORE_WIN32_WINDOW_STATE_FULLSCREEN. If @p window is @c NULL, the
  * function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_state_request_send(Ecore_Win32_Window      *window,
                                       Ecore_Win32_Window_State state,
                                       unsigned int             set)
@@ -1777,7 +1777,7 @@ ecore_win32_window_state_request_send(Ecore_Win32_Window      *window,
  * This function sets the type of @p window to @p type. If
  * @p window is @c NULL, the function does nothing.
  */
-EAPI void
+ECORE_WIN32_API void
 ecore_win32_window_type_set(Ecore_Win32_Window      *window,
                             Ecore_Win32_Window_Type  type)
 {

--- a/src/lib/ecore_win32/meson.build
+++ b/src/lib/ecore_win32/meson.build
@@ -25,7 +25,7 @@ if sys_windows == true
       dependencies: ecore_win32_deps + ecore_win32_pub_deps,
       include_directories : config_dir,
       install: true,
-      c_args : package_c_args,
+      c_args : [package_c_args, '-DEFL_BUILD'],
   )
 
   ecore_win32 = declare_dependency(


### PR DESCRIPTION
Use `ECORE_WIN32_API` instead of `EAPI` and comment `Ecore.h` and `Ecore_input.h`