### PR TITLE
windows: Implement delete callback funcionality for tls

### DIFF
--- a/src/lib/eina/eina_tls_win32.c
+++ b/src/lib/eina/eina_tls_win32.c
@@ -1,0 +1,58 @@
+#include "eina_hash.h"
+#include "eina_lock.h"
+
+Eina_Hash *_eina_tls_map;
+Eina_Lock _eina_tls_map_lock;
+
+void
+_eina_free_tls_value(Eina_TLS *key, void *val)
+{
+   if (val)
+     {
+        Eina_TLS_Delete_Cb delete_cb = eina_hash_find(_eina_tls_map, key);
+        if (delete_cb) delete_cb(val);
+        TlsSetValue(*key, NULL);
+     }
+}
+
+static Eina_Bool
+_eina_tls_hash_foreach_cb(const Eina_Hash *h, const void *key, void *cb, void *fdata)
+{
+    void *data = TlsGetValue(*(DWORD *) key);
+    if (data)
+      {
+         Eina_TLS_Delete_Cb delete_cb = (Eina_TLS_Delete_Cb) cb;
+         delete_cb(data);
+         TlsSetValue(*(DWORD *) key, NULL);
+      }
+    return EINA_TRUE;
+}
+
+BOOL WINAPI
+DllMain(HINSTANCE inst, DWORD reason, LPVOID reserved)
+{
+    switch (reason)
+      {
+        case DLL_PROCESS_ATTACH:
+            _eina_tls_map = eina_hash_int32_new(NULL);
+            if (!eina_lock_new(&_eina_tls_map_lock))
+              {
+                  eina_hash_free(_eina_tls_map);
+                  _eina_tls_map = NULL;
+                  return FALSE;
+              }
+            break;
+        case DLL_PROCESS_DETACH:
+            eina_hash_foreach(_eina_tls_map, _eina_tls_hash_foreach_cb, NULL);
+            eina_lock_free(&_eina_tls_map_lock);
+            eina_hash_free(_eina_tls_map);
+            break;
+        case DLL_THREAD_DETACH:
+            eina_lock_take(&_eina_tls_map_lock);
+            eina_hash_foreach(_eina_tls_map, _eina_tls_hash_foreach_cb, NULL);
+            eina_lock_release(&_eina_tls_map_lock);
+            break;
+      }
+
+    return TRUE;
+}

--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -202,6 +202,7 @@ if sys_windows == true
   sources += 'eina_file_win32.c'
   sources += 'eina_sched_win32.c'
   sources += 'eina_fnmatch.c'
+  sources += 'eina_tls_win32.c'
   public_sub_headers += 'eina_inline_lock_win32.x'
 else
   public_sub_headers += 'eina_thread_posix.h'


### PR DESCRIPTION
The implementation makes use of the DLL_THREAD/PROCESS_DETACH to call
delete_cb when the thread exits.