### PR TITLE
Convert malloc

### DIFF
--- a/src/tests/efl_check.h
+++ b/src/tests/efl_check.h
@@ -136,7 +136,7 @@ _efl_test_option_disp(int argc, char **argv, const Efl_Test_Case *etc)
           }
         else if (strcmp(argv[i], "--valgrind") == 0)
           {
-	           char **nav = malloc(sizeof(char*) * (argc + 3));
+	           char **nav = (char **) malloc(sizeof(char*) * (argc + 3));
              int j, k;
 
              nav[0] = "valgrind";


### PR DESCRIPTION
Malloc wasn't being casted, which yielded:
```
../src/tests/eo_cxx/../efl_check.h: In function 'int _efl_test_option_disp(int, char**, const Efl_Test_Case*)':
../src/tests/eo_cxx/../efl_check.h:139:32: error: invalid conversion from 'void*' to 'char**' [-fpermissive]
  139 |             char **nav = malloc(sizeof(char*) * (argc + 3));
      |                          ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                |
      |                                void*
```