### PR TITLE
eina_test_file.c: Do not check errno on success

### DIFF
--- a/src/tests/eina/eina_test_file.c
+++ b/src/tests/eina/eina_test_file.c
@@ -790,7 +790,6 @@ EFL_START_TEST(eina_test_file_mktemp)
         fd = eina_file_mkstemp(patterns[k], &tmpfile);
         ck_assert(fd >= 0);
         ck_assert(!!tmpfile);
-        ck_assert_msg(!errno, "ERROR(%s): %s\n", patterns[k], strerror(errno));
         file = eina_file_open(tmpfile, EINA_FALSE);
         fail_if(!file);
         eina_file_close(file);


### PR DESCRIPTION
errno is documented to only contains a valid value for mkstemp if the
function fails.