### PR TITLE
Make #89 compilation process achieve the same point of native-windows on Linux

### DIFF
--- a/src/lib/ecore/meson.build
+++ b/src/lib/ecore/meson.build
@@ -193,10 +193,6 @@ if get_option('g-mainloop') == true
   endif
 endif
 
-if get_option('systemd')
-  ecore_deps += systemd
-endif
-
 ecore_lib = library('ecore',
     ecore_src, pub_eo_file_target,
     dependencies: ecore_pub_deps + [ecore_deps, ecore_ext_deps],


### PR DESCRIPTION
The errors were related to:
- Lua was disabled: by just re-enabling it could go further;
- `master` removed the `systemd` option from `ecore`;