### PR TITLE
Remove unnecessary additional argument

### DIFF
--- a/src/lib/eina/eina_main.c
+++ b/src/lib/eina/eina_main.c
@@ -319,7 +319,7 @@ eina_init(void)
      }
 
 #ifdef EINA_HAVE_DEBUG_THREADS
-   eina_lock_take(&_eina_tracking_lock, NULL);
+   eina_lock_take(&_eina_tracking_lock);
 
    if (getenv("EINA_DEBUG_THREADS"))
      _eina_threads_debug = atoi(getenv("EINA_DEBUG_THREADS"));


### PR DESCRIPTION
`eina_lock_take` was reciving an aditional `NULL` argumment causing an too many arguments error:
```
  ../src/lib/eina/eina_main.c:322:4: error: too many arguments to function 'eina_lock_take'
    322 |    eina_lock_take(&_eina_tracking_lock, NULL);
        |    ^~~~~~~~~~~~~~
  In file included from ../src/lib/eina/eina_main.c:43:
  ../src/lib/eina/eina_lock.h:169:27: note: declared here
    169 | EINA_API Eina_Lock_Result eina_lock_take(Eina_Lock *mutex);
        |                           ^~~~~~~~~~~~~~

```
~Depends on #110~
