### PR TITLE
windows: fix eina_file_map_new

### DIFF
--- a/src/lib/eina/eina_file_common.h
+++ b/src/lib/eina/eina_file_common.h
@@ -116,6 +116,9 @@ struct _Eina_File
 struct _Eina_File_Map
 {
    void *map;  /**< A pointer to the mapped region */
+#ifdef _WIN32
+   void *pret; /**< The end pointer returned to file_map_new caller */
+#endif
 
    unsigned long int offset;  /**< The offset in the file */
    unsigned long int length;  /**< The length of the region */


### PR DESCRIPTION
 On Windows, the file map offset must be a multiple of the system allocation granularity.

We handle the alignment requirement internally. We round down the given offset to the next
aligned value. We then map the aligned offset plus the offset difference plus the map length.
We adjust the returned pointer value to the original offset and store the original pointer inside
the file map structure for use by the unmap function.