### PR TITLE
windows: Implement ftruncate

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -437,7 +437,7 @@ endif
 
 subprojects = [
 # name              |   option              | mod  | lib  | bin  | bench | tests | examples | true if build in efl-one | pkg-config options | name of static libs
-['evil'             ,[]                    , false,  true, false, false, false, false,  true, [], []],
+['evil'             ,[]                    , false,  true, false, false,  true, false,  true, [], []],
 ['eina'             ,[]                    , false,  true,  true,  true,  true,  true,  true, [], []],
 ['eolian'           ,[]                    , false,  true,  true, false,  true, false, false, ['eina'], []],
 ['eo'               ,[]                    , false,  true, false,  true,  true, false,  true, ['eina'], []],

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -23,7 +23,7 @@ LONGLONG _evil_time_freq;
 LONGLONG _evil_time_count;
 long     _evil_time_second;
 
-long 
+long
 _evil_systemtime_to_time(SYSTEMTIME st);
 
 long
@@ -60,8 +60,19 @@ execvp(const char *file, char *const argv[])
 int
 ftruncate(int fd, off_t size)
 {
-   // Fix-me: not implemented
-   return 0;
+   HANDLE file = (HANDLE)_get_osfhandle(fd);
+
+   if (SetFilePointer(file, (LONG)size, 0, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
+     {
+       return EINVAL;
+     }
+
+   if (!SetEndOfFile(file))
+     {
+       return EIO;
+     }
+
+    return 0;
 }
 
 
@@ -81,17 +92,17 @@ evil_time_get(void)
 }
 
 void
-usleep(__int64 usec) 
-{ 
-   HANDLE timer; 
-   LARGE_INTEGER ft; 
+usleep(__int64 usec)
+{
+   HANDLE timer;
+   LARGE_INTEGER ft;
 
    ft.QuadPart = -(10*usec); // Convert to 100 nanosecond interval, negative value indicates relative time
 
-   timer = CreateWaitableTimer(NULL, TRUE, NULL); 
-   SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0); 
-   WaitForSingleObject(timer, INFINITE); 
-   CloseHandle(timer); 
+   timer = CreateWaitableTimer(NULL, TRUE, NULL);
+   SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
+   WaitForSingleObject(timer, INFINITE);
+   CloseHandle(timer);
 }
 
 

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -62,7 +62,7 @@ ftruncate(int fd, off_t size)
 {
    HANDLE file = (HANDLE)_get_osfhandle(fd);
 
-   if (SetFilePointer(file, (LONG)size, 0, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
+   if (SetFilePointer(file, (LONG)size, NULL, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
      {
        _set_errno(EINVAL);
        return -1;

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -64,12 +64,14 @@ ftruncate(int fd, off_t size)
 
    if (SetFilePointer(file, (LONG)size, 0, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
      {
-       return EINVAL;
+       _set_errno(EINVAL);
+       return -1;
      }
 
    if (!SetEndOfFile(file))
      {
-       return EIO;
+       _set_errno(EIO);
+       return -1;
      }
 
     return 0;

--- a/src/tests/evil/evil_suite.c
+++ b/src/tests/evil/evil_suite.c
@@ -33,7 +33,7 @@
 #include "../efl_check.h"
 
 static const Efl_Test_Case etc[] = {
-   // { "Dlfcn", evil_test_dlfcn },
+   { "Dlfcn", evil_test_dlfcn },
    /* { "Fcntl", evil_test_fcntl }, */
    /* { "Langinfo", evil_test_langinfo }, */
    { "Main", evil_test_main },

--- a/src/tests/evil/evil_suite.c
+++ b/src/tests/evil/evil_suite.c
@@ -33,7 +33,7 @@
 #include "../efl_check.h"
 
 static const Efl_Test_Case etc[] = {
-   { "Dlfcn", evil_test_dlfcn },
+   // { "Dlfcn", evil_test_dlfcn },
    /* { "Fcntl", evil_test_fcntl }, */
    /* { "Langinfo", evil_test_langinfo }, */
    { "Main", evil_test_main },

--- a/src/tests/evil/meson.build
+++ b/src/tests/evil/meson.build
@@ -1,0 +1,23 @@
+evil_test_src = files(
+'evil_suite.c',
+'evil_suite.h',
+'evil_test_dlfcn.c',
+'evil_test_main.c',
+'evil_test_stdio.c',
+'evil_test_stdlib.c',
+'evil_test_unistd.c',
+)
+
+evil_test_exe = executable('evil_suite',
+  include_directories : config_dir,
+  sources : evil_test_src,
+  dependencies: [m, check_dep, eina, evil],
+  c_args : [
+  '-DTESTS_WD="`pwd`"',
+  '-DTESTS_BUILD_DIR="'+meson.current_build_dir()+'"',
+  '-DTESTS_SRC_DIR="'+meson.current_source_dir()+'"']
+)
+
+test('evil', evil_test_exe,
+  env : test_env,
+)


### PR DESCRIPTION
Also reenables evil tests and implements a test case for `ftruncate`.
I noticed that `evil_test_dlfcn` is failing and I'll try to fix it in a subsequent PR.