### PR TITLE
Configure Travis-CI to work on expertise/efl

### DIFF
--- a/.ci/ci-build-test.sh
+++ b/.ci/ci-build-test.sh
@@ -8,12 +8,4 @@ if [ "$1" = "codecov" ] || [ "$1" = "coverity" ] || [ "$1" = "mingw" ] || [ "$1"
 fi
 
 travis_fold compile_test compile_test
-if [ "$DISTRO" != "" ] ; then
-  docker exec --env EIO_MONITOR_POLL=1 $(cat $HOME/cid) .ci/build-example.sh
-elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-  exit 0
-  #FIXME: we don't install efl_ui.pc on osx?
-  export PATH="$(brew --prefix gettext)/bin:$PATH"
-  .ci/build-example.sh
-fi
 travis_endfold compile_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,6 @@ env:
 
 jobs:
   include:
-    - os: osx
-    - os: linux
-      env: DISTRO=Fedora32-mingw CI_BUILD_TYPE=mingw
     - os: linux
       env: DISTRO=Fedora32 CI_BUILD_TYPE=options-enabled
     - os: linux
@@ -126,7 +123,6 @@ script:
   - .ci/ci-make-install.sh "$CI_BUILD_TYPE"
   - .ci/ci-make-benchmark.sh "$CI_BUILD_TYPE"
   - .ci/ci-make-check.sh "$CI_BUILD_TYPE"
-  - .ci/ci-exactness.sh "$CI_BUILD_TYPE"
   - .ci/ci-make-distcheck.sh "$CI_BUILD_TYPE"
   - .ci/ci-build-test.sh "$CI_BUILD_TYPE"
 
@@ -139,15 +135,3 @@ before_cache:
        else
          mv $HOME/Library/Caches/Homebrew $HOME/cachedir/Homebrew
        fi
-
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#edevelop"
-    on_success: change
-    on_failure: always
-    template:
-      - "TravisCI build %{build_number} in branch %{branch}: %{result} - %{message} (%{elapsed_time})"
-      - "Commit: %{commit_subject} (%{commit}) from %{author}"
-      - "Change view : %{compare_url}"
-      - "Build details : %{build_url}"


### PR DESCRIPTION
- Remove notification;
- Remove `.ci/ci-exactness.sh` as it is useless at our stage of the windows port;
- Stop building examples;
- Disable OSX and Fedora+mingw builds;

Depends on #112
[Travis-CI build details for this PR](https://travis-ci.com/github/Coquinho/efl/builds/169839436) (at my fork)
OBS: Travis-CI is not activated to our repo yet. We should only activate it after this PR is merged and *every* branch should be rebased, otherwise, it will use a different CI configuration and send notifications to #edevelop at IRC at almost every push. 