### PR TITLE
Initialize _eina_tracking_lock

### DIFF
--- a/src/lib/eina/eina_main.c
+++ b/src/lib/eina/eina_main.c
@@ -319,7 +319,7 @@ eina_init(void)
      }
 
 #ifdef EINA_HAVE_DEBUG_THREADS
-   eina_lock_take(&_eina_tracking_lock);
+   eina_lock_new(&_eina_tracking_lock);
 
    if (getenv("EINA_DEBUG_THREADS"))
      _eina_threads_debug = atoi(getenv("EINA_DEBUG_THREADS"));


### PR DESCRIPTION
As spotted by @cauebs, `_eina_tracking_lock` isn't initialized. It seems
that while modifying every `pthread` call to an `eina` call we made a
mistake of changing a `pthread_mutex_init` to an `eina_lock_take`
instead of an `eina_lock_init`, we can see this while comparing
[native-windows](https://github.com/expertisesolutions/efl/blob/devs/expertise/native-windows/src/lib/eina/eina_main.c#L322)
`eina_main.c` to
[master's](https://github.com/Enlightenment/efl/blob/master/src/lib/eina/eina_main.c#L319).