### PR TITLE
Configure Travis-CI to work on expertise/efl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,17 +46,8 @@ env:
 
 jobs:
   include:
-    - os: osx
-    - os: linux
-      env: DISTRO=Fedora32-mingw CI_BUILD_TYPE=mingw
-    - os: linux
-      env: DISTRO=Fedora32 CI_BUILD_TYPE=options-enabled
     - os: linux
       env: DISTRO=Fedora32 CI_BUILD_TYPE=options-disabled
-    - os: linux
-      env: DISTRO=Fedora32 CI_BUILD_TYPE=wayland
-    - os: linux
-      env: DISTRO=Fedora32 CI_BUILD_TYPE=default
     - os: linux
       if: type = cron
       env: DISTRO=Fedora32 CI_BUILD_TYPE=release-ready
@@ -139,15 +130,3 @@ before_cache:
        else
          mv $HOME/Library/Caches/Homebrew $HOME/cachedir/Homebrew
        fi
-
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#edevelop"
-    on_success: change
-    on_failure: always
-    template:
-      - "TravisCI build %{build_number} in branch %{branch}: %{result} - %{message} (%{elapsed_time})"
-      - "Commit: %{commit_subject} (%{commit}) from %{author}"
-      - "Change view : %{compare_url}"
-      - "Build details : %{build_url}"


### PR DESCRIPTION
- Remove notification;
- Only enable `option-disable` build (OSX, MinGW, Wayland and default
  builds have been disabled as they don't work for now);

This build compile with these [meson options](https://github.com/expertisesolutions/efl/blob/devs/expertise/native-windows/.ci/ci-configure.sh#L24..#L33):
```
-Daudio=false -Davahi=false -Dx11=false -Dphysics=false -Deeze=false
-Dopengl=none -Deina-magic-debug=false -Dbuild-examples=false
-Dbuild-tests=false  -Dcrypto=gnutls -Dglib=false -Dgstreamer=false
-Dsystemd=false -Dpulseaudio=false  -Dnetwork-backend=connman -Dxinput2=false
-Dtslib=false
-Devas-loaders-disabler=gst,pdf,ps,raw,svg,xcf,bmp,dds,eet,generic,gif,ico,jp2k,json,pmaps,psd,tga,tgv,tiff,wbmp,webp,xpm
-Decore-imf-loaders-disabler=xim,ibus,scim  -Dfribidi=false -Dfontconfig=false
-Dedje-sound-and-video=false -Dembedded-lz4=false -Dlibmount=false -Dv4l2=false
-Delua=true -Dnls=false -Dbindings= -Dlua-interpreter=luajit
-Dnative-arch-optimization=false
```

You can see the [Travis-CI build](https://travis-ci.com/github/Coquinho/efl/builds/171466054) of this branch at my fork.

Depends on #146 

OBS: Travis-CI is not activated to our repo yet. We should only activate it after this PR is merged and *every* branch should be rebased, otherwise, it will use a different CI configuration and send notifications to #edevelop at IRC at almost every push. 