### PR TITLE
Linux build: Explicitly add ecore_x dependency to elementary examples

### DIFF
--- a/src/examples/elementary/meson.build
+++ b/src/examples/elementary/meson.build
@@ -123,8 +123,15 @@ examples = [
   'efl_canvas_textblock_obstacles_example'
 ]
 
+examples_deps = [elementary, ecore, eio, m]
+
+if get_option('x11')
+  config_h.set('HAVE_ELEMENTARY_X', '1')
+  examples_deps += ecore_x
+endif
+
 foreach example : examples
-  executable(example, example + '.c', dependencies: [elementary, ecore, eio, m])
+  executable(example, example + '.c', dependencies: examples_deps)
 endforeach
 if get_option('bindings').contains('cxx')
   cxx_examples = [

--- a/src/examples/elementary/win_example.c
+++ b/src/examples/elementary/win_example.c
@@ -1,6 +1,11 @@
 /*
  * gcc -o win_example win_example.c `pkg-config --cflags --libs elementary ecore-x`
  */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #ifdef HAVE_ELEMENTARY_X
 # include <Ecore_X.h>
 #endif


### PR DESCRIPTION
For some reason, `ecore_x` wasn't being set at `elementary` or at least while compiling `win_example.c`, so this PR explicitly adds `ecore_x`.

