### PR TITLE
Add eina_pipe to Eina.h

### DIFF
--- a/src/lib/eina/Eina.h
+++ b/src/lib/eina/Eina.h
@@ -278,6 +278,7 @@ extern "C" {
 #include <eina_vpath.h>
 #include <eina_abstract_content.h>
 #include <eina_fnmatch.h>
+#include <eina_pipe.h>
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
`eina_pipe` wasn't in `Eina.h` so it was inaccessible for other libraries,
which caused `-Wimplicit-function-declaration` at `ecore_anim.c`.
No by including `Eina.h` it should be enabled. 