### PR TITLE
Linux Build: Resolve implicity declaration at `eina_inline_lock_posix.x`

### DIFF
--- a/src/lib/eina/eina_inline_lock_posix.x
+++ b/src/lib/eina/eina_inline_lock_posix.x
@@ -156,6 +156,9 @@ EINA_API extern pthread_mutex_t _eina_tracking_lock;
 EINA_API extern Eina_Inlist *_eina_tracking;
 #endif
 
+EINA_API Eina_Lock_Result eina_lock_take_try(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_spinlock_take_try(Eina_Spinlock *spinlock);
+
 static inline Eina_Bool
 _eina_lock_new(Eina_Lock *mutex, Eina_Bool recursive)
 {


### PR DESCRIPTION
`eina_lock_take_try` and `eina_spinlock_take_try` were not defined for
use at `eina_inline_lock_posix.x` causing some implicity declaration of
those.