### PR TITLE
eina: Implement the eina_thread_self_id API

### DIFF
--- a/src/lib/eina/eina_inline_thread_posix.x
+++ b/src/lib/eina/eina_inline_thread_posix.x
@@ -18,6 +18,14 @@
 
 #include "eina_thread_posix.h"
 
+#ifdef HAVE_PTHREAD_NP_H
+#include <pthread_np.h>
+#endif
+
+#ifdef __linux__
+#include <sys/types.h>
+#endif
+
 /**
  * @def EINA_THREAD_CLEANUP_PUSH(cleanup, data)
  *
@@ -165,6 +173,18 @@ static inline Eina_Thread
 _eina_thread_self(void)
 {
    return (Eina_Thread)pthread_self();
+}
+
+static inline Eina_ThreadId
+_eina_thread_self_id(void)
+{
+#if defined HAVE_PTHREAD_GETTHREADID_NP
+    return pthread_getthreadid_np();
+#elif defined __linux__
+    return gettid();
+#else
+    return (Eina_ThreadId) pthread_self();
+#endif
 }
 
 static inline void

--- a/src/lib/eina/eina_inline_thread_win32.x
+++ b/src/lib/eina/eina_inline_thread_win32.x
@@ -120,6 +120,12 @@ _eina_thread_self(void)
    return ret;
 }
 
+static inline Eina_ThreadId
+_eina_thread_self_id(void)
+{
+    return GetCurrentThreadId();
+}
+
 static inline Eina_Bool
 _eina_thread_name_set(Eina_Thread thread, char *buf)
 {

--- a/src/lib/eina/eina_thread.c
+++ b/src/lib/eina/eina_thread.c
@@ -48,6 +48,12 @@ eina_thread_self(void)
    return _eina_thread_self();
 }
 
+EINA_API Eina_ThreadId
+eina_thread_self_id(void)
+{
+   return _eina_thread_self_id();
+}
+
 EINA_API Eina_Bool
 eina_thread_equal(Eina_Thread t1, Eina_Thread t2)
 {
@@ -176,16 +182,3 @@ eina_thread_shutdown(void)
    return EINA_TRUE;
 }
 
-#ifdef _WIN32
-DWORD
-eina_thread_self_id(void)
-{
-   return  GetCurrentThreadId();
-}
-
-DWORD
-eina_thread_id(Eina_Thread t)
-{
-   return  GetThreadId(t.handle);
-}
-#endif

--- a/src/lib/eina/eina_thread.h
+++ b/src/lib/eina/eina_thread.h
@@ -79,6 +79,18 @@ typedef enum _Eina_Thread_Priority
 EINA_API Eina_Thread eina_thread_self(void) EINA_WARN_UNUSED_RESULT;
 
 /**
+ * @brief Returns an integral compatible identifier of the current thread.
+ *
+ * Contrary to @eina_self_thread, this function returns an indentifier that
+ * is an integral type. It means you can compare it with the == operator and
+ * cast it to an integer type.
+ *
+ * @return integral identifier of current thread.
+ * @since 1.25
+ */
+EINA_API Eina_ThreadId eina_thread_self_id(void) EINA_WARN_UNUSED_RESULT;
+
+/**
  * @brief Checks if two thread identifiers are the same.
  * @param[in] t1 first thread identifier to compare.
  * @param[in] t2 second thread identifier to compare.

--- a/src/lib/eina/eina_thread_posix.h
+++ b/src/lib/eina/eina_thread_posix.h
@@ -46,4 +46,12 @@ typedef uintptr_t Eina_Thread;
  * Type for a generic thread.
  */
 
+#if defined HAVE_PTHREAD_GETTHREADID_NP
+typedef int Eina_ThreadId;
+#elif defined __linux__
+typedef pid_t Eina_ThreadId;
+#else
+typedef size_t EinaThreadId;
+#endif
+
 #endif

--- a/src/lib/eina/eina_thread_win32.h
+++ b/src/lib/eina/eina_thread_win32.h
@@ -59,7 +59,6 @@ typedef struct _Eina_Thread
    struct _Eina_ThreadData *data;
 } Eina_Thread;
 
-EINA_API DWORD eina_thread_self_id(void);
-EINA_API DWORD eina_thread_id(Eina_Thread t);
+typedef DWORD Eina_ThreadId;
 
 #endif

--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -361,6 +361,13 @@ if sys_osx == true
    endif
 endif
 
+if cc.has_header('pthread_np.h')
+  cc.set('HAVE_PTHREAD_H', 1)
+  if cc.has_function('pthread_getthreadid_np', prefix: '#include <pthread_np.h>')
+    cc.set('HAVE_PTHREAD_GETTHREADID_NP', 1)
+  endif
+endif
+
 if host_machine.endian() == 'big'
    eina_config.set('EINA_HAVE_WORDS_BIGENDIAN', '1')
 endif


### PR DESCRIPTION
eina_self_thread returns the type Eina_Thread, which is not guaranteed
to return a type comparable with the == operator or convertable to a
integral type.

This commits introduces the eina_thread_self_id API, which returns a
thread identifier compatible to an integral type.