### PR TITLE
windows: Fix tests cases in eina_test_lock.c

### DIFF
--- a/src/lib/eina/eina_inline_lock_win32.x
+++ b/src/lib/eina/eina_inline_lock_win32.x
@@ -300,6 +300,10 @@ _eina_condition_wait_ex(Eina_Condition *cond, DWORD timeout)
           {
              EINA_LOCK_ABORT_DEBUG((int) err, cond_wait, cond);
           }
+        else if (ERROR_TIMEOUT == err)
+          {
+             eina_error_set(ETIMEDOUT);
+          }
      }
 
 #ifdef EINA_HAVE_DEBUG_THREADS

--- a/src/tests/eina/eina_test_lock.c
+++ b/src/tests/eina/eina_test_lock.c
@@ -60,7 +60,14 @@ clock_gettime(int mode, struct timespec* ts)
 int
 clock_gettime(int mode, struct timespec* ts)
 {
-// TODO: implement clock_gettime() for _WIN32.
+   FILETIME sys_time;
+   ULARGE_INTEGER li_sys_time;
+
+   GetSystemTimeAsFileTime(&sys_time);
+   li_sys_time.u.LowPart = sys_time.dwLowDateTime;
+   li_sys_time.u.HighPart = sys_time.dwHighDateTime;
+   ts->tv_sec = li_sys_time.QuadPart / 10000000UL;
+   ts->tv_nsec = (li_sys_time.QuadPart % 10000000UL) * 100UL;
    return 0;
 }
 


### PR DESCRIPTION
We implement the `clock_gettime` for Windows and set eina error when the condition variable wait times out.