### PR TITLE
Add files to eina public_headers

### DIFF
--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -114,6 +114,7 @@ public_sub_headers = [
 'eina_vpath.h',
 'eina_abstract_content.h',
 'eina_fnmatch.h',
+'eina_pipe.h',
 ]
 
 public_headers = [
@@ -207,6 +208,7 @@ if sys_windows
   )
   public_sub_headers += files(
     'eina_thread_win32.h',
+    'eina_inline_lock_win32.x',
   )
 else
   eina_src += files(
@@ -215,6 +217,7 @@ else
   )
   public_sub_headers += files(
     'eina_thread_posix.h',
+    'eina_inline_lock_posix.x',
   )
 endif
 


### PR DESCRIPTION
`eina_inline_lock_posix.x`, `eina_inline_lock_win32.x` and `eina_pipe.h`
weren't available as `eina` `public_sub_headers` at `meson.build` making
then unavailable when instaling our build.