### PR TITLE
Resolve wrong variable array length conversion

### DIFF
--- a/src/tests/efl_check.h
+++ b/src/tests/efl_check.h
@@ -136,7 +136,7 @@ _efl_test_option_disp(int argc, char **argv, const Efl_Test_Case *etc)
           }
         else if (strcmp(argv[i], "--valgrind") == 0)
           {
-	     char *nav = (char *)malloc(sizeof(char) * (argc + 3));
+	           char **nav = malloc(sizeof(char*) * (argc + 3));
              int j, k;
 
              nav[0] = "valgrind";


### PR DESCRIPTION
As there is no variable array length with `msvc` it was changed to use
`malloc`, but was not correctly changed as nav is a char array.

We can see at `a5a587510e7` that the original definition was:
```
   char *nav = (char *)malloc(sizeof(char) * (argc + 3));
```
Which is not equivalent to our current implementation.