### PR TITLE
Move EINA_THREAD_CLEANUP{_POP/_PUSH} to eina_thread_<arq>.h

### DIFF
--- a/src/lib/eina/eina_inline_thread_posix.x
+++ b/src/lib/eina/eina_inline_thread_posix.x
@@ -26,69 +26,6 @@
 #include <sys/types.h>
 #endif
 
-/**
- * @def EINA_THREAD_CLEANUP_PUSH(cleanup, data)
- *
- * @brief Pushes a cleanup function to be executed when the thread is
- * canceled.
- *
- * This macro will schedule a function cleanup(data) to be executed if
- * the thread is canceled with eina_thread_cancel() and the thread
- * was previously marked as cancellable with
- * eina_thread_cancellable_set().
- *
- * It @b must be paired with EINA_THREAD_CLEANUP_POP() in the same
- * code block as they will expand to do {} while ()!
- *
- * The cleanup function may also be executed if
- * EINA_THREAD_CLEANUP_POP(EINA_TRUE) is used.
- *
- * @note If the block within EINA_THREAD_CLEANUP_PUSH() and
- *       EINA_THREAD_CLEANUP_POP() returns, the cleanup callback will
- *       @b not be executed! To avoid problems prefer to use
- *       eina_thread_cancellable_run()!
- *
- * @param[in] cleanup The function to execute on cancellation.
- * @param[in] data The context to give to cleanup function.
- *
- * @see eina_thread_cancellable_run()
- *
- * @since 1.19
- */
-#define EINA_THREAD_CLEANUP_PUSH(cleanup, data) \
-  pthread_cleanup_push(cleanup, data)
-
-/**
- * @def EINA_THREAD_CLEANUP_POP(exec_cleanup)
- *
- * @brief Pops a cleanup function to be executed when the thread is
- * canceled.
- *
- * This macro will remove a previously pushed cleanup function, thus
- * if the thread is canceled with eina_thread_cancel() and the thread
- * was previously marked as cancellable with
- * eina_thread_cancellable_set(), that cleanup won't be executed
- * anymore.
- *
- * It @b must be paired with EINA_THREAD_CLEANUP_PUSH() in the same
- * code block as they will expand to do {} while ()!
- *
- * @note If the block within EINA_THREAD_CLEANUP_PUSH() and
- *       EINA_THREAD_CLEANUP_POP() returns, the cleanup callback will
- *       @b not be executed even if exec_cleanup is EINA_TRUE! To
- *       avoid problems prefer to use eina_thread_cancellable_run()!
- *
- * @param[in] exec_cleanup if EINA_TRUE, the function registered with
- *        EINA_THREAD_CLEANUP_PUSH() will be executed.
- *
- * @see eina_thread_cancellable_run()
- *
- * @since 1.19
- */
-#define EINA_THREAD_CLEANUP_POP(exec_cleanup) \
-  pthread_cleanup_pop(exec_cleanup)
-
-
 static inline void *
 _eina_thread_join(Eina_Thread t)
 {

--- a/src/lib/eina/eina_inline_thread_win32.x
+++ b/src/lib/eina/eina_inline_thread_win32.x
@@ -20,9 +20,6 @@
 
 #include "eina_thread_win32.h"
 
-#define EINA_THREAD_CLEANUP_PUSH(cleanup, data)
-#define EINA_THREAD_CLEANUP_POP(exec_cleanup)
-
 static inline void *
 _eina_thread_join(Eina_Thread t)
 {

--- a/src/lib/eina/eina_thread_posix.h
+++ b/src/lib/eina/eina_thread_posix.h
@@ -34,6 +34,71 @@
 #define EINA_THREAD_CANCEL_ASYNCHRONOUS PTHREAD_CANCEL_ASYNCHRONOUS
 #define EINA_THREAD_CANCELED   PTHREAD_CANCELED
 
+/**
+ * @def EINA_THREAD_CLEANUP_PUSH(cleanup, data)
+ *
+ * @brief Pushes a cleanup function to be executed when the thread is
+ * canceled.
+ *
+ * This macro will schedule a function cleanup(data) to be executed if
+ * the thread is canceled with eina_thread_cancel() and the thread
+ * was previously marked as cancellable with
+ * eina_thread_cancellable_set().
+ *
+ * It @b must be paired with EINA_THREAD_CLEANUP_POP() in the same
+ * code block as they will expand to do {} while ()!
+ *
+ * The cleanup function may also be executed if
+ * EINA_THREAD_CLEANUP_POP(EINA_TRUE) is used.
+ *
+ * @note If the block within EINA_THREAD_CLEANUP_PUSH() and
+ *       EINA_THREAD_CLEANUP_POP() returns, the cleanup callback will
+ *       @b not be executed! To avoid problems prefer to use
+ *       eina_thread_cancellable_run()!
+ *
+ * @param[in] cleanup The function to execute on cancellation.
+ * @param[in] data The context to give to cleanup function.
+ *
+ * @see eina_thread_cancellable_run()
+ *
+ * @since 1.19
+ */
+#define EINA_THREAD_CLEANUP_PUSH(cleanup, data) \
+  pthread_cleanup_push(cleanup, data)
+
+/**
+ * @def EINA_THREAD_CLEANUP_POP(exec_cleanup)
+ *
+ * @brief Pops a cleanup function to be executed when the thread is
+ * canceled.
+ *
+ * This macro will remove a previously pushed cleanup function, thus
+ * if the thread is canceled with eina_thread_cancel() and the thread
+ * was previously marked as cancellable with
+ * eina_thread_cancellable_set(), that cleanup won't be executed
+ * anymore.
+ *
+ * It @b must be paired with EINA_THREAD_CLEANUP_PUSH() in the same
+ * code block as they will expand to do {} while ()!
+ *
+ * @note If the block within EINA_THREAD_CLEANUP_PUSH() and
+ *       EINA_THREAD_CLEANUP_POP() returns, the cleanup callback will
+ *       @b not be executed even if exec_cleanup is EINA_TRUE! To
+ *       avoid problems prefer to use eina_thread_cancellable_run()!
+ *
+ * @param[in] exec_cleanup if EINA_TRUE, the function registered with
+ *        EINA_THREAD_CLEANUP_PUSH() will be executed.
+ *
+ * @see eina_thread_cancellable_run()
+ *
+ * @since 1.19
+ */
+#define EINA_THREAD_CLEANUP_POP(exec_cleanup) \
+  pthread_cleanup_pop(exec_cleanup)
+
+
+
+
 #if defined(EINA_HAVE_PTHREAD_AFFINITY) || defined(EINA_HAVE_PTHREAD_SETNAME)
 # ifndef __linux__
 #  include <pthread_np.h>

--- a/src/lib/eina/eina_thread_win32.h
+++ b/src/lib/eina/eina_thread_win32.h
@@ -39,6 +39,9 @@
 #define EINA_THREAD_CANCEL_ASYNCHRONOUS 1
 #define EINA_THREAD_CANCELED   ((void *) -1)
 
+#define EINA_THREAD_CLEANUP_PUSH(cleanup, data)
+#define EINA_THREAD_CLEANUP_POP(exec_cleanup)
+
 struct _Eina_ThreadData
 {
    /*


### PR DESCRIPTION
It seems that a `define` made at .x isn't available outside the file, which
caused some undefined reference at `ecore_thread.c`.
By moving it to `.h` it became visible.