### PR TITLE
OSX build: Remove double definition functions

### DIFF
--- a/src/lib/eina/eina_inline_lock_posix.x
+++ b/src/lib/eina/eina_inline_lock_posix.x
@@ -716,9 +716,6 @@ _eina_barrier_wait(Eina_Barrier *barrier)
 #endif
 }
 
-EAPI Eina_Bool _eina_barrier_new(Eina_Barrier *barrier, int needed);
-EAPI void      _eina_barrier_free(Eina_Barrier *barrier);
-
 static inline Eina_Bool
 _eina_spinlock_new(Eina_Spinlock *spinlock)
 {


### PR DESCRIPTION
Remove barrier new/free declarations, as they happen next to its
definition.

Remove double definitions of OSX spinlock functions.