### PR TITLE
add missing "!" to thread inequality

### DIFF
--- a/src/lib/eo/eo.c
+++ b/src/lib/eo/eo.c
@@ -1458,7 +1458,7 @@ eo_class_free(_Efl_Class *klass)
    void *data;
    Eina_Thread self = eina_thread_self();
 
-   if (eina_thread_equal(self, _efl_object_main_thread) &&
+   if (!eina_thread_equal(self, _efl_object_main_thread) &&
        !eina_thread_equal(self, klass->construction_thread))
       CRI("Calling class deconstructor from thread that did not call constructor and is not main thread!\n"
           "This will probably crash!");


### PR DESCRIPTION
[By comparing ](https://github.com/expertisesolutions/efl/compare/devs/felipealmeida/eolian-test...devs/cauebs/eo-build) we can see that the original code was:
```
   if ((self != _efl_object_main_thread) &&	
       (self != klass->construction_thread))	
```
So the desired behavior would be:
```
   if (!eina_thread_equal(self, _efl_object_main_thread) &&
       !eina_thread_equal(self, klass->construction_thread))
```