### PR TITLE
OSX Build: Resolve typo of type Eina_ThreadId

### DIFF
--- a/src/lib/eina/eina_thread_posix.h
+++ b/src/lib/eina/eina_thread_posix.h
@@ -51,7 +51,7 @@ typedef int Eina_ThreadId;
 #elif defined __linux__
 typedef pid_t Eina_ThreadId;
 #else
-typedef size_t EinaThreadId;
+typedef size_t Eina_ThreadId;
 #endif
 
 #endif


### PR DESCRIPTION
There was a typo at `eina_thread_posix.h` `Eina_ThreadId` definition.