### PR TITLE
Getting freetype2 from meson wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,8 +100,5 @@ efl_libs.csv
 env.bat
 
 # Subprojects
-subprojects/pcre-*
-subprojects/zlib-*
-subprojects/getopt
-subprojects/packagecache
-subprojects/check*
+subprojects/*
+!subprojects/*.wrap

--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -234,6 +234,11 @@ if sys_windows
 
   # getopt
   getopt = subproject('getopt').get_variable('getopt_dep')
+
+  # freetype2
+  freetype2_project = subproject('freetype2')
+  freetype2 = freetype2_project.get_variable('libfreetype')
+  freetype2_dep = freetype2_project.get_variable('freetype_dep')
 else
   zlib = dependency('zlib')
   if not cc.has_header_symbol('regex.h', 'regcomp')

--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -219,6 +219,9 @@ endif
 # libcheck
 check = dependency('check', fallback : ['check', 'check_dep'])
 
+# freetype2
+freetype2 = dependency('freetype2', fallback : ['freetype2', 'freetype_dep'])
+
 if sys_windows
   # pcre
   pcre_project = subproject('pcre')
@@ -234,11 +237,6 @@ if sys_windows
 
   # getopt
   getopt = subproject('getopt').get_variable('getopt_dep')
-
-  # freetype2
-  freetype2_project = subproject('freetype2')
-  freetype2 = freetype2_project.get_variable('libfreetype')
-  freetype2_dep = freetype2_project.get_variable('freetype_dep')
 else
   zlib = dependency('zlib')
   if not cc.has_header_symbol('regex.h', 'regcomp')

--- a/src/lib/evas/meson.build
+++ b/src/lib/evas/meson.build
@@ -159,9 +159,7 @@ evas_src += files([
 
 evas_src_opt = [ ]
 
-if not sys_windows
-  evas_ext_none_static_deps += dependency('freetype2')
-endif
+evas_ext_none_static_deps += freetype2
 
 if (get_option('fontconfig'))
    config_h.set('HAVE_FONTCONFIG', '1')

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = freetype-2.9.1
+
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz
+source_filename = freetype-2.9.1.tar.gz
+source_hash = ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/freetype2/2.9.1/1/get_zip
+patch_filename = freetype2-2.9.1-1-wrap.zip
+patch_hash = 06222607775e707c6d7b8d21ffdb04c7672f676a18c5ebb9880545130ab0407b

--- a/win32-deps/meson.build
+++ b/win32-deps/meson.build
@@ -1,16 +1,6 @@
 
 if sys_windows
 
-  # Freetype
-  freetype_inc = include_directories('freetype.2.8.0.1/build/native/include/freetype')
-  freetype_lib = static_library('freetype',
-    include_directories: 'freetype.2.8.0.1/build/native/lib/x64/v141/static/Release'
-  )
-  freetype = declare_dependency(
-    link_with: freetype_lib,
-    include_directories: freetype_inc
-  )
-
   # Libjpeg-Turbo
   libjpeg_inc = include_directories('Libjpeg-Turbo.1.5.15/build/native/include')
   libjpeg_lib = static_library('libjpeg', 


### PR DESCRIPTION
Currently freetype2 is get using Nuget, but as freetype2 do exists as a meson wrap, we could be using it to built from sources instead of getting binaries with Nuget.