### PR TITLE
Linux Build: pipe function were not available at a linux build

### DIFF
--- a/src/lib/eina/eina_debug_timer.c
+++ b/src/lib/eina/eina_debug_timer.c
@@ -42,6 +42,7 @@
 #include "eina_thread.h"
 #include "eina_debug.h"
 #include "eina_debug_private.h"
+#include "eina_pipe.h"
 
 static Eina_Spinlock _lock;
 

--- a/src/lib/eina/eina_pipe.h
+++ b/src/lib/eina/eina_pipe.h
@@ -1,0 +1,17 @@
+#ifndef EINA_PIPE_H
+#define EINA_PIPE_H
+
+# ifdef _WIN32
+#  define pipe_write(fd, buffer, size) send((fd), (char *)(buffer), size, 0)
+#  define pipe_read(fd, buffer, size)  recv((fd), (char *)(buffer), size, 0)
+#  define pipe_close(fd)               closesocket(fd)
+#  define PIPE_FD_ERROR   SOCKET_ERROR
+# else
+#  include <unistd.h>
+#  define pipe_write(fd, buffer, size) write((fd), buffer, size)
+#  define pipe_read(fd, buffer, size)  read((fd), buffer, size)
+#  define pipe_close(fd)               close(fd)
+#  define PIPE_FD_ERROR   -1
+# endif // _WIN32
+
+#endif /* EINA_PIPE_H */

--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -110,7 +110,8 @@ public_sub_headers = [
 'eina_slstr.h',
 'eina_vpath.h',
 'eina_abstract_content.h',
-'eina_fnmatch.h'
+'eina_fnmatch.h',
+'eina_pipe.h',
 ]
 
 public_headers = [

--- a/src/lib/evil/evil_unistd.h
+++ b/src/lib/evil/evil_unistd.h
@@ -20,7 +20,7 @@
 
 #define execvp _ucrt_execvp  // overriding execvp below
 #include <process.h> // for _execvp (but not execvp), getpid
-#undef execvp 
+#undef execvp
 EVIL_API int execvp(const char *file, char *const argv[]);
 
 /* Values for the second argument to access.  These may be OR'd together.  */
@@ -28,19 +28,8 @@ EVIL_API int execvp(const char *file, char *const argv[]);
 #define W_OK    2       /* Test for write permission.  */
 #define X_OK    0       /* execute permission, originally '1', just a bypass here*/
 #define F_OK    0       /* Test for existence.  */
-
-# define pipe_write(fd, buffer, size) send((fd), (char *)(buffer), size, 0)
-# define pipe_read(fd, buffer, size)  recv((fd), (char *)(buffer), size, 0)
-# define pipe_close(fd)               closesocket(fd)
-# define PIPE_FD_ERROR   SOCKET_ERROR
-
 #else
 #include <unistd.h>
-
-# define pipe_write(fd, buffer, size) write((fd), buffer, size)
-# define pipe_read(fd, buffer, size)  read((fd), buffer, size)
-# define pipe_close(fd)               close(fd)
-# define PIPE_FD_ERROR   -1
 #endif // _WIN32
 
 /*


### PR DESCRIPTION
As pipe functions were defined at `evil` they were not available to any
other library. Now they are defined at `eina`.

You can have a look at tests with Travis-CI at my [fork](https://github.com/Coquinho/efl/runs/735172415).

Depends on #104 