### PR TITLE
eina: Change EAPI to EINA_API in Eina Library

### DIFF
--- a/src/lib/eina/eina_abi.c
+++ b/src/lib/eina/eina_abi.c
@@ -25,12 +25,12 @@
 #include "eina_unicode.h"
 #include "eina_safety_checks.h"
 
-EAPI Eina_Unicode eina_unicode_utf8_get_next(const char *buf, int *iindex)
+EINA_API Eina_Unicode eina_unicode_utf8_get_next(const char *buf, int *iindex)
 {
    return eina_unicode_utf8_next_get(buf, iindex);
 }
 
-EAPI unsigned int
+EINA_API unsigned int
 eina_mempool_alignof(unsigned int size)
 {
    unsigned int align;

--- a/src/lib/eina/eina_abstract_content.c
+++ b/src/lib/eina/eina_abstract_content.c
@@ -12,7 +12,7 @@ struct _Eina_Content
    const char *file;
    EINA_REFCOUNT;
 };
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_CONTENT;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_CONTENT;
 
 static int _eina_abstract_content_log_domain = -1;
 
@@ -39,7 +39,7 @@ _eina_content_ref(Eina_Content *content)
    EINA_REFCOUNT_REF(content);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_content_converter_conversion_register(const char *from, const char *to, Eina_Content_Conversion_Callback conversion)
 {
    Eina_Content_Conversion_Node *node = calloc(1, sizeof(Eina_Content_Conversion_Node));
@@ -93,7 +93,7 @@ end:
    return result;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_content_converter_convert_can(const char *from, const char *to)
 {
    return !!_conversion_callback_fetch(from, to);
@@ -107,7 +107,7 @@ _process_cb(const void *container EINA_UNUSED, void *data, void *fdata EINA_UNUS
    return n->to;
  }
 
-EAPI Eina_Iterator*
+EINA_API Eina_Iterator*
 eina_content_converter_possible_conversions(const char *from)
 {
    Eina_List *possibilities = _conversion_callback_fetch_possible(from);
@@ -115,7 +115,7 @@ eina_content_converter_possible_conversions(const char *from)
    return eina_iterator_processed_new(eina_list_iterator_new(possibilities) , EINA_PROCESS_CB(_process_cb), NULL, possibilities);
 }
 
-EAPI Eina_Content*
+EINA_API Eina_Content*
 eina_content_new(Eina_Slice data, const char *type)
 {
    Eina_Content *content;
@@ -149,7 +149,7 @@ err:
    return NULL;
 }
 
-EAPI void
+EINA_API void
 eina_content_free(Eina_Content *content)
 {
    EINA_REFCOUNT_UNREF(content)
@@ -161,7 +161,7 @@ eina_content_free(Eina_Content *content)
      }
 }
 
-EAPI const char*
+EINA_API const char*
 eina_content_as_file(Eina_Content *content)
 {
    if (!content->file)
@@ -189,19 +189,19 @@ eina_content_as_file(Eina_Content *content)
    return content->file;
 }
 
-EAPI const char*
+EINA_API const char*
 eina_content_type_get(Eina_Content *content)
 {
    return content->type;
 }
 
-EAPI Eina_Slice
+EINA_API Eina_Slice
 eina_content_data_get(Eina_Content *content)
 {
    return eina_rw_slice_slice_get(content->data);
 }
 
-EAPI Eina_Content*
+EINA_API Eina_Content*
 eina_content_convert(Eina_Content *content, const char *new_type)
 {
    Eina_Content_Conversion_Callback callback = _conversion_callback_fetch(content->type, new_type);
@@ -370,7 +370,7 @@ _eina_value_type_content_pget(const Eina_Value_Type *type EINA_UNUSED, const voi
    return EINA_TRUE;
 }
 
-EAPI const Eina_Value_Type _EINA_VALUE_TYPE_CONTENT ={
+EINA_API const Eina_Value_Type _EINA_VALUE_TYPE_CONTENT ={
   EINA_VALUE_TYPE_VERSION,
   sizeof(Eina_Content*),
   "Eina_Abstract_Content",

--- a/src/lib/eina/eina_abstract_content.h
+++ b/src/lib/eina/eina_abstract_content.h
@@ -33,7 +33,7 @@ typedef Eina_Content* (*Eina_Content_Conversion_Callback)(Eina_Content *from, co
  * @return The path to the file. Do not free this.
  *
  */
-EAPI const char* eina_content_as_file(Eina_Content *content);
+EINA_API const char* eina_content_as_file(Eina_Content *content);
 
 /**
  * Convert the content of the object to another type.
@@ -45,7 +45,7 @@ EAPI const char* eina_content_as_file(Eina_Content *content);
  *
  * @return A new content object. The caller of this function is owning this.
  */
-EAPI Eina_Content* eina_content_convert(Eina_Content *content, const char *new_type);
+EINA_API Eina_Content* eina_content_convert(Eina_Content *content, const char *new_type);
 
 /**
  * Get the type of the passed content.
@@ -54,7 +54,7 @@ EAPI Eina_Content* eina_content_convert(Eina_Content *content, const char *new_t
  *
  * @return The type of this content. Do no free this.
  */
-EAPI const char* eina_content_type_get(Eina_Content *content);
+EINA_API const char* eina_content_type_get(Eina_Content *content);
 
 /**
  * Get the Eina_Slice of the passed content.
@@ -63,7 +63,7 @@ EAPI const char* eina_content_type_get(Eina_Content *content);
  *
  * @return An Eina_Slice containing the data. Do not free.
  */
-EAPI Eina_Slice eina_content_data_get(Eina_Content *content);
+EINA_API Eina_Slice eina_content_data_get(Eina_Content *content);
 
 /**
  * Create a new content object, with the provided data and type.
@@ -73,14 +73,14 @@ EAPI Eina_Slice eina_content_data_get(Eina_Content *content);
  *
  * @return The new content object. The caller owns this object.
  */
-EAPI Eina_Content* eina_content_new(Eina_Slice data, const char *type);
+EINA_API Eina_Content* eina_content_new(Eina_Slice data, const char *type);
 
 /**
  * Free the content object.
  *
  * @param[in] content The content to free.
  */
-EAPI void eina_content_free(Eina_Content *content);
+EINA_API void eina_content_free(Eina_Content *content);
 
 /**
  * Register a new conversion callback.
@@ -90,7 +90,7 @@ EAPI void eina_content_free(Eina_Content *content);
  *
  * @return True if the callback was successfully registered.
  */
-EAPI Eina_Bool eina_content_converter_conversion_register(const char *from, const char *to, Eina_Content_Conversion_Callback convertion);
+EINA_API Eina_Bool eina_content_converter_conversion_register(const char *from, const char *to, Eina_Content_Conversion_Callback convertion);
 
 /**
  * Check if a specific conversion can be performed.
@@ -102,7 +102,7 @@ EAPI Eina_Bool eina_content_converter_conversion_register(const char *from, cons
  *
  * @return True if the conversion can be performed.
  */
-EAPI Eina_Bool eina_content_converter_convert_can(const char *from, const char *to);
+EINA_API Eina_Bool eina_content_converter_convert_can(const char *from, const char *to);
 
 /**
  * Returns an iterator containing all the target types that the provided source type can be converted to.
@@ -111,9 +111,9 @@ EAPI Eina_Bool eina_content_converter_convert_can(const char *from, const char *
  *
  * @return An Iterator containing MIME type strings. Free this via eina_iterator_free.
  */
-EAPI Eina_Iterator* eina_content_converter_possible_conversions(const char *from);
+EINA_API Eina_Iterator* eina_content_converter_possible_conversions(const char *from);
 
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_CONTENT;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_CONTENT;
 
 /**
  * Convert the Eina_Content object to an Eina_Value.
@@ -122,7 +122,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_CONTENT;
  *
  * @return An newly-allocated Eina_Value. Caller owns it.
  */
-EAPI Eina_Value* eina_value_content_new(Eina_Content *content);
+EINA_API Eina_Value* eina_value_content_new(Eina_Content *content);
 
 /**
  * Creates an Eina_Value from an Eina_Content.
@@ -131,7 +131,7 @@ EAPI Eina_Value* eina_value_content_new(Eina_Content *content);
  *
  * @return An Eina_Value with type EINA_VALUE_TYPE_CONTENT.
  */
-EAPI Eina_Value eina_value_content_init(Eina_Content *content);
+EINA_API Eina_Value eina_value_content_init(Eina_Content *content);
 
 /**
  * Gets the content from the Eina_Value.
@@ -142,7 +142,7 @@ EAPI Eina_Value eina_value_content_init(Eina_Content *content);
  *
  * @return A newly-allocated Eina_Content. Caller owns it.
  */
-EAPI Eina_Content* eina_value_to_content(const Eina_Value *value);
+EINA_API Eina_Content* eina_value_to_content(const Eina_Value *value);
 
 
 static inline Eina_Iterator*

--- a/src/lib/eina/eina_accessor.c
+++ b/src/lib/eina/eina_accessor.c
@@ -92,7 +92,7 @@ eina_accessor_shutdown(void)
 *============================================================================*/
 
 
-EAPI void
+EINA_API void
 eina_accessor_free(Eina_Accessor *accessor)
 {
    if (!accessor)
@@ -103,7 +103,7 @@ eina_accessor_free(Eina_Accessor *accessor)
    accessor->free(accessor);
 }
 
-EAPI void *
+EINA_API void *
 eina_accessor_container_get(Eina_Accessor *accessor)
 {
    EINA_MAGIC_CHECK_ACCESSOR(accessor);
@@ -112,7 +112,7 @@ eina_accessor_container_get(Eina_Accessor *accessor)
    return accessor->get_container(accessor);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_accessor_data_get(Eina_Accessor *accessor,
                        unsigned int position,
                        void **data)
@@ -124,7 +124,7 @@ eina_accessor_data_get(Eina_Accessor *accessor,
    return accessor->get_at(accessor, position, data);
 }
 
-EAPI void
+EINA_API void
 eina_accessor_over(Eina_Accessor *accessor,
                    Eina_Each_Cb cb,
                    unsigned int start,
@@ -156,7 +156,7 @@ eina_accessor_over(Eina_Accessor *accessor,
    (void) eina_accessor_unlock(accessor);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_accessor_lock(Eina_Accessor *accessor)
 {
    EINA_MAGIC_CHECK_ACCESSOR(accessor);
@@ -167,7 +167,7 @@ eina_accessor_lock(Eina_Accessor *accessor)
    return EINA_TRUE;
 }
 
-EAPI Eina_Accessor*
+EINA_API Eina_Accessor*
 eina_accessor_clone(Eina_Accessor *accessor)
 {
    EINA_MAGIC_CHECK_ACCESSOR(accessor);
@@ -179,7 +179,7 @@ eina_accessor_clone(Eina_Accessor *accessor)
    return NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_accessor_unlock(Eina_Accessor *accessor)
 {
    EINA_MAGIC_CHECK_ACCESSOR(accessor);
@@ -235,7 +235,7 @@ eina_carray_length_accessor_free(Eina_Accessor_CArray_Length *accessor)
    free(accessor);
 }
 
-EAPI Eina_Accessor *
+EINA_API Eina_Accessor *
 eina_carray_length_accessor_new(void** array, unsigned int step, unsigned int length)
 {
    Eina_Accessor_CArray_Length *accessor;
@@ -258,7 +258,7 @@ eina_carray_length_accessor_new(void** array, unsigned int step, unsigned int le
    return &accessor->accessor;
 }
 
-EAPI Eina_Accessor *
+EINA_API Eina_Accessor *
 eina_carray_length_ptr_accessor_new(void** array, unsigned int step, unsigned int length)
 {
    Eina_Accessor_CArray_Length *accessor;

--- a/src/lib/eina/eina_accessor.h
+++ b/src/lib/eina/eina_accessor.h
@@ -205,7 +205,7 @@ struct _Eina_Accessor
  * @param[in] accessor The accessor to free
  *
  */
-EAPI void      eina_accessor_free(Eina_Accessor *accessor);
+EINA_API void      eina_accessor_free(Eina_Accessor *accessor);
 
 /**
  * @brief Gets the data of an accessor at the given position.
@@ -219,7 +219,7 @@ EAPI void      eina_accessor_free(Eina_Accessor *accessor);
  * @return #EINA_TRUE on success, otherwise #EINA_FALSE
  *
  */
-EAPI Eina_Bool eina_accessor_data_get(Eina_Accessor *accessor,
+EINA_API Eina_Bool eina_accessor_data_get(Eina_Accessor *accessor,
                                       unsigned int   position,
                                       void         **data) EINA_ARG_NONNULL(1);
 
@@ -231,7 +231,7 @@ EAPI Eina_Bool eina_accessor_data_get(Eina_Accessor *accessor,
  * @return The container that created the accessor
  *
  */
-EAPI void *eina_accessor_container_get(Eina_Accessor *accessor) EINA_ARG_NONNULL(1) EINA_PURE;
+EINA_API void *eina_accessor_container_get(Eina_Accessor *accessor) EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Iterates over the container and executes a callback on the chosen elements.
@@ -249,7 +249,7 @@ EAPI void *eina_accessor_container_get(Eina_Accessor *accessor) EINA_ARG_NONNULL
  * @param[in] fdata The data passed to the callback
  *
  */
-EAPI void  eina_accessor_over(Eina_Accessor *accessor,
+EINA_API void  eina_accessor_over(Eina_Accessor *accessor,
                               Eina_Each_Cb   cb,
                               unsigned int   start,
                               unsigned int   end,
@@ -269,7 +269,7 @@ EAPI void  eina_accessor_over(Eina_Accessor *accessor,
  *
  * @warning None of the existing eina data structures are lockable.
  */
-EAPI Eina_Bool eina_accessor_lock(Eina_Accessor *accessor) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_accessor_lock(Eina_Accessor *accessor) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Clones the container of the accessor.
@@ -278,7 +278,7 @@ EAPI Eina_Bool eina_accessor_lock(Eina_Accessor *accessor) EINA_ARG_NONNULL(1);
  * @return Another accessor
  * @since 1.10
  */
-EAPI Eina_Accessor* eina_accessor_clone(Eina_Accessor *accessor) EINA_ARG_NONNULL(1);
+EINA_API Eina_Accessor* eina_accessor_clone(Eina_Accessor *accessor) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Unlocks the container of the accessor.
@@ -293,7 +293,7 @@ EAPI Eina_Accessor* eina_accessor_clone(Eina_Accessor *accessor) EINA_ARG_NONNUL
  *
  * @warning None of the existing eina data structures are lockable.
  */
-EAPI Eina_Bool eina_accessor_unlock(Eina_Accessor *accessor) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_accessor_unlock(Eina_Accessor *accessor) EINA_ARG_NONNULL(1);
 
 /**
  * @def EINA_ACCESSOR_FOREACH
@@ -363,7 +363,7 @@ EAPI Eina_Bool eina_accessor_unlock(Eina_Accessor *accessor) EINA_ARG_NONNULL(1)
  *
  * @since 1.23
  */
-EAPI Eina_Accessor* eina_carray_length_accessor_new(void** array, unsigned int step, unsigned int length);
+EINA_API Eina_Accessor* eina_carray_length_accessor_new(void** array, unsigned int step, unsigned int length);
 
 
 /**
@@ -383,7 +383,7 @@ EAPI Eina_Accessor* eina_carray_length_accessor_new(void** array, unsigned int s
 
  * @since 1.24
  */
-EAPI Eina_Accessor* eina_carray_length_ptr_accessor_new(void** array, unsigned int step, unsigned int length);
+EINA_API Eina_Accessor* eina_carray_length_ptr_accessor_new(void** array, unsigned int step, unsigned int length);
 /**
  * @def EINA_C_ARRAY_ACCESSOR_NEW
  * @brief Creates an Eina_Accessor that wraps a plain fixed size C array

--- a/src/lib/eina/eina_array.c
+++ b/src/lib/eina/eina_array.c
@@ -191,7 +191,7 @@ eina_array_accessor_clone(const Eina_Accessor_Array *it)
 }
 
 /* used from eina_inline_array.x, thus a needed symbol */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_array_grow(Eina_Array *array)
 {
    void **tmp;
@@ -272,7 +272,7 @@ eina_array_shutdown(void)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI Eina_Array *
+EINA_API Eina_Array *
 eina_array_new(unsigned int step)
 {
    Eina_Array *array;
@@ -291,7 +291,7 @@ eina_array_new(unsigned int step)
    return array;
 }
 
-EAPI void
+EINA_API void
 eina_array_free(Eina_Array *array)
 {
    if (!array) return;
@@ -301,7 +301,7 @@ eina_array_free(Eina_Array *array)
    MAGIC_FREE(array);
 }
 
-EAPI void
+EINA_API void
 eina_array_step_set(Eina_Array *array,
 		    unsigned int sizeof_eina_array,
 		    unsigned int step)
@@ -326,7 +326,7 @@ eina_array_step_set(Eina_Array *array,
    EINA_MAGIC_SET(array, EINA_MAGIC_ARRAY);
 }
 
-EAPI void
+EINA_API void
 eina_array_flush(Eina_Array *array)
 {
    EINA_SAFETY_ON_NULL_RETURN(array);
@@ -342,7 +342,7 @@ eina_array_flush(Eina_Array *array)
    array->data = NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_array_remove(Eina_Array *array, Eina_Bool (*keep)(void *data,
                                                        void *gdata),
                   void *gdata)
@@ -390,7 +390,7 @@ eina_array_remove(Eina_Array *array, Eina_Bool (*keep)(void *data,
    return EINA_TRUE;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_array_iterator_new(const Eina_Array *array)
 {
    Eina_Iterator_Array *it;
@@ -415,7 +415,7 @@ eina_array_iterator_new(const Eina_Array *array)
    return &it->iterator;
 }
 
-EAPI Eina_Accessor *
+EINA_API Eina_Accessor *
 eina_array_accessor_new(const Eina_Array *array)
 {
    Eina_Accessor_Array *ac;

--- a/src/lib/eina/eina_array.h
+++ b/src/lib/eina/eina_array.h
@@ -251,7 +251,7 @@ struct _Eina_Array
  * This function return a valid array on success, or @c NULL if memory
  * allocation fails.
  */
-EAPI Eina_Array *eina_array_new(unsigned int step) EINA_WARN_UNUSED_RESULT EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Array *eina_array_new(unsigned int step) EINA_WARN_UNUSED_RESULT EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Frees an array.
@@ -263,7 +263,7 @@ EAPI Eina_Array *eina_array_new(unsigned int step) EINA_WARN_UNUSED_RESULT EINA_
  * does not free the memory allocated for the elements of @p array. To
  * free them, walk the array with #EINA_ARRAY_ITER_NEXT.
  */
-EAPI void eina_array_free(Eina_Array *array);
+EINA_API void eina_array_free(Eina_Array *array);
 
 /**
  * @brief Sets the step of an array.
@@ -278,7 +278,7 @@ EAPI void eina_array_free(Eina_Array *array);
  *
  * @warning This function can @b only be called on uninitialized arrays.
  */
-EAPI void        eina_array_step_set(Eina_Array  *array,
+EINA_API void        eina_array_step_set(Eina_Array  *array,
                                      unsigned int sizeof_eina_array,
                                      unsigned int step) EINA_ARG_NONNULL(1);
 /**
@@ -303,7 +303,7 @@ static inline void eina_array_clean(Eina_Array *array) EINA_ARG_NONNULL(1);
  * there is no check of @p array. If it is @c NULL or invalid, the
  * program may crash.
  */
-EAPI void eina_array_flush(Eina_Array *array) EINA_ARG_NONNULL(1);
+EINA_API void eina_array_flush(Eina_Array *array) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Rebuilds an array by specifying the data to keep.
@@ -321,7 +321,7 @@ EAPI void eina_array_flush(Eina_Array *array) EINA_ARG_NONNULL(1);
  * If it wasn't able to remove items due to an allocation failure, it will
  * return #EINA_FALSE.
  */
-EAPI Eina_Bool eina_array_remove(Eina_Array * array,
+EINA_API Eina_Bool eina_array_remove(Eina_Array * array,
                                  Eina_Bool (*keep)(void *data, void *gdata),
                                  void *gdata) EINA_ARG_NONNULL(1, 2);
 
@@ -441,7 +441,7 @@ static inline Eina_Bool  eina_array_find(const Eina_Array *array,
  *
  * @see Eina_Iterator_Group
  */
-EAPI Eina_Iterator        *eina_array_iterator_new(const Eina_Array *array) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator        *eina_array_iterator_new(const Eina_Array *array) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets a new accessor associated with an array.
@@ -456,7 +456,7 @@ EAPI Eina_Iterator        *eina_array_iterator_new(const Eina_Array *array) EINA
  *
  * @see Eina_Accessor_Group
  */
-EAPI Eina_Accessor        *eina_array_accessor_new(const Eina_Array *array) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Accessor        *eina_array_accessor_new(const Eina_Array *array) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Iterates over an array using a callback function.

--- a/src/lib/eina/eina_benchmark.c
+++ b/src/lib/eina/eina_benchmark.c
@@ -134,7 +134,7 @@ eina_benchmark_shutdown(void)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Benchmark *
+EINA_API Eina_Benchmark *
 eina_benchmark_new(const char *name, const char *run)
 {
    Eina_Benchmark *new;
@@ -148,7 +148,7 @@ eina_benchmark_new(const char *name, const char *run)
    return new;
 }
 
-EAPI void
+EINA_API void
 eina_benchmark_free(Eina_Benchmark *bench)
 {
    Eina_Array *names;
@@ -179,7 +179,7 @@ eina_benchmark_free(Eina_Benchmark *bench)
    free(bench);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_benchmark_register(Eina_Benchmark *bench,
                         const char *name,
                         Eina_Benchmark_Specimens bench_cb,
@@ -209,7 +209,7 @@ eina_benchmark_register(Eina_Benchmark *bench,
    return EINA_TRUE;
 }
 
-EAPI Eina_Array *
+EINA_API Eina_Array *
 eina_benchmark_run(Eina_Benchmark *bench)
 {
    FILE *main_script;

--- a/src/lib/eina/eina_benchmark.h
+++ b/src/lib/eina/eina_benchmark.h
@@ -367,7 +367,7 @@ typedef void (*Eina_Benchmark_Specimens)(int request);
  * When the new module is not needed anymore, use
  * eina_benchmark_free() to free the allocated memory.
  */
-EAPI Eina_Benchmark *eina_benchmark_new(const char *name,
+EINA_API Eina_Benchmark *eina_benchmark_new(const char *name,
                                         const char *run);
 
 /**
@@ -379,7 +379,7 @@ EAPI Eina_Benchmark *eina_benchmark_new(const char *name,
  * registered and frees @p bench. If @p bench is @c NULL, this
  * function returns immediately.
  */
-EAPI void            eina_benchmark_free(Eina_Benchmark *bench);
+EINA_API void            eina_benchmark_free(Eina_Benchmark *bench);
 
 /**
  * @brief Adds a test to a benchmark.
@@ -401,7 +401,7 @@ EAPI void            eina_benchmark_free(Eina_Benchmark *bench);
  * If @p bench is @c NULL or @p count_step is 0, this function returns
  * immediately and does not add any tests to the benchmark.
  */
-EAPI Eina_Bool       eina_benchmark_register(Eina_Benchmark          *bench,
+EINA_API Eina_Bool       eina_benchmark_register(Eina_Benchmark          *bench,
                                              const char              *name,
                                              Eina_Benchmark_Specimens bench_cb,
                                              int                      count_start,
@@ -430,7 +430,7 @@ EAPI Eina_Bool       eina_benchmark_register(Eina_Benchmark          *bench,
  * the gnuplot file. The number of times each test is executed is
  * controlled by the parameters passed to eina_benchmark_register().
  */
-EAPI Eina_Array *eina_benchmark_run(Eina_Benchmark *bench);
+EINA_API Eina_Array *eina_benchmark_run(Eina_Benchmark *bench);
 
 /**
  * @}

--- a/src/lib/eina/eina_bezier.c
+++ b/src/lib/eina/eina_bezier.c
@@ -110,7 +110,7 @@ _eina_bezier_length_helper(const Eina_Bezier *b)
    return len;
 }
 
-EAPI void
+EINA_API void
 eina_bezier_values_set(Eina_Bezier *b,
                        double start_x, double start_y,
                        double ctrl_start_x, double ctrl_start_y,
@@ -127,7 +127,7 @@ eina_bezier_values_set(Eina_Bezier *b,
    b->end.y = end_y;
 }
 
-EAPI void
+EINA_API void
 eina_bezier_values_get(const Eina_Bezier *b,
                        double *start_x, double *start_y,
                        double *ctrl_start_x, double *ctrl_start_y,
@@ -145,7 +145,7 @@ eina_bezier_values_get(const Eina_Bezier *b,
 }
 
 
-EAPI void
+EINA_API void
 eina_bezier_point_at(const Eina_Bezier *bz, double t, double *px, double *py)
 {
    double m_t = 1.0 - t;
@@ -173,7 +173,7 @@ eina_bezier_point_at(const Eina_Bezier *bz, double t, double *px, double *py)
      }
 }
 
-EAPI double
+EINA_API double
 eina_bezier_angle_at(const Eina_Bezier *b, double t)
 {
    double x, y;
@@ -187,7 +187,7 @@ eina_bezier_angle_at(const Eina_Bezier *b, double t)
    return theta_normalized;
 }
 
-EAPI double
+EINA_API double
 eina_bezier_length_get(const Eina_Bezier *b)
 {
    return _eina_bezier_length_helper(b);
@@ -222,7 +222,7 @@ _eina_bezier_split_left(Eina_Bezier *b, double t, Eina_Bezier *left)
    left->end.y = b->start.y = left->ctrl_end.y + t * (b->ctrl_start.y - left->ctrl_end.y);
 }
 
-EAPI double
+EINA_API double
 eina_bezier_t_at(const Eina_Bezier *b, double l)
 {
    double len = eina_bezier_length_get(b);
@@ -260,7 +260,7 @@ eina_bezier_t_at(const Eina_Bezier *b, double l)
    return t;
 }
 
-EAPI void
+EINA_API void
 eina_bezier_split_at_length(const Eina_Bezier *b, double len,
                             Eina_Bezier *left, Eina_Bezier *right)
 {
@@ -274,7 +274,7 @@ eina_bezier_split_at_length(const Eina_Bezier *b, double len,
    _eina_bezier_split_left(right, t, left);
 }
 
-EAPI void
+EINA_API void
 eina_bezier_bounds_get(const Eina_Bezier *b, double *x, double *y, double *w, double *h)
 {
    double xmin = b->start.x;
@@ -314,7 +314,7 @@ eina_bezier_bounds_get(const Eina_Bezier *b, double *x, double *y, double *w, do
    if (h) *h = ymax - ymin;
 }
 
-EAPI void
+EINA_API void
 eina_bezier_on_interval(Eina_Bezier *b, double t0, double t1, Eina_Bezier *result)
 {
    Eina_Bezier bezier;

--- a/src/lib/eina/eina_bezier.h
+++ b/src/lib/eina/eina_bezier.h
@@ -64,7 +64,7 @@ struct _Eina_Bezier
  * @p b. No check is done on @p b.
  * @since 1.16
  */
-EAPI void eina_bezier_values_set(Eina_Bezier *b, double start_x, double start_y, double ctrl_start_x, double ctrl_start_y, double ctrl_end_x, double ctrl_end_y, double end_x, double end_y) EINA_ARG_NONNULL(1);
+EINA_API void eina_bezier_values_set(Eina_Bezier *b, double start_x, double start_y, double ctrl_start_x, double ctrl_start_y, double ctrl_end_x, double ctrl_end_y, double end_x, double end_y) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets the values of the points of the given floating
@@ -83,7 +83,7 @@ EAPI void eina_bezier_values_set(Eina_Bezier *b, double start_x, double start_y,
  * @p b. No check is done on @p b.
  * @since 1.16
  */
-EAPI void eina_bezier_values_get(const Eina_Bezier *b, double *start_x, double *start_y, double *ctrl_start_x, double *ctrl_start_y, double *ctrl_end_x, double *ctrl_end_y, double *end_x, double *end_y) EINA_ARG_NONNULL(1);
+EINA_API void eina_bezier_values_get(const Eina_Bezier *b, double *start_x, double *start_y, double *ctrl_start_x, double *ctrl_start_y, double *ctrl_end_x, double *ctrl_end_y, double *end_x, double *end_y) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Calculates the approximate length of the given floating point
@@ -99,7 +99,7 @@ EAPI void eina_bezier_values_get(const Eina_Bezier *b, double *start_x, double *
  * No check is done on @p b.
  * @since 1.16
  */
-EAPI double eina_bezier_length_get(const Eina_Bezier *b) EINA_ARG_NONNULL(1);
+EINA_API double eina_bezier_length_get(const Eina_Bezier *b) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Returns the relative position on a bezier at a given length.
@@ -116,7 +116,7 @@ EAPI double eina_bezier_length_get(const Eina_Bezier *b) EINA_ARG_NONNULL(1);
  *
  * @since 1.16
  */
-EAPI double eina_bezier_t_at(const Eina_Bezier *b, double len) EINA_ARG_NONNULL(1);
+EINA_API double eina_bezier_t_at(const Eina_Bezier *b, double len) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets the point on the bezier curve at position t.
@@ -129,7 +129,7 @@ EAPI double eina_bezier_t_at(const Eina_Bezier *b, double len) EINA_ARG_NONNULL(
  * No check is done on @p b.
  * @since 1.16
  */
-EAPI void eina_bezier_point_at(const Eina_Bezier *b, double t, double *px, double *py) EINA_ARG_NONNULL(1);
+EINA_API void eina_bezier_point_at(const Eina_Bezier *b, double t, double *px, double *py) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Determines the slope of the bezier at a given position.
@@ -140,7 +140,7 @@ EAPI void eina_bezier_point_at(const Eina_Bezier *b, double t, double *px, doubl
  * No check is done on @p b.
  * @since 1.16
  */
-EAPI double eina_bezier_angle_at(const Eina_Bezier *b, double t) EINA_ARG_NONNULL(1);
+EINA_API double eina_bezier_angle_at(const Eina_Bezier *b, double t) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Splits the bezier at a given length.
@@ -153,7 +153,7 @@ EAPI double eina_bezier_angle_at(const Eina_Bezier *b, double t) EINA_ARG_NONNUL
  * No check is done on @p b.
  * @since 1.16
  */
-EAPI void eina_bezier_split_at_length(const Eina_Bezier *b, double len, Eina_Bezier *left, Eina_Bezier *right) EINA_ARG_NONNULL(1);
+EINA_API void eina_bezier_split_at_length(const Eina_Bezier *b, double len, Eina_Bezier *left, Eina_Bezier *right) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Calculates the bounding box for the bezier.
@@ -167,7 +167,7 @@ EAPI void eina_bezier_split_at_length(const Eina_Bezier *b, double len, Eina_Bez
  * No check is done on @p b.
  * @since 1.17
  */
-EAPI void eina_bezier_bounds_get(const Eina_Bezier *b, double *x, double *y, double *w, double *h) EINA_ARG_NONNULL(1);
+EINA_API void eina_bezier_bounds_get(const Eina_Bezier *b, double *x, double *y, double *w, double *h) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Finds the bezier between the given interval.
@@ -180,6 +180,6 @@ EAPI void eina_bezier_bounds_get(const Eina_Bezier *b, double *x, double *y, dou
  * No check is done on @p b.
  * @since 1.17
  */
-EAPI void eina_bezier_on_interval(Eina_Bezier *b, double t0, double t1, Eina_Bezier *result);
+EINA_API void eina_bezier_on_interval(Eina_Bezier *b, double t0, double t1, Eina_Bezier *result);
 
 #endif // EINA_BEZIER_H

--- a/src/lib/eina/eina_binbuf.c
+++ b/src/lib/eina/eina_binbuf.c
@@ -53,7 +53,7 @@ static const char __BINBUF_MAGIC_STR[] = "Eina Binbuf";
 
 #include "eina_binbuf_template_c.x"
 
-EAPI Eina_Binbuf *
+EINA_API Eina_Binbuf *
 eina_binbuf_manage_new(const unsigned char *str, size_t length, Eina_Bool ro)
 {
    Eina_Binbuf *buf;

--- a/src/lib/eina/eina_binbuf.h
+++ b/src/lib/eina/eina_binbuf.h
@@ -47,7 +47,7 @@ typedef struct _Eina_Strbuf Eina_Binbuf;
  * @see eina_binbuf_append()
  * @see eina_binbuf_string_get()
  */
-EAPI Eina_Binbuf *eina_binbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Binbuf *eina_binbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates a new string buffer using the passed string.
@@ -73,7 +73,7 @@ EAPI Eina_Binbuf *eina_binbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
  *
  * @since 1.14.0
  */
-EAPI Eina_Binbuf *eina_binbuf_manage_new(const unsigned char *str, size_t length, Eina_Bool ro) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Binbuf *eina_binbuf_manage_new(const unsigned char *str, size_t length, Eina_Bool ro) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates a new string buffer using the passed string.
@@ -89,7 +89,7 @@ EAPI Eina_Binbuf *eina_binbuf_manage_new(const unsigned char *str, size_t length
  *
  * @since 1.2.0
  */
-EAPI Eina_Binbuf *eina_binbuf_manage_new_length(unsigned char *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_DEPRECATED;
+EINA_API Eina_Binbuf *eina_binbuf_manage_new_length(unsigned char *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_DEPRECATED;
 
 /**
  * @brief Creates a new string buffer using the passed string.
@@ -110,7 +110,7 @@ EAPI Eina_Binbuf *eina_binbuf_manage_new_length(unsigned char *str, size_t lengt
  *
  * @since 1.9.0
  */
-EAPI Eina_Binbuf *eina_binbuf_manage_read_only_new_length(const unsigned char *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_DEPRECATED;
+EINA_API Eina_Binbuf *eina_binbuf_manage_read_only_new_length(const unsigned char *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_DEPRECATED;
 
 /**
  * @brief Frees a string buffer.
@@ -120,7 +120,7 @@ EAPI Eina_Binbuf *eina_binbuf_manage_read_only_new_length(const unsigned char *s
  * This function frees the memory of @p buf. @p buf must have been
  * created by eina_binbuf_new().
  */
-EAPI void eina_binbuf_free(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_binbuf_free(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Resets a string buffer.
@@ -130,7 +130,7 @@ EAPI void eina_binbuf_free(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
  * This function resets @p buf: the buffer len is set to 0, and the
  * string is set to '\\0'. No memory is freed.
  */
-EAPI void eina_binbuf_reset(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_binbuf_reset(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Expands a buffer, making room for at least @p minimum_unused_space.
@@ -160,7 +160,7 @@ EAPI void eina_binbuf_reset(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
  *
  * @since 1.19
  */
-EAPI Eina_Rw_Slice eina_binbuf_expand(Eina_Binbuf *buf, size_t minimum_unused_space) EINA_ARG_NONNULL(1);
+EINA_API Eina_Rw_Slice eina_binbuf_expand(Eina_Binbuf *buf, size_t minimum_unused_space) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Marks more bytes as used.
@@ -180,7 +180,7 @@ EAPI Eina_Rw_Slice eina_binbuf_expand(Eina_Binbuf *buf, size_t minimum_unused_sp
  *
  * @since 1.19
  */
-EAPI Eina_Bool eina_binbuf_use(Eina_Binbuf *buf, size_t extra_bytes) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_binbuf_use(Eina_Binbuf *buf, size_t extra_bytes) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Appends a string of exact length to a buffer, reallocating as
@@ -200,7 +200,7 @@ EAPI Eina_Bool eina_binbuf_use(Eina_Binbuf *buf, size_t extra_bytes) EINA_ARG_NO
  * @see eina_binbuf_append()
  * @see eina_binbuf_append_n()
  */
-EAPI Eina_Bool eina_binbuf_append_length(Eina_Binbuf *buf, const unsigned char *str, size_t length) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_binbuf_append_length(Eina_Binbuf *buf, const unsigned char *str, size_t length) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a slice to a buffer, reallocating as necessary.
@@ -213,7 +213,7 @@ EAPI Eina_Bool eina_binbuf_append_length(Eina_Binbuf *buf, const unsigned char *
  *
  * @since 1.19
  */
-EAPI Eina_Bool eina_binbuf_append_slice(Eina_Binbuf *buf, const Eina_Slice slice) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_binbuf_append_slice(Eina_Binbuf *buf, const Eina_Slice slice) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Appends an Eina_Binbuf to a buffer, reallocating as necessary.
@@ -232,7 +232,7 @@ EAPI Eina_Bool eina_binbuf_append_slice(Eina_Binbuf *buf, const Eina_Slice slice
  *
  * @since 1.9.0
  */
-EAPI Eina_Bool eina_binbuf_append_buffer(Eina_Binbuf *buf, const Eina_Binbuf *data) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_binbuf_append_buffer(Eina_Binbuf *buf, const Eina_Binbuf *data) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a character to a string buffer, reallocating as
@@ -244,7 +244,7 @@ EAPI Eina_Bool eina_binbuf_append_buffer(Eina_Binbuf *buf, const Eina_Binbuf *da
  *
  * This function appends @p c to @p buf.
  */
-EAPI Eina_Bool eina_binbuf_append_char(Eina_Binbuf *buf, unsigned char c) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_binbuf_append_char(Eina_Binbuf *buf, unsigned char c) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Inserts a string of exact length into a buffer, reallocating as necessary.
@@ -264,7 +264,7 @@ EAPI Eina_Bool eina_binbuf_append_char(Eina_Binbuf *buf, unsigned char c) EINA_A
  * @see eina_binbuf_insert()
  * @see eina_binbuf_insert_n()
  */
-EAPI Eina_Bool eina_binbuf_insert_length(Eina_Binbuf *buf, const unsigned char *str, size_t length, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_binbuf_insert_length(Eina_Binbuf *buf, const unsigned char *str, size_t length, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts a slice into a buffer, reallocating as necessary.
@@ -278,7 +278,7 @@ EAPI Eina_Bool eina_binbuf_insert_length(Eina_Binbuf *buf, const unsigned char *
  *
  * @since 1.19.0
  */
-EAPI Eina_Bool eina_binbuf_insert_slice(Eina_Binbuf *buf, const Eina_Slice slice, size_t pos) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_binbuf_insert_slice(Eina_Binbuf *buf, const Eina_Slice slice, size_t pos) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Inserts a character into a string buffer, reallocating as
@@ -291,7 +291,7 @@ EAPI Eina_Bool eina_binbuf_insert_slice(Eina_Binbuf *buf, const Eina_Slice slice
  *
  * This function inserts @p c to @p buf at position @p pos.
  */
-EAPI Eina_Bool eina_binbuf_insert_char(Eina_Binbuf *buf, unsigned char c, size_t pos) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_binbuf_insert_char(Eina_Binbuf *buf, unsigned char c, size_t pos) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Removes a slice of the given string buffer.
@@ -307,7 +307,7 @@ EAPI Eina_Bool eina_binbuf_insert_char(Eina_Binbuf *buf, unsigned char c, size_t
  * (inclusive) and ending at @p end (non-inclusive). Both values are
  * in bytes.
  */
-EAPI Eina_Bool eina_binbuf_remove(Eina_Binbuf *buf, size_t start, size_t end) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_binbuf_remove(Eina_Binbuf *buf, size_t start, size_t end) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Retrieves a pointer to the contents of a string buffer.
@@ -322,7 +322,7 @@ EAPI Eina_Bool eina_binbuf_remove(Eina_Binbuf *buf, size_t start, size_t end) EI
  *
  * @see eina_binbuf_string_steal()
  */
-EAPI const unsigned char *eina_binbuf_string_get(const Eina_Binbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API const unsigned char *eina_binbuf_string_get(const Eina_Binbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Steals the contents of a string buffer.
@@ -337,7 +337,7 @@ EAPI const unsigned char *eina_binbuf_string_get(const Eina_Binbuf *buf) EINA_AR
  *
  * @see eina_binbuf_string_get()
  */
-EAPI unsigned char *eina_binbuf_string_steal(Eina_Binbuf *buf) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API unsigned char *eina_binbuf_string_steal(Eina_Binbuf *buf) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Frees the contents of a string buffer but not the buffer.
@@ -347,7 +347,7 @@ EAPI unsigned char *eina_binbuf_string_steal(Eina_Binbuf *buf) EINA_MALLOC EINA_
  * This function frees the string contained in @p buf without freeing
  * @p buf.
  */
-EAPI void eina_binbuf_string_free(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_binbuf_string_free(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Retrieves the length of the string buffer's content.
@@ -357,7 +357,7 @@ EAPI void eina_binbuf_string_free(Eina_Binbuf *buf) EINA_ARG_NONNULL(1);
  *
  * This function returns the length of @p buf.
  */
-EAPI size_t eina_binbuf_length_get(const Eina_Binbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API size_t eina_binbuf_length_get(const Eina_Binbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets a read-only slice of the buffer contents.
@@ -368,7 +368,7 @@ EAPI size_t eina_binbuf_length_get(const Eina_Binbuf *buf) EINA_ARG_NONNULL(1) E
  *
  * @since 1.19
  */
-EAPI Eina_Slice eina_binbuf_slice_get(const Eina_Binbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Slice eina_binbuf_slice_get(const Eina_Binbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets a read-write slice of the buffer contents.
@@ -382,7 +382,7 @@ EAPI Eina_Slice eina_binbuf_slice_get(const Eina_Binbuf *buf) EINA_WARN_UNUSED_R
  *
  * @since 1.19
  */
-EAPI Eina_Rw_Slice eina_binbuf_rw_slice_get(const Eina_Binbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Rw_Slice eina_binbuf_rw_slice_get(const Eina_Binbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Frees the buffer, returning its old contents.
@@ -393,7 +393,7 @@ EAPI Eina_Rw_Slice eina_binbuf_rw_slice_get(const Eina_Binbuf *buf) EINA_WARN_UN
  *
  * @since 1.19
  */
-EAPI unsigned char* eina_binbuf_release(Eina_Binbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API unsigned char* eina_binbuf_release(Eina_Binbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @}

--- a/src/lib/eina/eina_binbuf_template_c.x
+++ b/src/lib/eina/eina_binbuf_template_c.x
@@ -57,7 +57,7 @@ _FUNC_EXPAND(shutdown)(void)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI _STRBUF_STRUCT_NAME *
+EINA_API _STRBUF_STRUCT_NAME *
 _FUNC_EXPAND(new)(void)
 {
    _STRBUF_STRUCT_NAME *buf = eina_strbuf_common_new(_STRBUF_CSIZE);
@@ -65,7 +65,7 @@ _FUNC_EXPAND(new)(void)
    return buf;
 }
 
-EAPI _STRBUF_STRUCT_NAME *
+EINA_API _STRBUF_STRUCT_NAME *
 _FUNC_EXPAND(manage_new_length)(_STRBUF_DATA_TYPE *str, size_t length)
 {
    _STRBUF_STRUCT_NAME *buf =
@@ -74,7 +74,7 @@ _FUNC_EXPAND(manage_new_length)(_STRBUF_DATA_TYPE *str, size_t length)
    return buf;
 }
 
-EAPI _STRBUF_STRUCT_NAME *
+EINA_API _STRBUF_STRUCT_NAME *
 _FUNC_EXPAND(manage_read_only_new_length)(const _STRBUF_DATA_TYPE *str, size_t length)
 {
    _STRBUF_STRUCT_NAME *buf =
@@ -83,7 +83,7 @@ _FUNC_EXPAND(manage_read_only_new_length)(const _STRBUF_DATA_TYPE *str, size_t l
    return buf;
 }
 
-EAPI void
+EINA_API void
 _FUNC_EXPAND(free)(_STRBUF_STRUCT_NAME *buf)
 {
    if (!buf) return ;
@@ -93,14 +93,14 @@ _FUNC_EXPAND(free)(_STRBUF_STRUCT_NAME *buf)
    eina_strbuf_common_free(buf);
 }
 
-EAPI void
+EINA_API void
 _FUNC_EXPAND(reset)(_STRBUF_STRUCT_NAME *buf)
 {
    EINA_MAGIC_CHECK_STRBUF(buf);
    eina_strbuf_common_reset(_STRBUF_CSIZE, buf);
 }
 
-EAPI Eina_Rw_Slice
+EINA_API Eina_Rw_Slice
 _FUNC_EXPAND(expand)(_STRBUF_STRUCT_NAME *buf, size_t minimum_unused_space)
 {
    Eina_Rw_Slice ret = {.len = 0, .mem = NULL};
@@ -108,28 +108,28 @@ _FUNC_EXPAND(expand)(_STRBUF_STRUCT_NAME *buf, size_t minimum_unused_space)
    return eina_strbuf_common_expand(_STRBUF_CSIZE, buf, minimum_unused_space);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(use)(_STRBUF_STRUCT_NAME *buf, size_t extra_bytes)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_use(buf, extra_bytes);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(append_length)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *str, size_t length)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_append_length(_STRBUF_CSIZE, buf, (const void *) str, length);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(append_slice)(_STRBUF_STRUCT_NAME *buf, const Eina_Slice slice)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_append_length(_STRBUF_CSIZE, buf, slice.mem, slice.len);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(append_buffer)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_STRUCT_NAME *data)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
@@ -138,70 +138,70 @@ _FUNC_EXPAND(append_buffer)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_STRUCT_NAME 
    return eina_strbuf_common_append_length(_STRBUF_CSIZE, buf, (_STRBUF_DATA_TYPE *) eina_strbuf_common_string_get(data), eina_strbuf_common_length_get(data));
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(insert_length)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *str, size_t length, size_t pos)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_insert_length(_STRBUF_CSIZE, buf, (const void *) str, length, pos);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(insert_slice)(_STRBUF_STRUCT_NAME *buf, const Eina_Slice slice, size_t pos)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_insert_length(_STRBUF_CSIZE, buf, slice.mem, slice.len, pos);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(append_char)(_STRBUF_STRUCT_NAME *buf, _STRBUF_DATA_TYPE c)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_append_char(_STRBUF_CSIZE, buf, (const void *) &c);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(insert_char)(_STRBUF_STRUCT_NAME *buf, _STRBUF_DATA_TYPE c, size_t pos)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_insert_char(_STRBUF_CSIZE, buf, (const void *) &c, pos);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(remove)(_STRBUF_STRUCT_NAME *buf, size_t start, size_t end)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_remove(_STRBUF_CSIZE, buf, start, end);
 }
 
-EAPI const _STRBUF_DATA_TYPE *
+EINA_API const _STRBUF_DATA_TYPE *
 _FUNC_EXPAND(string_get)(const _STRBUF_STRUCT_NAME *buf)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, NULL);
    return (const _STRBUF_DATA_TYPE *) eina_strbuf_common_string_get(buf);
 }
 
-EAPI _STRBUF_DATA_TYPE *
+EINA_API _STRBUF_DATA_TYPE *
 _FUNC_EXPAND(string_steal)(_STRBUF_STRUCT_NAME *buf)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, NULL);
    return (_STRBUF_DATA_TYPE *) eina_strbuf_common_string_steal(_STRBUF_CSIZE, buf);
 }
 
-EAPI void
+EINA_API void
 _FUNC_EXPAND(string_free)(_STRBUF_STRUCT_NAME *buf)
 {
    EINA_MAGIC_CHECK_STRBUF(buf);
    eina_strbuf_common_string_free(_STRBUF_CSIZE, buf);
 }
 
-EAPI size_t
+EINA_API size_t
 _FUNC_EXPAND(length_get)(const _STRBUF_STRUCT_NAME *buf)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, 0);
    return eina_strbuf_common_length_get(buf);
 }
 
-EAPI Eina_Slice
+EINA_API Eina_Slice
 _FUNC_EXPAND(slice_get)(const _STRBUF_STRUCT_NAME *buf)
 {
    Eina_Slice ret = {.len = 0, .mem = NULL};
@@ -209,7 +209,7 @@ _FUNC_EXPAND(slice_get)(const _STRBUF_STRUCT_NAME *buf)
    return eina_strbuf_common_slice_get(buf);
 }
 
-EAPI Eina_Rw_Slice
+EINA_API Eina_Rw_Slice
 _FUNC_EXPAND(rw_slice_get)(const _STRBUF_STRUCT_NAME *buf)
 {
    Eina_Rw_Slice ret = {.len = 0, .mem = NULL};
@@ -217,7 +217,7 @@ _FUNC_EXPAND(rw_slice_get)(const _STRBUF_STRUCT_NAME *buf)
    return eina_strbuf_common_rw_slice_get(buf);
 }
 
-EAPI _STRBUF_DATA_TYPE*
+EINA_API _STRBUF_DATA_TYPE*
 _FUNC_EXPAND(release)(_STRBUF_STRUCT_NAME *buf)
 {
    _STRBUF_DATA_TYPE *result;

--- a/src/lib/eina/eina_binshare.c
+++ b/src/lib/eina/eina_binshare.c
@@ -83,7 +83,7 @@ static const char EINA_MAGIC_BINSHARE_NODE_STR[] = "Eina Binshare Node";
  *
  * @see eina_init()
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_binshare_init(void)
 {
    Eina_Bool ret;
@@ -124,7 +124,7 @@ eina_binshare_init(void)
  *
  * @see eina_shutdown()
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_binshare_shutdown(void)
 {
    Eina_Bool ret;
@@ -144,7 +144,7 @@ eina_binshare_shutdown(void)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI void
+EINA_API void
 eina_binshare_del(const void *obj)
 {
    if (!obj)
@@ -154,7 +154,7 @@ eina_binshare_del(const void *obj)
      CRI("EEEK trying to del non-shared binshare %p", obj);
 }
 
-EAPI const void *
+EINA_API const void *
 eina_binshare_add_length(const void *obj, unsigned int olen)
 {
    return eina_share_common_add_length(binshare_share,
@@ -163,19 +163,19 @@ eina_binshare_add_length(const void *obj, unsigned int olen)
                                                      0);
 }
 
-EAPI const void *
+EINA_API const void *
 eina_binshare_ref(const void *obj)
 {
    return eina_share_common_ref(binshare_share, obj);
 }
 
-EAPI int
+EINA_API int
 eina_binshare_length(const void *obj)
 {
    return eina_share_common_length(binshare_share, obj);
 }
 
-EAPI void
+EINA_API void
 eina_binshare_dump(void)
 {
    eina_share_common_dump(binshare_share, NULL, 0);

--- a/src/lib/eina/eina_binshare.h
+++ b/src/lib/eina/eina_binshare.h
@@ -93,7 +93,7 @@
  *
  * @see eina_binshare_add()
  */
-EAPI const void *eina_binshare_add_length(const void  *obj,
+EINA_API const void *eina_binshare_add_length(const void  *obj,
                                           unsigned int olen) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -110,7 +110,7 @@ EAPI const void *eina_binshare_add_length(const void  *obj,
  *
  * @note There is no unref since this is the work of eina_binshare_del().
  */
-EAPI const void *eina_binshare_ref(const void *obj);
+EINA_API const void *eina_binshare_ref(const void *obj);
 
 /**
  * @brief Notes that the given object has lost an instance.
@@ -125,7 +125,7 @@ EAPI const void *eina_binshare_ref(const void *obj);
  * @warning If the given pointer is not shared, bad things happen, mostly a
  *          segmentation fault.
  */
-EAPI void        eina_binshare_del(const void *obj);
+EINA_API void        eina_binshare_del(const void *obj);
 
 /**
  * @brief Notes that the given object @b must be shared.
@@ -138,7 +138,7 @@ EAPI void        eina_binshare_del(const void *obj);
  * @warning If the given pointer is not shared, bad things happen, mostly a
  *          segmentation fault. If in doubt, try strlen().
  */
-EAPI int         eina_binshare_length(const void *obj) EINA_WARN_UNUSED_RESULT EINA_PURE;
+EINA_API int         eina_binshare_length(const void *obj) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief Dumps the contents of share_common.
@@ -146,7 +146,7 @@ EAPI int         eina_binshare_length(const void *obj) EINA_WARN_UNUSED_RESULT E
  * @details This function dumps all the objects from share_common to stdout with a
  *          DDD: prefix per line and a memory usage summary.
  */
-EAPI void        eina_binshare_dump(void);
+EINA_API void        eina_binshare_dump(void);
 
 /**
  * @brief Retrieves an instance of a blob for use in a program.

--- a/src/lib/eina/eina_convert.c
+++ b/src/lib/eina/eina_convert.c
@@ -91,9 +91,9 @@ static inline void reverse(char s[], int length)
  * @cond LOCAL
  */
 
-EAPI Eina_Error EINA_ERROR_CONVERT_P_NOT_FOUND = 0;
-EAPI Eina_Error EINA_ERROR_CONVERT_0X_NOT_FOUND = 0;
-EAPI Eina_Error EINA_ERROR_CONVERT_OUTRUN_STRING_LENGTH = 0;
+EINA_API Eina_Error EINA_ERROR_CONVERT_P_NOT_FOUND = 0;
+EINA_API Eina_Error EINA_ERROR_CONVERT_0X_NOT_FOUND = 0;
+EINA_API Eina_Error EINA_ERROR_CONVERT_OUTRUN_STRING_LENGTH = 0;
 
 /**
  * @endcond
@@ -150,7 +150,7 @@ eina_convert_shutdown(void)
  * Come from the second edition of The C Programming Language ("K&R2") on page 64
  */
 
-EAPI int
+EINA_API int
 eina_convert_itoa(int n, char *s)
 {
    int i = 0;
@@ -175,7 +175,7 @@ eina_convert_itoa(int n, char *s)
    return i + r;
 }
 
-EAPI int
+EINA_API int
 eina_convert_xtoa(unsigned int n, char *s)
 {
    int i;
@@ -194,7 +194,7 @@ eina_convert_xtoa(unsigned int n, char *s)
    return i;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_convert_atod(const char *src, int length, long long *m, long *e)
 {
    const char *str = src;
@@ -286,7 +286,7 @@ on_length_error:
    return EINA_FALSE;
 }
 
-EAPI int
+EINA_API int
 eina_convert_dtoa(double d, char *des)
 {
    int length = 0;
@@ -350,7 +350,7 @@ eina_convert_dtoa(double d, char *des)
    return length + eina_convert_itoa(p, des);
 }
 
-EAPI int
+EINA_API int
 eina_convert_fptoa(Eina_F32p32 fp, char *des)
 {
    int length = 0;
@@ -434,7 +434,7 @@ eina_convert_fptoa(Eina_F32p32 fp, char *des)
    return length + eina_convert_itoa(p, des);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_convert_atofp(const char *src, int length, Eina_F32p32 *fp)
 {
    long long m;
@@ -468,7 +468,7 @@ eina_convert_atofp(const char *src, int length, Eina_F32p32 *fp)
  * No hexadecimal form supported
  * no sequence supported after NAN
  */
-EAPI double
+EINA_API double
 eina_convert_strtod_c(const char *nptr, char **endptr)
 {
    const char *iter;

--- a/src/lib/eina/eina_convert.h
+++ b/src/lib/eina/eina_convert.h
@@ -158,9 +158,9 @@
  * @{
  */
 
-EAPI extern Eina_Error EINA_ERROR_CONVERT_P_NOT_FOUND; /**< Not used, perhaps a placeholder?  Defined as 0 in eina_convert.c*/
-EAPI extern Eina_Error EINA_ERROR_CONVERT_0X_NOT_FOUND; /**< Not used, perhaps a placeholder?  Defined as 0 in eina_convert.c*/
-EAPI extern Eina_Error EINA_ERROR_CONVERT_OUTRUN_STRING_LENGTH; /**< Not used, perhaps a placeholder?  Defined as 0 in eina_convert.c*/
+EINA_API extern Eina_Error EINA_ERROR_CONVERT_P_NOT_FOUND; /**< Not used, perhaps a placeholder?  Defined as 0 in eina_convert.c*/
+EINA_API extern Eina_Error EINA_ERROR_CONVERT_0X_NOT_FOUND; /**< Not used, perhaps a placeholder?  Defined as 0 in eina_convert.c*/
+EINA_API extern Eina_Error EINA_ERROR_CONVERT_OUTRUN_STRING_LENGTH; /**< Not used, perhaps a placeholder?  Defined as 0 in eina_convert.c*/
 
 /**
  * @brief Converts an integer number to a string in decimal base.
@@ -177,7 +177,7 @@ EAPI extern Eina_Error EINA_ERROR_CONVERT_OUTRUN_STRING_LENGTH; /**< Not used, p
  * The returned value is the length of the string, including the null
  * terminated character.
  */
-EAPI int       eina_convert_itoa(int n, char *s)  EINA_ARG_NONNULL(2);
+EINA_API int       eina_convert_itoa(int n, char *s)  EINA_ARG_NONNULL(2);
 
 /**
  * @brief Converts an integer number to a string in hexadecimal base.
@@ -195,7 +195,7 @@ EAPI int       eina_convert_itoa(int n, char *s)  EINA_ARG_NONNULL(2);
  * The returned value is the length of the string, including the nul
  * terminated character.
  */
-EAPI int       eina_convert_xtoa(unsigned int n, char *s) EINA_ARG_NONNULL(2);
+EINA_API int       eina_convert_xtoa(unsigned int n, char *s) EINA_ARG_NONNULL(2);
 
 
 /**
@@ -220,7 +220,7 @@ EAPI int       eina_convert_xtoa(unsigned int n, char *s) EINA_ARG_NONNULL(2);
  * The returned value is the length of the string, including the null
  * character.
  */
-EAPI int       eina_convert_dtoa(double d, char *des) EINA_ARG_NONNULL(2);
+EINA_API int       eina_convert_dtoa(double d, char *des) EINA_ARG_NONNULL(2);
 
 /**
  * @brief Converts a string to a double.
@@ -257,7 +257,7 @@ EAPI int       eina_convert_dtoa(double d, char *des) EINA_ARG_NONNULL(2);
  * If the string is invalid #EINA_FALSE is returned, otherwise #EINA_TRUE is
  * returned.
  */
-EAPI Eina_Bool eina_convert_atod(const char *src,
+EINA_API Eina_Bool eina_convert_atod(const char *src,
                                  int         length,
                                  long long  *m,
                                  long       *e) EINA_ARG_NONNULL(1, 3, 4);
@@ -289,7 +289,7 @@ EAPI Eina_Bool eina_convert_atod(const char *src,
  * implements the frexp() function for fixed point numbers and does
  * some optimization.
  */
-EAPI int       eina_convert_fptoa(Eina_F32p32 fp,
+EINA_API int       eina_convert_fptoa(Eina_F32p32 fp,
                                   char       *des) EINA_ARG_NONNULL(2);
 
 /**
@@ -329,7 +329,7 @@ EAPI int       eina_convert_fptoa(Eina_F32p32 fp,
  * @note The code uses eina_convert_atod() and do the correct bit
  * shift to compute the fixed point number.
  */
-EAPI Eina_Bool eina_convert_atofp(const char  *src,
+EINA_API Eina_Bool eina_convert_atofp(const char  *src,
                                   int          length,
                                   Eina_F32p32 *fp) EINA_ARG_NONNULL(1, 3);
 
@@ -347,7 +347,7 @@ EAPI Eina_Bool eina_convert_atofp(const char  *src,
  * without locale-dependency, this function can replace strtod.
  * For more information, please refer documents of strtod, strtod_l.
  */
-EAPI double eina_convert_strtod_c(const char *nptr, char **endptr);
+EINA_API double eina_convert_strtod_c(const char *nptr, char **endptr);
 
 /**
  * @}

--- a/src/lib/eina/eina_counter.c
+++ b/src/lib/eina/eina_counter.c
@@ -113,7 +113,7 @@ _eina_counter_asiprintf(char *base, int *position, const char *format, ...)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI Eina_Counter *
+EINA_API Eina_Counter *
 eina_counter_new(const char *name)
 {
    Eina_Counter *counter;
@@ -131,7 +131,7 @@ eina_counter_new(const char *name)
    return counter;
 }
 
-EAPI void
+EINA_API void
 eina_counter_free(Eina_Counter *counter)
 {
    EINA_SAFETY_ON_NULL_RETURN(counter);
@@ -147,7 +147,7 @@ eina_counter_free(Eina_Counter *counter)
    free(counter);
 }
 
-EAPI void
+EINA_API void
 eina_counter_start(Eina_Counter *counter)
 {
    Eina_Clock *clk;
@@ -165,7 +165,7 @@ eina_counter_start(Eina_Counter *counter)
    clk->start = tp;
 }
 
-EAPI void
+EINA_API void
 eina_counter_stop(Eina_Counter *counter, int specimen)
 {
    Eina_Clock *clk;
@@ -185,7 +185,7 @@ eina_counter_stop(Eina_Counter *counter, int specimen)
    clk->valid = EINA_TRUE;
 }
 
-EAPI char *
+EINA_API char *
 eina_counter_dump(Eina_Counter *counter)
 {
    Eina_Clock *clk;

--- a/src/lib/eina/eina_counter.h
+++ b/src/lib/eina/eina_counter.h
@@ -124,7 +124,7 @@ typedef struct _Eina_Counter Eina_Counter;
  * @note When the new counter is not needed anymore, use eina_counter_free() to
  *       free the allocated memory.
  */
-EAPI Eina_Counter *eina_counter_new(const char *name) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Counter *eina_counter_new(const char *name) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Deletes a counter.
@@ -135,7 +135,7 @@ EAPI Eina_Counter *eina_counter_new(const char *name) EINA_WARN_UNUSED_RESULT EI
  * @param[in] counter The counter to delete
  *
  */
-EAPI void          eina_counter_free(Eina_Counter *counter) EINA_ARG_NONNULL(1);
+EINA_API void          eina_counter_free(Eina_Counter *counter) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Starts the time count.
@@ -152,7 +152,7 @@ EAPI void          eina_counter_free(Eina_Counter *counter) EINA_ARG_NONNULL(1);
  * @note To stop the timing, eina_counter_stop() must be called with the
  *       same counter.
  */
-EAPI void          eina_counter_start(Eina_Counter *counter) EINA_ARG_NONNULL(1);
+EINA_API void          eina_counter_start(Eina_Counter *counter) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Stops the time count.
@@ -165,7 +165,7 @@ EAPI void          eina_counter_start(Eina_Counter *counter) EINA_ARG_NONNULL(1)
  * @param[in] specimen The number of the test
  *
  */
-EAPI void          eina_counter_stop(Eina_Counter *counter,
+EINA_API void          eina_counter_stop(Eina_Counter *counter,
                                      int           specimen) EINA_ARG_NONNULL(1);
 
 /**
@@ -185,7 +185,7 @@ EAPI void          eina_counter_stop(Eina_Counter *counter,
  *
  * @note The unit of time is nanoseconds.
  */
-EAPI char         *eina_counter_dump(Eina_Counter *counter) EINA_ARG_NONNULL(1);
+EINA_API char         *eina_counter_dump(Eina_Counter *counter) EINA_ARG_NONNULL(1);
 
 /**
  * @}

--- a/src/lib/eina/eina_cow.c
+++ b/src/lib/eina/eina_cow.c
@@ -326,7 +326,7 @@ eina_cow_shutdown(void)
    return EINA_TRUE;
 }
 
-EAPI Eina_Cow *
+EINA_API Eina_Cow *
 eina_cow_add(const char *name, unsigned int struct_size, unsigned int step, const void *default_value, Eina_Bool gc)
 {
    const char *choice, *tmp;
@@ -390,7 +390,7 @@ eina_cow_add(const char *name, unsigned int struct_size, unsigned int step, cons
    return NULL;
 }
 
-EAPI void
+EINA_API void
 eina_cow_del(Eina_Cow *cow)
 {
    if (!cow) return;
@@ -405,7 +405,7 @@ eina_cow_del(Eina_Cow *cow)
    free(cow);
 }
 
-EAPI const Eina_Cow_Data *
+EINA_API const Eina_Cow_Data *
 eina_cow_alloc(Eina_Cow *cow)
 {
 #ifdef EINA_COW_MAGIC_ON
@@ -415,7 +415,7 @@ eina_cow_alloc(Eina_Cow *cow)
    return cow->default_value;
 }
 
-EAPI void
+EINA_API void
 eina_cow_free(Eina_Cow *cow, const Eina_Cow_Data **data)
 {
    Eina_Cow_Ptr *ref;
@@ -451,7 +451,7 @@ eina_cow_free(Eina_Cow *cow, const Eina_Cow_Data **data)
    eina_mempool_free(cow->pool, (void*) ref);
 }
 
-EAPI void *
+EINA_API void *
 eina_cow_write(Eina_Cow *cow,
 	       const Eina_Cow_Data * const *data)
 {
@@ -535,7 +535,7 @@ eina_cow_write(Eina_Cow *cow,
    return (void *) *data;
 }
 
-EAPI void
+EINA_API void
 eina_cow_done(Eina_Cow *cow,
 	      const Eina_Cow_Data * const * dst,
 	      const void *data,
@@ -569,7 +569,7 @@ eina_cow_done(Eina_Cow *cow,
    _eina_cow_togc_add(cow, ref, (const Eina_Cow_Data **) dst);
 }
 
-EAPI void
+EINA_API void
 eina_cow_memcpy(Eina_Cow *cow,
 		const Eina_Cow_Data * const *dst,
 		const Eina_Cow_Data *src)
@@ -603,7 +603,7 @@ eina_cow_memcpy(Eina_Cow *cow,
    *((const void**)dst) = src;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_cow_gc(Eina_Cow *cow)
 {
    Eina_Cow_GC *gc;

--- a/src/lib/eina/eina_cow.h
+++ b/src/lib/eina/eina_cow.h
@@ -61,14 +61,14 @@ typedef void Eina_Cow_Data;
  * @param[in] gc Is it possible to run garbage collection on this pool.
  * @return A valid new Eina_Cow, or @c NULL on error.
  */
-EAPI Eina_Cow *eina_cow_add(const char *name, unsigned int struct_size, unsigned int step, const void *default_value, Eina_Bool gc) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Cow *eina_cow_add(const char *name, unsigned int struct_size, unsigned int step, const void *default_value, Eina_Bool gc) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Destroys an Eina_Cow pool and all the allocated memory.
  *
  * @param[in] cow The pool to destroy
  */
-EAPI void eina_cow_del(Eina_Cow *cow);
+EINA_API void eina_cow_del(Eina_Cow *cow);
 
 /**
  * @brief Returns an initialized pointer from the pool.
@@ -76,7 +76,7 @@ EAPI void eina_cow_del(Eina_Cow *cow);
  * @param[in] cow The pool to take things from.
  * @return A pointer to the new pool instance
  */
-EAPI const Eina_Cow_Data *eina_cow_alloc(Eina_Cow *cow) EINA_WARN_UNUSED_RESULT;
+EINA_API const Eina_Cow_Data *eina_cow_alloc(Eina_Cow *cow) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Frees a pointer from the pool.
@@ -87,7 +87,7 @@ EAPI const Eina_Cow_Data *eina_cow_alloc(Eina_Cow *cow) EINA_WARN_UNUSED_RESULT;
  * @note To simplify the caller code *data will point to the default
  * read only state after the call to this function.
  */
-EAPI void eina_cow_free(Eina_Cow *cow, const Eina_Cow_Data **data);
+EINA_API void eina_cow_free(Eina_Cow *cow, const Eina_Cow_Data **data);
 
 /**
  * @brief Gets a writeable pointer from a const pointer.
@@ -97,7 +97,7 @@ EAPI void eina_cow_free(Eina_Cow *cow, const Eina_Cow_Data **data);
  *
  * @note This function is not thread safe.
  */
-EAPI void *eina_cow_write(Eina_Cow *cow,
+EINA_API void *eina_cow_write(Eina_Cow *cow,
 			  const Eina_Cow_Data * const *src) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -110,7 +110,7 @@ EAPI void *eina_cow_write(Eina_Cow *cow,
  *
  * @note This function is not thread safe.
  */
-EAPI void eina_cow_done(Eina_Cow *cow,
+EINA_API void eina_cow_done(Eina_Cow *cow,
 			const Eina_Cow_Data * const *dst,
 			const void *data,
 			Eina_Bool needed_gc);
@@ -121,7 +121,7 @@ EAPI void eina_cow_done(Eina_Cow *cow,
  * @param[in] dst The destination to update.
  * @param[in] src The source of information to copy.
  */
-EAPI void eina_cow_memcpy(Eina_Cow *cow,
+EINA_API void eina_cow_memcpy(Eina_Cow *cow,
 			  const Eina_Cow_Data * const *dst,
 			  const Eina_Cow_Data *src);
 
@@ -135,7 +135,7 @@ EAPI void eina_cow_memcpy(Eina_Cow *cow,
  * It does run a hash function on all possible common structures trying to
  * find the one that matches and merge them into one pointer.
  */
-EAPI Eina_Bool eina_cow_gc(Eina_Cow *cow);
+EINA_API Eina_Bool eina_cow_gc(Eina_Cow *cow);
 
 /**
  * @def EINA_COW_WRITE_BEGIN

--- a/src/lib/eina/eina_cpu.c
+++ b/src/lib/eina/eina_cpu.c
@@ -165,7 +165,7 @@ _ppc_cpu_features(Eina_Cpu_Features *features)
 /* FIXME the features checks should be called when this function is called?
  * or make it static by doing eina_cpu_init() and return a local var
  */
-EAPI Eina_Cpu_Features eina_cpu_features = 0;
+EINA_API Eina_Cpu_Features eina_cpu_features = 0;
 
 Eina_Bool
 eina_cpu_init(void)
@@ -192,7 +192,7 @@ eina_cpu_shutdown(void)
  *
  * @return
  */
-EAPI Eina_Cpu_Features eina_cpu_features_get(void)
+EINA_API Eina_Cpu_Features eina_cpu_features_get(void)
 {
    return eina_cpu_features;
 }
@@ -302,13 +302,13 @@ _eina_page_size(void)
      }
 }
 
-EAPI int eina_cpu_page_size(void)
+EINA_API int eina_cpu_page_size(void)
 {
    if (_page_size == 0) _eina_page_size();
    return _page_size;
 }
 
-EAPI int eina_cpu_count(void)
+EINA_API int eina_cpu_count(void)
 {
    return _cpu_count;
 }

--- a/src/lib/eina/eina_cpu.h
+++ b/src/lib/eina/eina_cpu.h
@@ -64,14 +64,14 @@ typedef enum _Eina_Cpu_Features
  *
  * @return the current cpu features
  */
-EAPI extern Eina_Cpu_Features eina_cpu_features;
+EINA_API extern Eina_Cpu_Features eina_cpu_features;
 
 /**
  * @brief Cpu features accessor.
  *
  * @return the current cpu features
  */
-EAPI Eina_Cpu_Features eina_cpu_features_get(void);
+EINA_API Eina_Cpu_Features eina_cpu_features_get(void);
 
 /**
  * @brief Gets the current number of processors.
@@ -79,7 +79,7 @@ EAPI Eina_Cpu_Features eina_cpu_features_get(void);
  * @return The number of processors that are online, that
  * is available when the function is called.
  */
-EAPI int               eina_cpu_count(void);
+EINA_API int               eina_cpu_count(void);
 
 /**
  * @brief Gets the current virtual page size.
@@ -88,7 +88,7 @@ EAPI int               eina_cpu_count(void);
  * allocation performed by the operating system on behalf of the program, and
  * for transfers between the main memory and any other auxiliary store.
  */
-EAPI int               eina_cpu_page_size(void);
+EINA_API int               eina_cpu_page_size(void);
 
 /**
  * @brief Reverses the byte order of a 16-bit (destination) register.

--- a/src/lib/eina/eina_crc.c
+++ b/src/lib/eina/eina_crc.c
@@ -287,7 +287,7 @@ static const unsigned int table[8][256] =
    }
 };
 
-EAPI unsigned int
+EINA_API unsigned int
 _eina_crc(const char *data, int len, unsigned int seed, Eina_Bool start_stream)
 {
    unsigned int crc;

--- a/src/lib/eina/eina_debug.c
+++ b/src/lib/eina/eina_debug.c
@@ -143,7 +143,7 @@ struct _Eina_Debug_Session
 static void _opcodes_register_all(Eina_Debug_Session *session);
 static void _thread_start(Eina_Debug_Session *session);
 
-EAPI int
+EINA_API int
 eina_debug_session_send(Eina_Debug_Session *session, int dest, int op, void *data, int size)
 {
    Eina_Debug_Packet_Header hdr;
@@ -262,13 +262,13 @@ end:
    return rret;
 }
 
-EAPI void
+EINA_API void
 eina_debug_disable()
 {
    _debug_disabled = EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 eina_debug_session_terminate(Eina_Debug_Session *session)
 {
    /* Close fd here so the thread terminates its own session by itself */
@@ -287,7 +287,7 @@ eina_debug_session_terminate(Eina_Debug_Session *session)
      }
 }
 
-EAPI void
+EINA_API void
 eina_debug_session_dispatch_override(Eina_Debug_Session *session, Eina_Debug_Dispatch_Cb disp_cb)
 {
    if (!session) return;
@@ -295,7 +295,7 @@ eina_debug_session_dispatch_override(Eina_Debug_Session *session, Eina_Debug_Dis
    session->dispatch_cb = disp_cb;
 }
 
-EAPI Eina_Debug_Dispatch_Cb
+EINA_API Eina_Debug_Dispatch_Cb
 eina_debug_session_dispatch_get(Eina_Debug_Session *session)
 {
    if (session) return session->dispatch_cb;
@@ -458,7 +458,7 @@ _session_create(int fd)
    return session;
 }
 
-EAPI Eina_Debug_Session *
+EINA_API Eina_Debug_Session *
 eina_debug_remote_connect(int port)
 {
    int fd;
@@ -488,7 +488,7 @@ err:
    return NULL;
 }
 
-EAPI Eina_Debug_Session *
+EINA_API Eina_Debug_Session *
 eina_debug_local_connect(Eina_Bool is_master)
 {
 #ifndef _WIN32
@@ -608,7 +608,7 @@ _thread_start(Eina_Debug_Session *session)
  * - Pointer to ops: returned in the response to determine which opcodes have been added
  * - List of opcode names separated by \0
  */
-EAPI void
+EINA_API void
 eina_debug_opcodes_register(Eina_Debug_Session *session, const Eina_Debug_Opcode ops[],
       Eina_Debug_Opcode_Status_Cb status_cb, void *data)
 {
@@ -630,7 +630,7 @@ eina_debug_opcodes_register(Eina_Debug_Session *session, const Eina_Debug_Opcode
       _opcodes_registration_send(session, info);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_debug_dispatch(Eina_Debug_Session *session, void *buffer)
 {
    Eina_Debug_Packet_Header *hdr = buffer;
@@ -655,13 +655,13 @@ eina_debug_dispatch(Eina_Debug_Session *session, void *buffer)
    return EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 eina_debug_session_data_set(Eina_Debug_Session *session, void *data)
 {
    if (session) session->data = data;
 }
 
-EAPI void *
+EINA_API void *
 eina_debug_session_data_get(Eina_Debug_Session *session)
 {
    if (session) return session->data;
@@ -718,7 +718,7 @@ eina_debug_shutdown(void)
    return EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 eina_debug_fork_reset(void)
 {
    extern Eina_Bool fork_resetting;

--- a/src/lib/eina/eina_debug.h
+++ b/src/lib/eina/eina_debug.h
@@ -162,7 +162,7 @@ typedef struct
  * of them.
  * Need to be invoked before eina_init. Otherwise it won't have any effect.
  */
-EAPI void eina_debug_disable(void);
+EINA_API void eina_debug_disable(void);
 
 /**
  * @brief Connect to the local daemon
@@ -171,7 +171,7 @@ EAPI void eina_debug_disable(void);
  *
  * @return The session on success or NULL otherwise.
  */
-EAPI Eina_Debug_Session *eina_debug_local_connect(Eina_Bool is_master);
+EINA_API Eina_Debug_Session *eina_debug_local_connect(Eina_Bool is_master);
 
 /**
  * @brief Connect to remote daemon
@@ -182,14 +182,14 @@ EAPI Eina_Debug_Session *eina_debug_local_connect(Eina_Bool is_master);
  *
  * @return The session on success or NULL otherwise.
  */
-EAPI Eina_Debug_Session *eina_debug_remote_connect(int port);
+EINA_API Eina_Debug_Session *eina_debug_remote_connect(int port);
 
 /**
  * @brief Terminate the session
  *
  * @param[in,out] session the session to terminate
  */
-EAPI void eina_debug_session_terminate(Eina_Debug_Session *session);
+EINA_API void eina_debug_session_terminate(Eina_Debug_Session *session);
 
 /**
  * @brief Override the dispatcher of a specific session
@@ -201,7 +201,7 @@ EAPI void eina_debug_session_terminate(Eina_Debug_Session *session);
  * @param[in,out] session the session
  * @param[in] disp_cb the new dispatcher for the given session
  */
-EAPI void eina_debug_session_dispatch_override(Eina_Debug_Session *session, Eina_Debug_Dispatch_Cb disp_cb);
+EINA_API void eina_debug_session_dispatch_override(Eina_Debug_Session *session, Eina_Debug_Dispatch_Cb disp_cb);
 
 /**
  * @brief Get the dispatcher of a specific session
@@ -210,7 +210,7 @@ EAPI void eina_debug_session_dispatch_override(Eina_Debug_Session *session, Eina
  *
  * @return The session dispatcher.
  */
-EAPI Eina_Debug_Dispatch_Cb eina_debug_session_dispatch_get(Eina_Debug_Session *session);
+EINA_API Eina_Debug_Dispatch_Cb eina_debug_session_dispatch_get(Eina_Debug_Session *session);
 
 /**
  * @brief Dispatch a given packet according to its header.
@@ -224,7 +224,7 @@ EAPI Eina_Debug_Dispatch_Cb eina_debug_session_dispatch_get(Eina_Debug_Session *
  *
  * @return True on success, false if the connection seems compromised.
  */
-EAPI Eina_Bool eina_debug_dispatch(Eina_Debug_Session *session, void *buffer);
+EINA_API Eina_Bool eina_debug_dispatch(Eina_Debug_Session *session, void *buffer);
 
 /**
  * @brief Set data to a session
@@ -232,7 +232,7 @@ EAPI Eina_Bool eina_debug_dispatch(Eina_Debug_Session *session, void *buffer);
  * @param[in,out] session the session
  * @param[in] data the data to set
  */
-EAPI void eina_debug_session_data_set(Eina_Debug_Session *session, void *data);
+EINA_API void eina_debug_session_data_set(Eina_Debug_Session *session, void *data);
 
 /**
  * @brief Get the data attached to a session
@@ -241,7 +241,7 @@ EAPI void eina_debug_session_data_set(Eina_Debug_Session *session, void *data);
  *
  * @return The data of the session.
  */
-EAPI void *eina_debug_session_data_get(Eina_Debug_Session *session);
+EINA_API void *eina_debug_session_data_get(Eina_Debug_Session *session);
 
 /**
  * @brief Register opcodes to a session
@@ -257,7 +257,7 @@ EAPI void *eina_debug_session_data_get(Eina_Debug_Session *session);
  * @param[in] status_cb a function to call when the opcodes are received
  * @param[in] status_data the data to give to status_cb
  */
-EAPI void eina_debug_opcodes_register(Eina_Debug_Session *session,
+EINA_API void eina_debug_opcodes_register(Eina_Debug_Session *session,
       const Eina_Debug_Opcode ops[],
       Eina_Debug_Opcode_Status_Cb status_cb, void *status_data);
 
@@ -274,7 +274,7 @@ EAPI void eina_debug_opcodes_register(Eina_Debug_Session *session,
  *
  * @return The number of sent bytes.
  */
-EAPI int eina_debug_session_send(Eina_Debug_Session *session, int dest_id, int op, void *data, int size);
+EINA_API int eina_debug_session_send(Eina_Debug_Session *session, int dest_id, int op, void *data, int size);
 
 /**
  * @brief Add a timer
@@ -285,7 +285,7 @@ EAPI int eina_debug_session_send(Eina_Debug_Session *session, int dest_id, int o
  *
  * @return The timer handle, NULL on error.
  */
-EAPI Eina_Debug_Timer *eina_debug_timer_add(unsigned int timeout_ms, Eina_Debug_Timer_Cb cb, void *data);
+EINA_API Eina_Debug_Timer *eina_debug_timer_add(unsigned int timeout_ms, Eina_Debug_Timer_Cb cb, void *data);
 
 /**
  * @brief Delete a timer
@@ -295,7 +295,7 @@ EAPI Eina_Debug_Timer *eina_debug_timer_add(unsigned int timeout_ms, Eina_Debug_
  * If the timer reaches the end and has not be renewed, trying to delete it will lead to a crash, as
  * it has already been deleted internally.
  */
-EAPI void eina_debug_timer_del(Eina_Debug_Timer *timer);
+EINA_API void eina_debug_timer_del(Eina_Debug_Timer *timer);
 
 /**
  * @brief Reset the eina debug system after forking
@@ -303,7 +303,7 @@ EAPI void eina_debug_timer_del(Eina_Debug_Timer *timer);
  * Call this any time the application forks
  * @since 1.21
  * */
-EAPI void eina_debug_fork_reset(void);
+EINA_API void eina_debug_fork_reset(void);
 /**
  * @}
  */

--- a/src/lib/eina/eina_debug_timer.c
+++ b/src/lib/eina/eina_debug_timer.c
@@ -159,7 +159,7 @@ _monitor(void *_data EINA_UNUSED)
    return NULL;
 }
 
-EAPI Eina_Debug_Timer *
+EINA_API Eina_Debug_Timer *
 eina_debug_timer_add(unsigned int timeout_ms, Eina_Debug_Timer_Cb cb, void *data)
 {
    if (!cb || !timeout_ms) return NULL;
@@ -205,7 +205,7 @@ eina_debug_timer_add(unsigned int timeout_ms, Eina_Debug_Timer_Cb cb, void *data
    return t;
 }
 
-EAPI void
+EINA_API void
 eina_debug_timer_del(Eina_Debug_Timer *t)
 {
   abort();

--- a/src/lib/eina/eina_error.c
+++ b/src/lib/eina/eina_error.c
@@ -132,7 +132,7 @@ static inline int strerror_r(int errnum, char *buf, size_t buflen)
  * @cond LOCAL
  */
 
-EAPI Eina_Error EINA_ERROR_OUT_OF_MEMORY = ENOMEM;
+EINA_API Eina_Error EINA_ERROR_OUT_OF_MEMORY = ENOMEM;
 
 /**
  * @endcond
@@ -219,7 +219,7 @@ eina_error_shutdown(void)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Error
+EINA_API Eina_Error
 eina_error_msg_register(const char *msg)
 {
    Eina_Error_Message *eem;
@@ -241,7 +241,7 @@ eina_error_msg_register(const char *msg)
    return EINA_ERROR_FROM_INDEX(_eina_errors_count); /* identifier = index + 1 (== _count). */
 }
 
-EAPI Eina_Error
+EINA_API Eina_Error
 eina_error_msg_static_register(const char *msg)
 {
    Eina_Error_Message *eem;
@@ -257,7 +257,7 @@ eina_error_msg_static_register(const char *msg)
    return EINA_ERROR_FROM_INDEX(_eina_errors_count); /* identifier = index + 1 (== _count). */
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_error_msg_modify(Eina_Error error, const char *msg)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(msg, EINA_FALSE);
@@ -285,7 +285,7 @@ eina_error_msg_modify(Eina_Error error, const char *msg)
    return EINA_TRUE;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_error_msg_get(Eina_Error error)
 {
    if (!EINA_ERROR_REGISTERED_CHECK(error))
@@ -379,7 +379,7 @@ eina_error_msg_get(Eina_Error error)
    return _eina_errors[error - 1].string;
 }
 
-EAPI Eina_Error
+EINA_API Eina_Error
 eina_error_get(void)
 {
    if (eina_main_loop_is())
@@ -388,7 +388,7 @@ eina_error_get(void)
    return (Eina_Error)(uintptr_t) eina_tls_get(_eina_last_key);
 }
 
-EAPI void
+EINA_API void
 eina_error_set(Eina_Error err)
 {
    if (eina_main_loop_is())
@@ -397,7 +397,7 @@ eina_error_set(Eina_Error err)
      eina_tls_set(_eina_last_key, (void*)(uintptr_t) err);
 }
 
-EAPI Eina_Error
+EINA_API Eina_Error
 eina_error_find(const char *msg)
 {
    size_t i;

--- a/src/lib/eina/eina_error.h
+++ b/src/lib/eina/eina_error.h
@@ -113,7 +113,7 @@ typedef Eina_Bool Eina_Success_Flag;
  *
  * @deprecated since 1.19, same as @c ENOMEM from @c errno.h
  */
-EAPI extern Eina_Error EINA_ERROR_OUT_OF_MEMORY EINA_DEPRECATED; /* use ENOMEM */
+EINA_API extern Eina_Error EINA_ERROR_OUT_OF_MEMORY EINA_DEPRECATED; /* use ENOMEM */
 
 /**
  * @brief Registers a new error type.
@@ -131,7 +131,7 @@ EAPI extern Eina_Error EINA_ERROR_OUT_OF_MEMORY EINA_DEPRECATED; /* use ENOMEM *
  *
  * @see eina_error_msg_static_register()
  */
-EAPI Eina_Error  eina_error_msg_register(const char *msg) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Error  eina_error_msg_register(const char *msg) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Registers a new error type, statically allocated message.
@@ -150,7 +150,7 @@ EAPI Eina_Error  eina_error_msg_register(const char *msg) EINA_ARG_NONNULL(1) EI
  *
  * @see eina_error_msg_register()
  */
-EAPI Eina_Error  eina_error_msg_static_register(const char *msg) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Error  eina_error_msg_static_register(const char *msg) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Changes the message of an already registered message.
@@ -171,7 +171,7 @@ EAPI Eina_Error  eina_error_msg_static_register(const char *msg) EINA_ARG_NONNUL
  *
  * @see eina_error_msg_register()
  */
-EAPI Eina_Bool   eina_error_msg_modify(Eina_Error  error,
+EINA_API Eina_Bool   eina_error_msg_modify(Eina_Error  error,
                                        const char *msg) EINA_ARG_NONNULL(2);
 
 /**
@@ -183,7 +183,7 @@ EAPI Eina_Bool   eina_error_msg_modify(Eina_Error  error,
  *
  * @note This function is thread safe @since 1.10, but slower to use.
  */
-EAPI Eina_Error  eina_error_get(void);
+EINA_API Eina_Error  eina_error_get(void);
 
 /**
  * @brief Sets the last error.
@@ -197,7 +197,7 @@ EAPI Eina_Error  eina_error_get(void);
  *
  * @note This function is thread safe @since 1.10, but slower to use.
  */
-EAPI void        eina_error_set(Eina_Error err);
+EINA_API void        eina_error_set(Eina_Error err);
 
 /**
  * @brief Returns the description of the given error number.
@@ -208,7 +208,7 @@ EAPI void        eina_error_set(Eina_Error err);
  * @return The description of the error
  *
  */
-EAPI const char *eina_error_msg_get(Eina_Error error) EINA_PURE;
+EINA_API const char *eina_error_msg_get(Eina_Error error) EINA_PURE;
 
 /**
  * @brief Finds the #Eina_Error corresponding to a message string.
@@ -223,7 +223,7 @@ EAPI const char *eina_error_msg_get(Eina_Error error) EINA_PURE;
  *       eina_error_msg_static_register() or modified with
  *       eina_error_msg_modify().
  */
-EAPI Eina_Error  eina_error_find(const char *msg) EINA_ARG_NONNULL(1) EINA_PURE;
+EINA_API Eina_Error  eina_error_find(const char *msg) EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @}

--- a/src/lib/eina/eina_evlog.c
+++ b/src/lib/eina/eina_evlog.c
@@ -156,7 +156,7 @@ push_buf(Eina_Evlog_Buf *b, unsigned int size)
    return ptr;
 }
 
-EAPI void
+EINA_API void
 eina_evlog(const char *event, void *obj, double srctime, const char *detail)
 {
    Eina_Evlog_Item *item;
@@ -193,7 +193,7 @@ eina_evlog(const char *event, void *obj, double srctime, const char *detail)
    eina_spinlock_release(&_evlog_lock);
 }
 
-EAPI Eina_Evlog_Buf *
+EINA_API Eina_Evlog_Buf *
 eina_evlog_steal(void)
 {
    Eina_Evlog_Buf *stolen = NULL;
@@ -217,7 +217,7 @@ eina_evlog_steal(void)
    return stolen;
 }
 
-EAPI void
+EINA_API void
 eina_evlog_start(void)
 {
    eina_spinlock_take(&_evlog_lock);
@@ -231,7 +231,7 @@ eina_evlog_start(void)
    eina_spinlock_release(&_evlog_lock);
 }
 
-EAPI void
+EINA_API void
 eina_evlog_stop(void)
 {
    eina_spinlock_take(&_evlog_lock);

--- a/src/lib/eina/eina_evlog.h
+++ b/src/lib/eina/eina_evlog.h
@@ -113,7 +113,7 @@ struct _Eina_Evlog_Buf
  *
  * @since 1.15
  */
-EAPI void
+EINA_API void
 eina_evlog(const char *event, void *obj, double srctime, const char *detail);
 
 /**
@@ -126,7 +126,7 @@ eina_evlog(const char *event, void *obj, double srctime, const char *detail);
  *
  * @since 1.15
  */
-EAPI Eina_Evlog_Buf *
+EINA_API Eina_Evlog_Buf *
 eina_evlog_steal(void);
 
 /**
@@ -134,7 +134,7 @@ eina_evlog_steal(void);
  *
  * @since 1.15
  */
-EAPI void
+EINA_API void
 eina_evlog_start(void);
 
 /**
@@ -145,7 +145,7 @@ eina_evlog_start(void);
  *
  * @since 1.15
  */
-EAPI void
+EINA_API void
 eina_evlog_stop(void);
 
 /**

--- a/src/lib/eina/eina_file.c
+++ b/src/lib/eina/eina_file.c
@@ -558,7 +558,7 @@ eina_file_cleanup(Eina_Tmpstr *path)
 
 
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_dir_list(const char *dir,
                    Eina_Bool recursive,
                    Eina_File_Dir_List_Cb cb,
@@ -590,7 +590,7 @@ eina_file_dir_list(const char *dir,
    return EINA_TRUE;
 }
 
-EAPI Eina_Array *
+EINA_API Eina_Array *
 eina_file_split(char *path)
 {
    Eina_Array *ea;
@@ -623,7 +623,7 @@ eina_file_split(char *path)
    return ea;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_ls(const char *dir)
 {
 #ifdef HAVE_DIRENT_H
@@ -671,7 +671,7 @@ eina_file_ls(const char *dir)
 #endif
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_direct_ls(const char *dir)
 {
 #ifdef HAVE_DIRENT_H
@@ -731,7 +731,7 @@ eina_file_direct_ls(const char *dir)
 #endif
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_stat_ls(const char *dir)
 {
 #ifdef HAVE_DIRENT_H
@@ -791,7 +791,7 @@ eina_file_stat_ls(const char *dir)
 #endif
 }
 
-EAPI Eina_File *
+EINA_API Eina_File *
 eina_file_open(const char *path, Eina_Bool shared)
 {
    Eina_File *file;
@@ -900,7 +900,7 @@ eina_file_open(const char *path, Eina_Bool shared)
    return NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_refresh(Eina_File *file)
 {
    struct stat file_stat;
@@ -933,7 +933,7 @@ eina_file_refresh(Eina_File *file)
    return r;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_unlink(const char *pathname)
 {
    if ( unlink(pathname) < 0)
@@ -943,7 +943,7 @@ eina_file_unlink(const char *pathname)
    return EINA_TRUE;
 }
 
-EAPI void *
+EINA_API void *
 eina_file_map_all(Eina_File *file, Eina_File_Populate rule)
 {
    int flags = MAP_SHARED;
@@ -994,7 +994,7 @@ eina_file_map_all(Eina_File *file, Eina_File_Populate rule)
    return ret;
 }
 
-EAPI void *
+EINA_API void *
 eina_file_map_new(Eina_File *file, Eina_File_Populate rule,
                   unsigned long int offset, unsigned long int length)
 {
@@ -1073,7 +1073,7 @@ eina_file_map_new(Eina_File *file, Eina_File_Populate rule,
    return NULL;
 }
 
-EAPI void
+EINA_API void
 eina_file_map_free(Eina_File *file, void *map)
 {
    EINA_SAFETY_ON_NULL_RETURN(file);
@@ -1104,7 +1104,7 @@ eina_file_map_free(Eina_File *file, void *map)
    eina_lock_release(&file->lock);
 }
 
-EAPI void
+EINA_API void
 eina_file_map_populate(Eina_File *file, Eina_File_Populate rule, const void *map,
                        unsigned long int offset, unsigned long int length)
 {
@@ -1119,7 +1119,7 @@ eina_file_map_populate(Eina_File *file, Eina_File_Populate rule, const void *map
    eina_lock_release(&file->lock);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_map_faulted(Eina_File *file, void *map)
 {
    Eina_Bool r = EINA_FALSE;
@@ -1161,7 +1161,7 @@ eina_file_map_faulted(Eina_File *file, void *map)
    return r;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_xattr_get(Eina_File *file)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(file, NULL);
@@ -1171,7 +1171,7 @@ eina_file_xattr_get(Eina_File *file)
    return eina_xattr_fd_ls(file->fd);
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_xattr_value_get(Eina_File *file)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(file, NULL);
@@ -1181,7 +1181,7 @@ eina_file_xattr_value_get(Eina_File *file)
    return eina_xattr_value_fd_ls(file->fd);
 }
 
-EAPI int
+EINA_API int
 eina_file_statat(void *container, Eina_File_Direct_Info *info, Eina_Stat *st)
 {
    struct stat buf;
@@ -1256,7 +1256,7 @@ eina_file_statat(void *container, Eina_File_Direct_Info *info, Eina_Stat *st)
    return 0;
 }
 
-EAPI void
+EINA_API void
 eina_file_close_from(int fd, int *except_fd)
 {
 #if defined(_WIN32)

--- a/src/lib/eina/eina_file.h
+++ b/src/lib/eina/eina_file.h
@@ -264,7 +264,7 @@ struct _Eina_File_Line
  * @param[in] data The data to pass to the callback
  * @return #EINA_TRUE on success, otherwise #EINA_FALSE
  */
-EAPI Eina_Bool eina_file_dir_list(const char           *dir,
+EINA_API Eina_Bool eina_file_dir_list(const char           *dir,
                                   Eina_Bool             recursive,
                                   Eina_File_Dir_List_Cb cb,
                                   void                 *data) EINA_ARG_NONNULL(1, 3);
@@ -280,7 +280,7 @@ EAPI Eina_Bool eina_file_dir_list(const char           *dir,
  * @return An array of the parts of the path to split
  *
  */
-EAPI Eina_Array    *eina_file_split(char *path) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API Eina_Array    *eina_file_split(char *path) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * @brief Gets an iterator to list the content of a directory.
@@ -300,7 +300,7 @@ EAPI Eina_Array    *eina_file_split(char *path) EINA_WARN_UNUSED_RESULT EINA_ARG
  *
  * @see eina_file_direct_ls()
  */
-EAPI Eina_Iterator *eina_file_ls(const char *dir) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API Eina_Iterator *eina_file_ls(const char *dir) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * @brief Gets an iterator to list the content of a directory, with direct
@@ -327,7 +327,7 @@ EAPI Eina_Iterator *eina_file_ls(const char *dir) EINA_WARN_UNUSED_RESULT EINA_A
  *
  * @see eina_file_direct_ls()
  */
-EAPI Eina_Iterator *eina_file_stat_ls(const char *dir) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API Eina_Iterator *eina_file_stat_ls(const char *dir) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * @brief Uses information provided by #Eina_Iterator of eina_file_stat_ls() or eina_file_direct_ls()
@@ -345,7 +345,7 @@ EAPI Eina_Iterator *eina_file_stat_ls(const char *dir) EINA_WARN_UNUSED_RESULT E
  *
  * @since 1.2
  */
-EAPI int eina_file_statat(void *container, Eina_File_Direct_Info *info, Eina_Stat *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1, 2, 3);
+EINA_API int eina_file_statat(void *container, Eina_File_Direct_Info *info, Eina_Stat *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief Close all file descriptors that are open at or above the given fd
@@ -362,7 +362,7 @@ EAPI int eina_file_statat(void *container, Eina_File_Direct_Info *info, Eina_Sta
  * 
  * @since 1.24
  */
-EAPI void eina_file_close_from(int fd, int *except_fd);
+EINA_API void eina_file_close_from(int fd, int *except_fd);
 
 /**
  * @brief Generates and creates a uniquely named temporary file from a template name.
@@ -393,7 +393,7 @@ EAPI void eina_file_close_from(int fd, int *except_fd);
  * @see eina_file_mkdtemp()
  * @since 1.8
  */
-EAPI int eina_file_mkstemp(const char *templatename, Eina_Tmpstr **path) EINA_ARG_NONNULL(1);
+EINA_API int eina_file_mkstemp(const char *templatename, Eina_Tmpstr **path) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Generates and creates a uniquely named temporary directory from a template name.
@@ -417,7 +417,7 @@ EAPI int eina_file_mkstemp(const char *templatename, Eina_Tmpstr **path) EINA_AR
  * @see eina_file_mkstemp()
  * @since 1.8
  */
-EAPI Eina_Bool eina_file_mkdtemp(const char *templatename, Eina_Tmpstr **path) EINA_ARG_NONNULL(1,2);
+EINA_API Eina_Bool eina_file_mkdtemp(const char *templatename, Eina_Tmpstr **path) EINA_ARG_NONNULL(1,2);
 
 /**
  * @brief Gets an iterator to list the content of a directory, with direct
@@ -446,7 +446,7 @@ EAPI Eina_Bool eina_file_mkdtemp(const char *templatename, Eina_Tmpstr **path) E
  *
  * @see eina_file_ls()
  */
-EAPI Eina_Iterator *eina_file_direct_ls(const char *dir) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API Eina_Iterator *eina_file_direct_ls(const char *dir) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * @brief Sanitizes the file path.
@@ -460,7 +460,7 @@ EAPI Eina_Iterator *eina_file_direct_ls(const char *dir) EINA_WARN_UNUSED_RESULT
  *
  * @since 1.1
  */
-EAPI char *eina_file_path_sanitize(const char *path);
+EINA_API char *eina_file_path_sanitize(const char *path);
 
 /**
  * @typedef Eina_File_Copy_Progress
@@ -497,7 +497,7 @@ typedef enum {
  *
  * @note During the progress it may call back @p cb with the progress summary.
  */
-EAPI Eina_Bool eina_file_copy(const char *src, const char *dst, Eina_File_Copy_Flags flags, Eina_File_Copy_Progress cb, const void *cb_data) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_file_copy(const char *src, const char *dst, Eina_File_Copy_Flags flags, Eina_File_Copy_Progress cb, const void *cb_data) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Gets a read-only handler to a file.
@@ -512,7 +512,7 @@ EAPI Eina_Bool eina_file_copy(const char *src, const char *dst, Eina_File_Copy_F
  *
  * @since 1.1
  */
-EAPI Eina_File *eina_file_open(const char *name, Eina_Bool shared) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API Eina_File *eina_file_open(const char *name, Eina_Bool shared) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * @brief Creates a virtual file from a memory pointer.
@@ -525,7 +525,7 @@ EAPI Eina_File *eina_file_open(const char *name, Eina_Bool shared) EINA_WARN_UNU
  *
  * @since 1.8
  */
-EAPI Eina_File *
+EINA_API Eina_File *
 eina_file_virtualize(const char *virtual_name, const void *data, unsigned long long length, Eina_Bool copy) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
@@ -536,7 +536,7 @@ eina_file_virtualize(const char *virtual_name, const void *data, unsigned long l
  *
  * @since 1.8
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_virtual(Eina_File *file) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
@@ -549,7 +549,7 @@ eina_file_virtual(Eina_File *file) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
  *
  * @since 1.8
  */
-EAPI Eina_Bool eina_file_refresh(Eina_File *file);
+EINA_API Eina_Bool eina_file_refresh(Eina_File *file);
 
 /**
  * @brief Duplicates a read-only handler of a previously open file.
@@ -561,7 +561,7 @@ EAPI Eina_Bool eina_file_refresh(Eina_File *file);
  *
  * @since 1.8
  */
-EAPI Eina_File * eina_file_dup(const Eina_File *file);
+EINA_API Eina_File * eina_file_dup(const Eina_File *file);
 
 /**
  * @brief Unrefs the file handler.
@@ -571,7 +571,7 @@ EAPI Eina_File * eina_file_dup(const Eina_File *file);
  *
  * @since 1.1
  */
-EAPI void eina_file_close(Eina_File *file);
+EINA_API void eina_file_close(Eina_File *file);
 
 /**
  * @brief Gets the file size at open time.
@@ -581,7 +581,7 @@ EAPI void eina_file_close(Eina_File *file);
  *
  * @since 1.1
  */
-EAPI size_t eina_file_size_get(const Eina_File *file);
+EINA_API size_t eina_file_size_get(const Eina_File *file);
 
 /**
  * @brief Gets the last modification time of an open file.
@@ -591,7 +591,7 @@ EAPI size_t eina_file_size_get(const Eina_File *file);
  *
  * @since 1.1
  */
-EAPI time_t eina_file_mtime_get(const Eina_File *file);
+EINA_API time_t eina_file_mtime_get(const Eina_File *file);
 
 /**
  * @brief Gets the filename of an open file.
@@ -601,7 +601,7 @@ EAPI time_t eina_file_mtime_get(const Eina_File *file);
  *
  * @since 1.1
  */
-EAPI const char *eina_file_filename_get(const Eina_File *file);
+EINA_API const char *eina_file_filename_get(const Eina_File *file);
 
 /**
  * @brief Gets the extended attribute of an open file.
@@ -614,7 +614,7 @@ EAPI const char *eina_file_filename_get(const Eina_File *file);
  *
  * @since 1.2
  */
-EAPI Eina_Iterator *eina_file_xattr_get(Eina_File *file);
+EINA_API Eina_Iterator *eina_file_xattr_get(Eina_File *file);
 
 /**
  * @brief Gets the extended attribute of an open file.
@@ -628,7 +628,7 @@ EAPI Eina_Iterator *eina_file_xattr_get(Eina_File *file);
  *
  * @since 1.2
  */
-EAPI Eina_Iterator *eina_file_xattr_value_get(Eina_File *file);
+EINA_API Eina_Iterator *eina_file_xattr_value_get(Eina_File *file);
 
 /**
  * @brief Maps all the files to a buffer.
@@ -640,7 +640,7 @@ EAPI Eina_Iterator *eina_file_xattr_value_get(Eina_File *file);
  *
  * @since 1.1
  */
-EAPI void *eina_file_map_all(Eina_File *file, Eina_File_Populate rule);
+EINA_API void *eina_file_map_all(Eina_File *file, Eina_File_Populate rule);
 
 /**
  * @brief Maps a part of the file.
@@ -656,7 +656,7 @@ EAPI void *eina_file_map_all(Eina_File *file, Eina_File_Populate rule);
  *
  * @since 1.1
  */
-EAPI void *eina_file_map_new(Eina_File *file, Eina_File_Populate rule,
+EINA_API void *eina_file_map_new(Eina_File *file, Eina_File_Populate rule,
                              unsigned long int offset, unsigned long int length);
 
 /**
@@ -667,7 +667,7 @@ EAPI void *eina_file_map_new(Eina_File *file, Eina_File_Populate rule,
  *
  * @since 1.1
  */
-EAPI void eina_file_map_free(Eina_File *file, void *map);
+EINA_API void eina_file_map_free(Eina_File *file, void *map);
 
 /**
  * @brief Asks the OS to populate or otherwise pages of memory in file mapping.
@@ -683,7 +683,7 @@ EAPI void eina_file_map_free(Eina_File *file, void *map);
  * 
  * @since 1.8
  */
-EAPI void
+EINA_API void
 eina_file_map_populate(Eina_File *file, Eina_File_Populate rule, const void *map,
                        unsigned long int offset, unsigned long int length);
 
@@ -698,7 +698,7 @@ eina_file_map_populate(Eina_File *file, Eina_File_Populate rule, const void *map
  *
  * @since 1.3
  */
-EAPI Eina_Iterator *eina_file_map_lines(Eina_File *file);
+EINA_API Eina_Iterator *eina_file_map_lines(Eina_File *file);
 
 /**
  * @brief Tells whether there has been an IO error during the life of a mmaped file.
@@ -709,7 +709,7 @@ EAPI Eina_Iterator *eina_file_map_lines(Eina_File *file);
  *
  * @since 1.2
  */
-EAPI Eina_Bool eina_file_map_faulted(Eina_File *file, void *map);
+EINA_API Eina_Bool eina_file_map_faulted(Eina_File *file, void *map);
 
 /**
  * @brief Joins two paths of known length.
@@ -768,7 +768,7 @@ static inline size_t eina_file_path_join(char *dst,
  *
  * @since 1.19
  */
-EAPI Eina_Bool eina_file_unlink(const char *pathname);
+EINA_API Eina_Bool eina_file_unlink(const char *pathname);
 
 /**
  * @brief Make sure a file descriptor will be closed on exec.
@@ -781,7 +781,7 @@ EAPI Eina_Bool eina_file_unlink(const char *pathname);
  *
  * @since 1.20
  */
-EAPI Eina_Bool eina_file_close_on_exec(int fd, Eina_Bool on);
+EINA_API Eina_Bool eina_file_close_on_exec(int fd, Eina_Bool on);
 
 #include "eina_inline_file.x"
 
@@ -796,26 +796,26 @@ typedef unsigned int Eina_Statgen;
  * @brief Force the stat generation counter to tick over so any following i/o does real i/o and stat calls
  * @since 1.23
  */
-EAPI void         eina_file_statgen_next(void);
+EINA_API void         eina_file_statgen_next(void);
 
 /**
  * @brief Get the current stat generation counter value
  * @return 0 if you should always do stat calls and compare, or some other value that changes like a generation counter
  * @since 1.23
  */
-EAPI Eina_Statgen eina_file_statgen_get(void);
+EINA_API Eina_Statgen eina_file_statgen_get(void);
 
 /**
  * @brief Enable stat generation count optimiziing to only stat/do file i/o between generation counts changing
  * @since 1.23
  */
-EAPI void         eina_file_statgen_enable(void);
+EINA_API void         eina_file_statgen_enable(void);
 
 /**
  * @brief Disable stat generation count optimiziing to only stat/do file i/o between generation counts changing
  * @since 1.23
  */
-EAPI void         eina_file_statgen_disable(void);
+EINA_API void         eina_file_statgen_disable(void);
 
 /**
  * @}

--- a/src/lib/eina/eina_file_common.c
+++ b/src/lib/eina/eina_file_common.c
@@ -75,7 +75,7 @@ Eina_Lock _eina_file_lock_cache;
 static Eina_Spinlock _eina_statgen_lock;
 static Eina_Statgen _eina_statgen = 0;
 
-EAPI void
+EINA_API void
 eina_file_statgen_next(void)
 {
    eina_spinlock_take(&_eina_statgen_lock);
@@ -87,7 +87,7 @@ eina_file_statgen_next(void)
    eina_spinlock_release(&_eina_statgen_lock);
 }
 
-EAPI Eina_Statgen
+EINA_API Eina_Statgen
 eina_file_statgen_get(void)
 {
    Eina_Statgen s;
@@ -97,7 +97,7 @@ eina_file_statgen_get(void)
    return s;
 }
 
-EAPI void
+EINA_API void
 eina_file_statgen_enable(void)
 {
    eina_spinlock_take(&_eina_statgen_lock);
@@ -105,7 +105,7 @@ eina_file_statgen_enable(void)
    eina_spinlock_release(&_eina_statgen_lock);
 }
 
-EAPI void
+EINA_API void
 eina_file_statgen_disable(void)
 {
    eina_spinlock_take(&_eina_statgen_lock);
@@ -407,7 +407,7 @@ _eina_file_map_close(Eina_File_Map *map)
 
 // Global API
 
-EAPI char *
+EINA_API char *
 eina_file_path_sanitize(const char *path)
 {
    Eina_Tmpstr *result = NULL;
@@ -432,7 +432,7 @@ eina_file_path_sanitize(const char *path)
    return r;
 }
 
-EAPI Eina_File *
+EINA_API Eina_File *
 eina_file_virtualize(const char *virtual_name, const void *data, unsigned long long length, Eina_Bool copy)
 {
    Eina_File *file;
@@ -496,7 +496,7 @@ eina_file_virtualize(const char *virtual_name, const void *data, unsigned long l
    return file;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_virtual(Eina_File *file)
 {
    if (!file) return EINA_FALSE;
@@ -504,7 +504,7 @@ eina_file_virtual(Eina_File *file)
    return file->virtual;
 }
 
-EAPI Eina_File *
+EINA_API Eina_File *
 eina_file_dup(const Eina_File *f)
 {
    Eina_File *file = (Eina_File*) f;
@@ -546,7 +546,7 @@ eina_file_clean_close(Eina_File *file)
    free(file);
 }
 
-EAPI void
+EINA_API void
 eina_file_close(Eina_File *file)
 {
    Eina_Bool leave = EINA_TRUE;
@@ -576,21 +576,21 @@ eina_file_close(Eina_File *file)
    eina_lock_release(&_eina_file_lock_cache);
 }
 
-EAPI size_t
+EINA_API size_t
 eina_file_size_get(const Eina_File *file)
 {
    EINA_FILE_MAGIC_CHECK(file, 0);
    return file->length;
 }
 
-EAPI time_t
+EINA_API time_t
 eina_file_mtime_get(const Eina_File *file)
 {
    EINA_FILE_MAGIC_CHECK(file, 0);
    return file->mtime;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_file_filename_get(const Eina_File *file)
 {
    EINA_FILE_MAGIC_CHECK(file, NULL);
@@ -697,7 +697,7 @@ _eina_file_map_lines_iterator_free(Eina_Lines_Iterator *it)
    free(it);
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_map_lines(Eina_File *file)
 {
    Eina_Lines_Iterator *it;
@@ -954,7 +954,7 @@ _eina_file_copy_internal(int s, int d, off_t total, Eina_File_Copy_Progress cb, 
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_copy(const char *src, const char *dst, Eina_File_Copy_Flags flags, Eina_File_Copy_Progress cb, const void *cb_data)
 {
    struct stat st;
@@ -995,7 +995,7 @@ eina_file_copy(const char *src, const char *dst, Eina_File_Copy_Flags flags, Ein
    return success;
 }
 
-EAPI int
+EINA_API int
 eina_file_mkstemp(const char *templatename, Eina_Tmpstr **path)
 {
    char buffer[PATH_MAX];
@@ -1054,7 +1054,7 @@ eina_file_mkstemp(const char *templatename, Eina_Tmpstr **path)
    return fd;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_mkdtemp(const char *templatename, Eina_Tmpstr **path)
 {
    char buffer[PATH_MAX];
@@ -1149,7 +1149,7 @@ eina_file_shutdown(void)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_close_on_exec(int fd, Eina_Bool on)
 {
 #ifdef _WIN32

--- a/src/lib/eina/eina_file_win32.c
+++ b/src/lib/eina/eina_file_win32.c
@@ -452,7 +452,7 @@ eina_file_cleanup(Eina_Tmpstr *path)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_dir_list(const char *dir,
                    Eina_Bool recursive,
                    Eina_File_Dir_List_Cb cb,
@@ -514,7 +514,7 @@ eina_file_dir_list(const char *dir,
    return EINA_TRUE;
 }
 
-EAPI Eina_Array *
+EINA_API Eina_Array *
 eina_file_split(char *path)
 {
    Eina_Array *ea;
@@ -547,7 +547,7 @@ eina_file_split(char *path)
    return ea;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_ls(const char *dir)
 {
    Eina_File_Iterator *it;
@@ -592,7 +592,7 @@ eina_file_ls(const char *dir)
    return NULL;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_direct_ls(const char *dir)
 {
    Eina_File_Direct_Iterator *it;
@@ -643,13 +643,13 @@ eina_file_direct_ls(const char *dir)
    return NULL;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_file_stat_ls(const char *dir)
 {
    return eina_file_direct_ls(dir);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_refresh(Eina_File *file)
 {
    WIN32_FILE_ATTRIBUTE_DATA fad;
@@ -681,7 +681,7 @@ eina_file_refresh(Eina_File *file)
    return r;
 }
 
-EAPI Eina_File *
+EINA_API Eina_File *
 eina_file_open(const char *path, Eina_Bool shared)
 {
    Eina_File *file;
@@ -790,7 +790,7 @@ eina_file_open(const char *path, Eina_Bool shared)
    return NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_unlink(const char *pathname)
 {
    Eina_Stringshare *unlink_path = eina_file_sanitize(pathname);
@@ -829,23 +829,23 @@ eina_file_unlink(const char *pathname)
 }
 
 
-EAPI Eina_Iterator *eina_file_xattr_get(Eina_File *file EINA_UNUSED)
+EINA_API Eina_Iterator *eina_file_xattr_get(Eina_File *file EINA_UNUSED)
 {
    return NULL;
 }
 
-EAPI Eina_Iterator *eina_file_xattr_value_get(Eina_File *file EINA_UNUSED)
+EINA_API Eina_Iterator *eina_file_xattr_value_get(Eina_File *file EINA_UNUSED)
 {
    return NULL;
 }
 
-EAPI void
+EINA_API void
 eina_file_map_populate(Eina_File *file EINA_UNUSED, Eina_File_Populate rule EINA_UNUSED, const void *map EINA_UNUSED,
                        unsigned long int offset EINA_UNUSED, unsigned long int length EINA_UNUSED)
 {
 }
 
-EAPI void *
+EINA_API void *
 eina_file_map_all(Eina_File *file, Eina_File_Populate rule EINA_UNUSED)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(file, NULL);
@@ -888,7 +888,7 @@ eina_file_map_all(Eina_File *file, Eina_File_Populate rule EINA_UNUSED)
    return NULL;
 }
 
-EAPI void *
+EINA_API void *
 eina_file_map_new(Eina_File *file, Eina_File_Populate rule,
                   unsigned long int offset, unsigned long int length)
 {
@@ -961,7 +961,7 @@ eina_file_map_new(Eina_File *file, Eina_File_Populate rule,
    return map->map;
 }
 
-EAPI void
+EINA_API void
 eina_file_map_free(Eina_File *file, void *map)
 {
    EINA_SAFETY_ON_NULL_RETURN(file);
@@ -992,7 +992,7 @@ eina_file_map_free(Eina_File *file, void *map)
    eina_lock_release(&file->lock);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_file_map_faulted(Eina_File *file, void *map EINA_UNUSED)
 {
 #warning "We need to handle access to corrupted memory mapped file."
@@ -1030,7 +1030,7 @@ eina_file_map_faulted(Eina_File *file, void *map EINA_UNUSED)
    return EINA_FALSE;
 }
 
-EAPI int
+EINA_API int
 eina_file_statat(void *container EINA_UNUSED, Eina_File_Direct_Info *info, Eina_Stat *st)
 {
    struct __stat64 buf;

--- a/src/lib/eina/eina_fp.c
+++ b/src/lib/eina/eina_fp.c
@@ -423,7 +423,7 @@ static const Eina_F32p32 eina_trigo[MAX_PREC] =
    0x0000000000653d02, 0x0000000000000000
 };
 
-EAPI Eina_F32p32
+EINA_API Eina_F32p32
 eina_f32p32_cos(Eina_F32p32 a)
 {
    Eina_F32p32 F32P32_2PI;
@@ -471,7 +471,7 @@ eina_f32p32_cos(Eina_F32p32 a)
    return result;
 }
 
-EAPI Eina_F32p32
+EINA_API Eina_F32p32
 eina_f32p32_sin(Eina_F32p32 a)
 {
    Eina_F32p32 F32P32_PI2;

--- a/src/lib/eina/eina_fp.h
+++ b/src/lib/eina/eina_fp.h
@@ -194,7 +194,7 @@ static inline unsigned int eina_f32p32_fracc_get(Eina_F32p32 v);
  * @param[in] a The angle in radians to calculate the cosine from.
  * @return The cosine of the angle @p a
  */
-EAPI Eina_F32p32           eina_f32p32_cos(Eina_F32p32 a);
+EINA_API Eina_F32p32           eina_f32p32_cos(Eina_F32p32 a);
 
 /**
  * @brief Calculates the sine of a floating point number
@@ -202,7 +202,7 @@ EAPI Eina_F32p32           eina_f32p32_cos(Eina_F32p32 a);
  * @param[in] a The angle in radians to calculate the sine from.
  * @return The cosine of the angle @p a
  */
-EAPI Eina_F32p32           eina_f32p32_sin(Eina_F32p32 a);
+EINA_API Eina_F32p32           eina_f32p32_sin(Eina_F32p32 a);
 
 
 /**

--- a/src/lib/eina/eina_freeq.c
+++ b/src/lib/eina/eina_freeq.c
@@ -431,7 +431,7 @@ _eina_freeq_new_postponed(void)
    return fq;
 }
 
-EAPI Eina_FreeQ *
+EINA_API Eina_FreeQ *
 eina_freeq_new(Eina_FreeQ_Type type)
 {
    switch (type)
@@ -445,7 +445,7 @@ eina_freeq_new(Eina_FreeQ_Type type)
      }
 }
 
-EAPI void
+EINA_API void
 eina_freeq_free(Eina_FreeQ *fq)
 {
    if (!fq) return;
@@ -455,7 +455,7 @@ eina_freeq_free(Eina_FreeQ *fq)
    free(fq);
 }
 
-EAPI Eina_FreeQ_Type
+EINA_API Eina_FreeQ_Type
 eina_freeq_type_get(Eina_FreeQ *fq)
 {
    if (fq && fq->postponed)
@@ -470,13 +470,13 @@ eina_freeq_main_set(Eina_FreeQ *fq)
    _eina_freeq_main = fq;
 }
 
-EAPI Eina_FreeQ *
+EINA_API Eina_FreeQ *
 eina_freeq_main_get(void)
 {
    return _eina_freeq_main;
 }
 
-EAPI void
+EINA_API void
 eina_freeq_count_max_set(Eina_FreeQ *fq, int count)
 {
    if (!fq) return;
@@ -489,7 +489,7 @@ eina_freeq_count_max_set(Eina_FreeQ *fq, int count)
    UNLOCK_FQ(fq);
 }
 
-EAPI int
+EINA_API int
 eina_freeq_count_max_get(Eina_FreeQ *fq)
 {
    int count;
@@ -502,7 +502,7 @@ eina_freeq_count_max_get(Eina_FreeQ *fq)
    return count;
 }
 
-EAPI void
+EINA_API void
 eina_freeq_mem_max_set(Eina_FreeQ *fq, size_t mem)
 {
    if (!fq) return;
@@ -514,7 +514,7 @@ eina_freeq_mem_max_set(Eina_FreeQ *fq, size_t mem)
    UNLOCK_FQ(fq);
 }
 
-EAPI size_t
+EINA_API size_t
 eina_freeq_mem_max_get(Eina_FreeQ *fq)
 {
    size_t mem;
@@ -527,7 +527,7 @@ eina_freeq_mem_max_get(Eina_FreeQ *fq)
    return mem;
 }
 
-EAPI void
+EINA_API void
 eina_freeq_clear(Eina_FreeQ *fq)
 {
    if (!fq) return;
@@ -537,7 +537,7 @@ eina_freeq_clear(Eina_FreeQ *fq)
    UNLOCK_FQ(fq);
 }
 
-EAPI void
+EINA_API void
 eina_freeq_reduce(Eina_FreeQ *fq, int count)
 {
    if (!fq) return;
@@ -551,7 +551,7 @@ eina_freeq_reduce(Eina_FreeQ *fq, int count)
    UNLOCK_FQ(fq);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_freeq_ptr_pending(Eina_FreeQ *fq)
 {
    Eina_Bool pending;
@@ -564,7 +564,7 @@ eina_freeq_ptr_pending(Eina_FreeQ *fq)
    return pending;
 }
 
-EAPI void
+EINA_API void
 eina_freeq_ptr_add(Eina_FreeQ *fq,
                    void *ptr,
                    void (*free_func) (void *ptr),

--- a/src/lib/eina/eina_freeq.h
+++ b/src/lib/eina/eina_freeq.h
@@ -126,7 +126,7 @@ typedef enum _Eina_FreeQ_Type
  * @return A new free queue
  * @since 1.19
  */
-EAPI Eina_FreeQ *
+EINA_API Eina_FreeQ *
 eina_freeq_new(Eina_FreeQ_Type type);
 
 /**
@@ -136,7 +136,7 @@ eina_freeq_new(Eina_FreeQ_Type type);
  * 
  * @since 1.19
  */
-EAPI void
+EINA_API void
 eina_freeq_free(Eina_FreeQ *fq);
 
 /**
@@ -146,7 +146,7 @@ eina_freeq_free(Eina_FreeQ *fq);
  *
  * @since 1.19
  */
-EAPI Eina_FreeQ_Type
+EINA_API Eina_FreeQ_Type
 eina_freeq_type_get(Eina_FreeQ *fq);
 
 /**
@@ -156,7 +156,7 @@ eina_freeq_type_get(Eina_FreeQ *fq);
  * 
  * @since 1.19
  */
-EAPI Eina_FreeQ *
+EINA_API Eina_FreeQ *
 eina_freeq_main_get(void);
 
 /**
@@ -177,7 +177,7 @@ eina_freeq_main_get(void);
  *
  * @since 1.19
  */
-EAPI void
+EINA_API void
 eina_freeq_count_max_set(Eina_FreeQ *fq, int count);
 
 /**
@@ -188,7 +188,7 @@ eina_freeq_count_max_set(Eina_FreeQ *fq, int count);
  * 
  * @since 1.19
  */
-EAPI int
+EINA_API int
 eina_freeq_count_max_get(Eina_FreeQ *fq);
 
 /**
@@ -210,7 +210,7 @@ eina_freeq_count_max_get(Eina_FreeQ *fq);
  * 
  * @since 1.19
  */
-EAPI void
+EINA_API void
 eina_freeq_mem_max_set(Eina_FreeQ *fq, size_t mem);
 
 /**
@@ -221,7 +221,7 @@ eina_freeq_mem_max_set(Eina_FreeQ *fq, size_t mem);
  *
  * @since 1.19
  */
-EAPI size_t
+EINA_API size_t
 eina_freeq_mem_max_get(Eina_FreeQ *fq);
 
 /**
@@ -235,7 +235,7 @@ eina_freeq_mem_max_get(Eina_FreeQ *fq);
  * 
  * @since 1.19
  */
-EAPI void
+EINA_API void
 eina_freeq_clear(Eina_FreeQ *fq);
 
 /**
@@ -251,7 +251,7 @@ eina_freeq_clear(Eina_FreeQ *fq);
  * 
  * @since 1.19
  */
-EAPI void
+EINA_API void
 eina_freeq_reduce(Eina_FreeQ *fq, int count);
 
 /**
@@ -262,7 +262,7 @@ eina_freeq_reduce(Eina_FreeQ *fq, int count);
  * 
  * @since 1.19
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_freeq_ptr_pending(Eina_FreeQ *fq);
 
 /**
@@ -306,7 +306,7 @@ eina_freeq_ptr_pending(Eina_FreeQ *fq);
  * 
  * @since 1.19
  */
-EAPI void
+EINA_API void
 eina_freeq_ptr_add(Eina_FreeQ *fq, void *ptr, void (*free_func) (void *ptr), size_t size);
 
 /**

--- a/src/lib/eina/eina_hamster.c
+++ b/src/lib/eina/eina_hamster.c
@@ -53,7 +53,7 @@ static const int _eina_hamster =
 *                                   API                                      *
 *============================================================================*/
 
-EAPI int
+EINA_API int
 eina_hamster_count(void)
 {
    return _eina_hamster;

--- a/src/lib/eina/eina_hamster.h
+++ b/src/lib/eina/eina_hamster.h
@@ -40,7 +40,7 @@
  *
  * This function returns how many hamsters you have.
  */
-EAPI int eina_hamster_count(void);
+EINA_API int eina_hamster_count(void);
 
 /**
  * @}

--- a/src/lib/eina/eina_hash.c
+++ b/src/lib/eina/eina_hash.c
@@ -729,7 +729,7 @@ _eina_hash_iterator_free(Eina_Iterator_Hash *it)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI void
+EINA_API void
 eina_hash_free_cb_set(Eina_Hash *hash, Eina_Free_Cb data_free_cb)
 {
    EINA_MAGIC_CHECK_HASH(hash);
@@ -738,7 +738,7 @@ eina_hash_free_cb_set(Eina_Hash *hash, Eina_Free_Cb data_free_cb)
    hash->data_free_cb = data_free_cb;
 }
 
-EAPI Eina_Hash *
+EINA_API Eina_Hash *
 eina_hash_new(Eina_Key_Length key_length_cb,
               Eina_Key_Cmp key_cmp_cb,
               Eina_Key_Hash key_hash_cb,
@@ -776,7 +776,7 @@ on_error:
    return NULL;
 }
 
-EAPI Eina_Hash *
+EINA_API Eina_Hash *
 eina_hash_string_djb2_new(Eina_Free_Cb data_free_cb)
 {
    return eina_hash_new(EINA_KEY_LENGTH(_eina_string_key_length),
@@ -786,7 +786,7 @@ eina_hash_string_djb2_new(Eina_Free_Cb data_free_cb)
                         EINA_HASH_BUCKET_SIZE);
 }
 
-EAPI Eina_Hash *
+EINA_API Eina_Hash *
 eina_hash_string_superfast_new(Eina_Free_Cb data_free_cb)
 {
    return eina_hash_new(EINA_KEY_LENGTH(_eina_string_key_length),
@@ -796,7 +796,7 @@ eina_hash_string_superfast_new(Eina_Free_Cb data_free_cb)
                         EINA_HASH_BUCKET_SIZE);
 }
 
-EAPI Eina_Hash *
+EINA_API Eina_Hash *
 eina_hash_string_small_new(Eina_Free_Cb data_free_cb)
 {
    return eina_hash_new(EINA_KEY_LENGTH(_eina_string_key_length),
@@ -806,7 +806,7 @@ eina_hash_string_small_new(Eina_Free_Cb data_free_cb)
                         EINA_HASH_SMALL_BUCKET_SIZE);
 }
 
-EAPI Eina_Hash *
+EINA_API Eina_Hash *
 eina_hash_int32_new(Eina_Free_Cb data_free_cb)
 {
    return eina_hash_new(EINA_KEY_LENGTH(_eina_int32_key_length),
@@ -816,7 +816,7 @@ eina_hash_int32_new(Eina_Free_Cb data_free_cb)
                         EINA_HASH_BUCKET_SIZE);
 }
 
-EAPI Eina_Hash *
+EINA_API Eina_Hash *
 eina_hash_int64_new(Eina_Free_Cb data_free_cb)
 {
    return eina_hash_new(EINA_KEY_LENGTH(_eina_int64_key_length),
@@ -826,7 +826,7 @@ eina_hash_int64_new(Eina_Free_Cb data_free_cb)
                         EINA_HASH_BUCKET_SIZE);
 }
 
-EAPI Eina_Hash *
+EINA_API Eina_Hash *
 eina_hash_pointer_new(Eina_Free_Cb data_free_cb)
 {
 #ifdef EFL64
@@ -844,7 +844,7 @@ eina_hash_pointer_new(Eina_Free_Cb data_free_cb)
 #endif
 }
 
-EAPI Eina_Hash *
+EINA_API Eina_Hash *
 eina_hash_stringshared_new(Eina_Free_Cb data_free_cb)
 {
    return eina_hash_new(NULL,
@@ -854,7 +854,7 @@ eina_hash_stringshared_new(Eina_Free_Cb data_free_cb)
                         EINA_HASH_BUCKET_SIZE);
 }
 
-EAPI int
+EINA_API int
 eina_hash_population(const Eina_Hash *hash)
 {
    if (!hash)
@@ -864,7 +864,7 @@ eina_hash_population(const Eina_Hash *hash)
    return hash->population;
 }
 
-EAPI void
+EINA_API void
 eina_hash_free(Eina_Hash *hash)
 {
    int i;
@@ -882,7 +882,7 @@ eina_hash_free(Eina_Hash *hash)
    free(hash);
 }
 
-EAPI void
+EINA_API void
 eina_hash_free_buckets(Eina_Hash *hash)
 {
    int i;
@@ -902,7 +902,7 @@ eina_hash_free_buckets(Eina_Hash *hash)
      }
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_add_by_hash(Eina_Hash *hash,
                       const void *key,
                       int key_length,
@@ -917,7 +917,7 @@ eina_hash_add_by_hash(Eina_Hash *hash,
                                       data);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_direct_add_by_hash(Eina_Hash *hash,
                              const void *key,
                              int key_length,
@@ -927,7 +927,7 @@ eina_hash_direct_add_by_hash(Eina_Hash *hash,
    return eina_hash_add_alloc_by_hash(hash, key, key_length, 0, key_hash, data);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_add(Eina_Hash *hash, const void *key, const void *data)
 {
    int key_length;
@@ -944,7 +944,7 @@ eina_hash_add(Eina_Hash *hash, const void *key, const void *data)
    return eina_hash_add_alloc_by_hash(hash, key, key_length, key_length, key_hash, data);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_direct_add(Eina_Hash *hash, const void *key, const void *data)
 {
    int key_length;
@@ -961,7 +961,7 @@ eina_hash_direct_add(Eina_Hash *hash, const void *key, const void *data)
    return eina_hash_add_alloc_by_hash(hash, key, key_length, 0, key_hash, data);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_del_by_key_hash(Eina_Hash *hash,
                           const void *key,
                           int key_length,
@@ -973,7 +973,7 @@ eina_hash_del_by_key_hash(Eina_Hash *hash,
    return _eina_hash_del_by_key_hash(hash, key, key_length, key_hash, NULL);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_del_by_key(Eina_Hash *hash, const void *key)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(hash, EINA_FALSE);
@@ -982,7 +982,7 @@ eina_hash_del_by_key(Eina_Hash *hash, const void *key)
    return _eina_hash_del_by_key(hash, key, NULL);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_del_by_data(Eina_Hash *hash, const void *data)
 {
    Eina_Hash_Element *hash_element;
@@ -1006,7 +1006,7 @@ error:
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_del_by_hash(Eina_Hash *hash,
                       const void *key,
                       int key_length,
@@ -1026,7 +1026,7 @@ eina_hash_del_by_hash(Eina_Hash *hash,
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_del(Eina_Hash *hash, const void *key, const void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(hash, EINA_FALSE);
@@ -1038,7 +1038,7 @@ eina_hash_del(Eina_Hash *hash, const void *key, const void *data)
    return _eina_hash_del_by_key(hash, key, data);
 }
 
-EAPI void *
+EINA_API void *
 eina_hash_find_by_hash(const Eina_Hash *hash,
                        const void *key,
                        int key_length,
@@ -1065,7 +1065,7 @@ eina_hash_find_by_hash(const Eina_Hash *hash,
    return NULL;
 }
 
-EAPI void *
+EINA_API void *
 eina_hash_find(const Eina_Hash *hash, const void *key)
 {
    int key_length;
@@ -1086,7 +1086,7 @@ eina_hash_find(const Eina_Hash *hash, const void *key)
    return eina_hash_find_by_hash(hash, key, key_length, key_hash);
 }
 
-EAPI void *
+EINA_API void *
 eina_hash_modify_by_hash(Eina_Hash *hash,
                          const void *key,
                          int key_length,
@@ -1117,7 +1117,7 @@ eina_hash_modify_by_hash(Eina_Hash *hash,
    return old_data;
 }
 
-EAPI void *
+EINA_API void *
 eina_hash_set(Eina_Hash *hash, const void *key, const void *data)
 {
    Eina_Hash_Tuple tuple;
@@ -1170,7 +1170,7 @@ eina_hash_set(Eina_Hash *hash, const void *key, const void *data)
    return NULL;
 }
 
-EAPI void *
+EINA_API void *
 eina_hash_modify(Eina_Hash *hash, const void *key, const void *data)
 {
    int key_length;
@@ -1187,7 +1187,7 @@ eina_hash_modify(Eina_Hash *hash, const void *key, const void *data)
    return eina_hash_modify_by_hash(hash, key, key_length, key_hash, data);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_hash_move(Eina_Hash *hash, const void *old_key, const void *new_key)
 {
    Eina_Free_Cb hash_free_cb;
@@ -1219,7 +1219,7 @@ error:
 *                                Iterator                                    *
 *============================================================================*/
 
-EAPI void
+EINA_API void
 eina_hash_foreach(const Eina_Hash *hash,
                   Eina_Hash_Foreach func,
                   const void *fdata)
@@ -1242,7 +1242,7 @@ eina_hash_foreach(const Eina_Hash *hash,
    eina_iterator_free(it);
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_hash_iterator_data_new(const Eina_Hash *hash)
 {
    Eina_Iterator_Hash *it;
@@ -1268,7 +1268,7 @@ eina_hash_iterator_data_new(const Eina_Hash *hash)
    return &it->iterator;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_hash_iterator_key_new(const Eina_Hash *hash)
 {
    Eina_Iterator_Hash *it;
@@ -1295,7 +1295,7 @@ eina_hash_iterator_key_new(const Eina_Hash *hash)
    return &it->iterator;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_hash_iterator_tuple_new(const Eina_Hash *hash)
 {
    Eina_Iterator_Hash *it;
@@ -1326,7 +1326,7 @@ eina_hash_iterator_tuple_new(const Eina_Hash *hash)
 
 /* Paul Hsieh (http://www.azillionmonkeys.com/qed/hash.html)
    used by WebCore (http://webkit.org/blog/8/hashtables-part-2/) */
-EAPI int
+EINA_API int
 eina_hash_superfast(const char *key, int len)
 {
    int hash = len, tmp;
@@ -1378,7 +1378,7 @@ eina_hash_superfast(const char *key, int len)
    return hash;
 }
 
-EAPI void
+EINA_API void
 eina_hash_list_append(Eina_Hash *hash, const void *key, const void *data)
 {
    Eina_Hash_Tuple tuple;
@@ -1411,7 +1411,7 @@ eina_hash_list_append(Eina_Hash *hash, const void *key, const void *data)
                             eina_list_append(NULL, data));
 }
 
-EAPI void
+EINA_API void
 eina_hash_list_direct_append(Eina_Hash *hash, const void *key, const void *data)
 {
    Eina_Hash_Tuple tuple;
@@ -1444,7 +1444,7 @@ eina_hash_list_direct_append(Eina_Hash *hash, const void *key, const void *data)
                             eina_list_append(NULL, data));
 }
 
-EAPI void
+EINA_API void
 eina_hash_list_prepend(Eina_Hash *hash, const void *key, const void *data)
 {
    Eina_Hash_Tuple tuple;
@@ -1477,7 +1477,7 @@ eina_hash_list_prepend(Eina_Hash *hash, const void *key, const void *data)
                             eina_list_append(NULL, data));
 }
 
-EAPI void
+EINA_API void
 eina_hash_list_direct_prepend(Eina_Hash *hash, const void *key, const void *data)
 {
    Eina_Hash_Tuple tuple;
@@ -1510,7 +1510,7 @@ eina_hash_list_direct_prepend(Eina_Hash *hash, const void *key, const void *data
                             eina_list_append(NULL, data));
 }
 
-EAPI void
+EINA_API void
 eina_hash_list_remove(Eina_Hash *hash, const void *key, const void *data)
 {
    Eina_Hash_Tuple tuple;

--- a/src/lib/eina/eina_hash.h
+++ b/src/lib/eina/eina_hash.h
@@ -371,7 +371,7 @@ typedef Eina_Bool    (*Eina_Hash_Foreach)(const Eina_Hash *hash, const void *key
  * eina_hash_int64_new(), eina_hash_pointer_new() and
  * eina_hash_stringshared_new().
  */
-EAPI Eina_Hash *eina_hash_new(Eina_Key_Length key_length_cb,
+EINA_API Eina_Hash *eina_hash_new(Eina_Key_Length key_length_cb,
                               Eina_Key_Cmp    key_cmp_cb,
                               Eina_Key_Hash   key_hash_cb,
                               Eina_Free_Cb    data_free_cb,
@@ -391,7 +391,7 @@ EAPI Eina_Hash *eina_hash_new(Eina_Key_Length key_length_cb,
  * @since 1.1
  * @see eina_hash_new.
  */
-EAPI void eina_hash_free_cb_set(Eina_Hash *hash, Eina_Free_Cb data_free_cb) EINA_ARG_NONNULL(1);
+EINA_API void eina_hash_free_cb_set(Eina_Hash *hash, Eina_Free_Cb data_free_cb) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Creates a new hash table using the djb2 algorithm.
@@ -406,7 +406,7 @@ EAPI void eina_hash_free_cb_set(Eina_Hash *hash, Eina_Free_Cb data_free_cb) EINA
  * be looked up with pointers other than the original key pointer that
  * was used to add values.
  */
-EAPI Eina_Hash *eina_hash_string_djb2_new(Eina_Free_Cb data_free_cb);
+EINA_API Eina_Hash *eina_hash_string_djb2_new(Eina_Free_Cb data_free_cb);
 
 /**
  * @brief Creates a new hash table for use with strings.
@@ -425,7 +425,7 @@ EAPI Eina_Hash *eina_hash_string_djb2_new(Eina_Free_Cb data_free_cb);
  * remotely request and push data in it. This hash is subject to denial
  * of service.
  */
-EAPI Eina_Hash *eina_hash_string_superfast_new(Eina_Free_Cb data_free_cb);
+EINA_API Eina_Hash *eina_hash_string_superfast_new(Eina_Free_Cb data_free_cb);
 
 /**
  * @brief Creates a new hash table for use with strings with small bucket size.
@@ -442,7 +442,7 @@ EAPI Eina_Hash *eina_hash_string_superfast_new(Eina_Free_Cb data_free_cb);
  * table. Values can then be looked up with pointers other than the
  * original key pointer that was used to add values.
  */
-EAPI Eina_Hash *eina_hash_string_small_new(Eina_Free_Cb data_free_cb);
+EINA_API Eina_Hash *eina_hash_string_small_new(Eina_Free_Cb data_free_cb);
 
 /**
  * @brief Creates a new hash table for use with 32bit integers.
@@ -460,7 +460,7 @@ EAPI Eina_Hash *eina_hash_string_small_new(Eina_Free_Cb data_free_cb);
  * used to add values. This method is not suitable to match string keys as
  * it would only match the first character.
  */
-EAPI Eina_Hash *eina_hash_int32_new(Eina_Free_Cb data_free_cb);
+EINA_API Eina_Hash *eina_hash_int32_new(Eina_Free_Cb data_free_cb);
 
 /**
  * @brief Creates a new hash table for use with 64bit integers.
@@ -477,7 +477,7 @@ EAPI Eina_Hash *eina_hash_int32_new(Eina_Free_Cb data_free_cb);
  * used to add values. This method is not suitable to match string keys as
  * it would only match the first character.
  */
-EAPI Eina_Hash *eina_hash_int64_new(Eina_Free_Cb data_free_cb);
+EINA_API Eina_Hash *eina_hash_int64_new(Eina_Free_Cb data_free_cb);
 
 /**
  * @brief Creates a new hash table for use with pointers.
@@ -503,7 +503,7 @@ EAPI Eina_Hash *eina_hash_int64_new(Eina_Free_Cb data_free_cb);
  *    eina_hash_add(hash, &data, data);
  * @endcode
  */
-EAPI Eina_Hash *eina_hash_pointer_new(Eina_Free_Cb data_free_cb);
+EINA_API Eina_Hash *eina_hash_pointer_new(Eina_Free_Cb data_free_cb);
 
 /**
  * @brief Creates a new hash table optimized for stringshared values.
@@ -528,7 +528,7 @@ EAPI Eina_Hash *eina_hash_pointer_new(Eina_Free_Cb data_free_cb);
  * eina_hash_find(hash, "key");
  * @endcode
  */
-EAPI Eina_Hash *eina_hash_stringshared_new(Eina_Free_Cb data_free_cb);
+EINA_API Eina_Hash *eina_hash_stringshared_new(Eina_Free_Cb data_free_cb);
 
 /**
  * @brief Adds an entry to the given hash table.
@@ -553,7 +553,7 @@ EAPI Eina_Hash *eina_hash_stringshared_new(Eina_Free_Cb data_free_cb);
  *
  * Key strings are case sensitive.
  */
-EAPI Eina_Bool  eina_hash_add(Eina_Hash  *hash,
+EINA_API Eina_Bool  eina_hash_add(Eina_Hash  *hash,
                               const void *key,
                               const void *data) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -582,7 +582,7 @@ EAPI Eina_Bool  eina_hash_add(Eina_Hash  *hash,
  * @p key, so it must be a string constant or stored elsewhere (such as
  * in the object being added). Key strings are case sensitive.
  */
-EAPI Eina_Bool eina_hash_direct_add(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_direct_add(Eina_Hash  *hash,
                                     const void *key,
                                     const void *data) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -607,7 +607,7 @@ EAPI Eina_Bool eina_hash_direct_add(Eina_Hash  *hash,
  * eina_hash_del_by_key_hash(). If you don't have the key, use
  * eina_hash_del_by_data() directly.
  */
-EAPI Eina_Bool eina_hash_del(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_del(Eina_Hash  *hash,
                              const void *key,
                              const void *data) EINA_ARG_NONNULL(1);
 
@@ -622,7 +622,7 @@ EAPI Eina_Bool eina_hash_del(Eina_Hash  *hash,
  * This function retrieves the entry associated with @p key in
  * @p hash. If @p hash is @c NULL, this function returns @c NULL.
  */
-EAPI void *eina_hash_find(const Eina_Hash *hash,
+EINA_API void *eina_hash_find(const Eina_Hash *hash,
                           const void      *key) EINA_ARG_NONNULL(2);
 
 /**
@@ -637,7 +637,7 @@ EAPI void *eina_hash_find(const Eina_Hash *hash,
  * This function modifies the data of @p key with @p data in @p
  * hash. If no entry is found, nothing is added to @p hash.
  */
-EAPI void *eina_hash_modify(Eina_Hash  *hash,
+EINA_API void *eina_hash_modify(Eina_Hash  *hash,
                             const void *key,
                             const void *data) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -655,7 +655,7 @@ EAPI void *eina_hash_modify(Eina_Hash  *hash,
  * hash. If no entry is found, @p data is added to @p hash with the
  * key @p key.
  */
-EAPI void *eina_hash_set(Eina_Hash  *hash,
+EINA_API void *eina_hash_set(Eina_Hash  *hash,
                          const void *key,
                          const void *data) EINA_ARG_NONNULL(1, 2);
 
@@ -672,7 +672,7 @@ EAPI void *eina_hash_set(Eina_Hash  *hash,
  * but does not call the Eina_Free_Cb associated with the hash table
  * when destroying the old key.
  */
-EAPI Eina_Bool eina_hash_move(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_move(Eina_Hash  *hash,
                               const void *old_key,
                               const void *new_key) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -699,7 +699,7 @@ EAPI Eina_Bool eina_hash_move(Eina_Hash  *hash,
  * hash = NULL;
  * @endcode
  */
-EAPI void      eina_hash_free(Eina_Hash *hash) EINA_ARG_NONNULL(1);
+EINA_API void      eina_hash_free(Eina_Hash *hash) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Frees the given hash table buckets resources.
@@ -715,7 +715,7 @@ EAPI void      eina_hash_free(Eina_Hash *hash) EINA_ARG_NONNULL(1);
  *
  * If @p hash is @c NULL, the function returns immediately.
  */
-EAPI void      eina_hash_free_buckets(Eina_Hash *hash) EINA_ARG_NONNULL(1);
+EINA_API void      eina_hash_free_buckets(Eina_Hash *hash) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Returns the number of entries in the given hash table.
@@ -724,7 +724,7 @@ EAPI void      eina_hash_free_buckets(Eina_Hash *hash) EINA_ARG_NONNULL(1);
  * @return The number of entries in the hash table, or @c 0 on error or
  * if @p hash is @c NULL.
  */
-EAPI int       eina_hash_population(const Eina_Hash *hash) EINA_ARG_NONNULL(1);
+EINA_API int       eina_hash_population(const Eina_Hash *hash) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Adds an entry to the given hash table by its key hash.
@@ -747,7 +747,7 @@ EAPI int       eina_hash_population(const Eina_Hash *hash) EINA_ARG_NONNULL(1);
  *
  * @see eina_hash_add()
  */
-EAPI Eina_Bool eina_hash_add_by_hash(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_add_by_hash(Eina_Hash  *hash,
                                      const void *key,
                                      int         key_length,
                                      int         key_hash,
@@ -778,7 +778,7 @@ EAPI Eina_Bool eina_hash_add_by_hash(Eina_Hash  *hash,
  *
  * @see eina_hash_direct_add()
  */
-EAPI Eina_Bool eina_hash_direct_add_by_hash(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_direct_add_by_hash(Eina_Hash  *hash,
                                             const void *key,
                                             int         key_length,
                                             int         key_hash,
@@ -803,7 +803,7 @@ EAPI Eina_Bool eina_hash_direct_add_by_hash(Eina_Hash  *hash,
  * @note If you don't have the key_hash, use eina_hash_del_by_key()
  * instead.  If you don't have the key, use eina_hash_del_by_data().
  */
-EAPI Eina_Bool eina_hash_del_by_key_hash(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_del_by_key_hash(Eina_Hash  *hash,
                                          const void *key,
                                          int         key_length,
                                          int         key_hash) EINA_ARG_NONNULL(1, 2);
@@ -828,7 +828,7 @@ EAPI Eina_Bool eina_hash_del_by_key_hash(Eina_Hash  *hash,
  * @note If you already have the key_hash, use eina_hash_del_by_key_hash().
  * If you don't have the key, use eina_hash_del_by_data() instead.
  */
-EAPI Eina_Bool eina_hash_del_by_key(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_del_by_key(Eina_Hash  *hash,
                                     const void *key) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -850,7 +850,7 @@ EAPI Eina_Bool eina_hash_del_by_key(Eina_Hash  *hash,
  * @note If you already have the key, use eina_hash_del_by_key()
  * or eina_hash_del_by_key_hash() instead.
  */
-EAPI Eina_Bool eina_hash_del_by_data(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_del_by_data(Eina_Hash  *hash,
                                      const void *data) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -880,7 +880,7 @@ EAPI Eina_Bool eina_hash_del_by_data(Eina_Hash  *hash,
  * @note If you already have the key, use eina_hash_del_by_key_hash().
  * If you don't have the key, use eina_hash_del_by_data() directly.
  */
-EAPI Eina_Bool eina_hash_del_by_hash(Eina_Hash  *hash,
+EINA_API Eina_Bool eina_hash_del_by_hash(Eina_Hash  *hash,
                                      const void *key,
                                      int         key_length,
                                      int         key_hash,
@@ -901,7 +901,7 @@ EAPI Eina_Bool eina_hash_del_by_hash(Eina_Hash  *hash,
  * @p key. It is ignored if @p key is @c NULL. Do not forget to count
  * '\\0' for string when setting the value of @p key_length.
  */
-EAPI void *eina_hash_find_by_hash(const Eina_Hash *hash,
+EINA_API void *eina_hash_find_by_hash(const Eina_Hash *hash,
                                   const void      *key,
                                   int              key_length,
                                   int              key_hash) EINA_ARG_NONNULL(1, 2);
@@ -921,7 +921,7 @@ EAPI void *eina_hash_find_by_hash(const Eina_Hash *hash,
  * if not found. If an existing entry is not found, nothing is added to
  * the hash.
  */
-EAPI void *eina_hash_modify_by_hash(Eina_Hash  *hash,
+EINA_API void *eina_hash_modify_by_hash(Eina_Hash  *hash,
                                     const void *key,
                                     int         key_length,
                                     int         key_hash,
@@ -941,7 +941,7 @@ EAPI void *eina_hash_modify_by_hash(Eina_Hash  *hash,
  * @warning If the hash structure changes then the iterator becomes
  * invalid; adding or removing items may lead to program crash.
  */
-EAPI Eina_Iterator *eina_hash_iterator_key_new(const Eina_Hash *hash) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_hash_iterator_key_new(const Eina_Hash *hash) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Returns a new iterator associated with a hash.
@@ -957,7 +957,7 @@ EAPI Eina_Iterator *eina_hash_iterator_key_new(const Eina_Hash *hash) EINA_MALLO
  * @warning If the hash structure changes then the iterator becomes
  * invalid; adding or removing items may lead to program crash.
  */
-EAPI Eina_Iterator *eina_hash_iterator_data_new(const Eina_Hash *hash) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_hash_iterator_data_new(const Eina_Hash *hash) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Returned a new iterator associated with hash keys and data.
@@ -976,7 +976,7 @@ EAPI Eina_Iterator *eina_hash_iterator_data_new(const Eina_Hash *hash) EINA_MALL
  * @warning If the hash structure changes then the iterator becomes
  * invalid; adding or removing items may lead to program crash.
  */
-EAPI Eina_Iterator *eina_hash_iterator_tuple_new(const Eina_Hash *hash) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_hash_iterator_tuple_new(const Eina_Hash *hash) EINA_MALLOC EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Calls a function on every member stored in the hash table.
@@ -1013,7 +1013,7 @@ EAPI Eina_Iterator *eina_hash_iterator_tuple_new(const Eina_Hash *hash) EINA_MAL
  * }
  * @endcode
  */
-EAPI void           eina_hash_foreach(const Eina_Hash  *hash,
+EINA_API void           eina_hash_foreach(const Eina_Hash  *hash,
                                       Eina_Hash_Foreach func,
                                       const void       *fdata) EINA_ARG_NONNULL(1, 2);
 
@@ -1031,7 +1031,7 @@ EAPI void           eina_hash_foreach(const Eina_Hash  *hash,
  *
  * @since 1.10
  */
-EAPI void eina_hash_list_append(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
+EINA_API void eina_hash_list_append(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief Appends data to an #Eina_List inside a hash using eina_hash_direct_add().
@@ -1046,7 +1046,7 @@ EAPI void eina_hash_list_append(Eina_Hash *hash, const void *key, const void *da
  *
  * @since 1.23
  */
-EAPI void eina_hash_list_direct_append(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
+EINA_API void eina_hash_list_direct_append(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief Prepends data to an #Eina_List inside a hash.
@@ -1061,7 +1061,7 @@ EAPI void eina_hash_list_direct_append(Eina_Hash *hash, const void *key, const v
  *
  * @since 1.10
  */
-EAPI void eina_hash_list_prepend(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
+EINA_API void eina_hash_list_prepend(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief Prepends data to an #Eina_List inside a hash using eina_hash_direct_add().
@@ -1076,7 +1076,7 @@ EAPI void eina_hash_list_prepend(Eina_Hash *hash, const void *key, const void *d
  *
  * @since 1.23
  */
-EAPI void eina_hash_list_direct_prepend(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
+EINA_API void eina_hash_list_direct_prepend(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief Removes data from an #Eina_List inside a hash.
@@ -1091,7 +1091,7 @@ EAPI void eina_hash_list_direct_prepend(Eina_Hash *hash, const void *key, const 
  *
  * @since 1.10
  */
-EAPI void eina_hash_list_remove(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
+EINA_API void eina_hash_list_remove(Eina_Hash *hash, const void *key, const void *data) EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief
@@ -1101,7 +1101,7 @@ EAPI void eina_hash_list_remove(Eina_Hash *hash, const void *key, const void *da
  * @param[in] len The length of the key.
  * @return The hash value.
  */
-EAPI int eina_hash_superfast(const char *key,
+EINA_API int eina_hash_superfast(const char *key,
                              int         len) EINA_ARG_NONNULL(1);
 
 /**

--- a/src/lib/eina/eina_inarray.c
+++ b/src/lib/eina/eina_inarray.c
@@ -338,7 +338,7 @@ eina_inarray_shutdown(void)
 /*============================================================================*
 *                                   API                                      *
 *============================================================================*/
-EAPI Eina_Inarray *
+EINA_API Eina_Inarray *
 eina_inarray_new(unsigned int member_size, unsigned int step)
 {
    Eina_Inarray *ret;
@@ -351,7 +351,7 @@ eina_inarray_new(unsigned int member_size, unsigned int step)
    return ret;
 }
 
-EAPI void
+EINA_API void
 eina_inarray_free(Eina_Inarray *array)
 {
    if (!array)
@@ -362,7 +362,7 @@ eina_inarray_free(Eina_Inarray *array)
    free(array);
 }
 
-EAPI void
+EINA_API void
 eina_inarray_step_set(Eina_Inarray *array,
 		      unsigned int sizeof_eina_inarray,
 		      unsigned int member_size,
@@ -384,7 +384,7 @@ eina_inarray_step_set(Eina_Inarray *array,
    _eina_inarray_setup(array, member_size, step);
 }
 
-EAPI void
+EINA_API void
 eina_inarray_flush(Eina_Inarray *array)
 {
    EINA_MAGIC_CHECK_INARRAY(array);
@@ -394,7 +394,7 @@ eina_inarray_flush(Eina_Inarray *array)
    array->members = NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_inarray_resize(Eina_Inarray *array, unsigned int new_size)
 {
    Eina_Bool r;
@@ -407,7 +407,7 @@ eina_inarray_resize(Eina_Inarray *array, unsigned int new_size)
    return EINA_TRUE;
 }
 
-EAPI int
+EINA_API int
 eina_inarray_push(Eina_Inarray *array, const void *data)
 {
    void *p;
@@ -425,7 +425,7 @@ eina_inarray_push(Eina_Inarray *array, const void *data)
    return array->len - 1;
 }
 
-EAPI void *
+EINA_API void *
 eina_inarray_grow(Eina_Inarray *array, unsigned int size)
 {
    void *p;
@@ -442,7 +442,7 @@ eina_inarray_grow(Eina_Inarray *array, unsigned int size)
    return p;
 }
 
-EAPI int
+EINA_API int
 eina_inarray_insert(Eina_Inarray *array, const void *data, Eina_Compare_Cb compare)
 {
    const unsigned char *itr, *itr_end;
@@ -471,7 +471,7 @@ eina_inarray_insert(Eina_Inarray *array, const void *data, Eina_Compare_Cb compa
    return eina_inarray_push(array, data);
 }
 
-EAPI int
+EINA_API int
 eina_inarray_insert_sorted(Eina_Inarray *array, const void *data, Eina_Compare_Cb compare)
 {
    unsigned int pos;
@@ -490,7 +490,7 @@ eina_inarray_insert_sorted(Eina_Inarray *array, const void *data, Eina_Compare_C
    return pos;
 }
 
-EAPI int
+EINA_API int
 eina_inarray_remove(Eina_Inarray *array, const void *data)
 {
    const unsigned char *itr, *itr_end;
@@ -528,7 +528,7 @@ found:
    return position;
 }
 
-EAPI void *
+EINA_API void *
 eina_inarray_pop(Eina_Inarray *array)
 {
    EINA_MAGIC_CHECK_INARRAY(array, NULL);
@@ -539,7 +539,7 @@ eina_inarray_pop(Eina_Inarray *array)
    return _eina_inarray_get(array, array->len);
 }
 
-EAPI void *
+EINA_API void *
 eina_inarray_nth(const Eina_Inarray *array, unsigned int position)
 {
    EINA_MAGIC_CHECK_INARRAY(array, NULL);
@@ -547,7 +547,7 @@ eina_inarray_nth(const Eina_Inarray *array, unsigned int position)
    return _eina_inarray_get(array, position);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_inarray_insert_at(Eina_Inarray *array, unsigned int position, const void *data)
 {
    unsigned int sz;
@@ -569,7 +569,7 @@ eina_inarray_insert_at(Eina_Inarray *array, unsigned int position, const void *d
    return EINA_TRUE;
 }
 
-EAPI void *
+EINA_API void *
 eina_inarray_alloc_at(Eina_Inarray *array, unsigned int position, unsigned int member_count)
 {
    unsigned int sz;
@@ -591,7 +591,7 @@ eina_inarray_alloc_at(Eina_Inarray *array, unsigned int position, unsigned int m
    return p;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_inarray_replace_at(Eina_Inarray *array, unsigned int position, const void *data)
 {
    unsigned char *p;
@@ -605,7 +605,7 @@ eina_inarray_replace_at(Eina_Inarray *array, unsigned int position, const void *
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_inarray_remove_at(Eina_Inarray *array, unsigned int position)
 {
    EINA_MAGIC_CHECK_INARRAY(array, EINA_FALSE);
@@ -623,7 +623,7 @@ eina_inarray_remove_at(Eina_Inarray *array, unsigned int position)
    return EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 eina_inarray_reverse(Eina_Inarray *array)
 {
    size_t sz;
@@ -653,7 +653,7 @@ eina_inarray_reverse(Eina_Inarray *array)
      }
 }
 
-EAPI void
+EINA_API void
 eina_inarray_sort(Eina_Inarray *array, Eina_Compare_Cb compare)
 {
    EINA_MAGIC_CHECK_INARRAY(array);
@@ -661,7 +661,7 @@ eina_inarray_sort(Eina_Inarray *array, Eina_Compare_Cb compare)
    qsort(array->members, array->len, array->member_size, compare);
 }
 
-EAPI int
+EINA_API int
 eina_inarray_search(const Eina_Inarray *array, const void *data, Eina_Compare_Cb compare)
 {
    EINA_MAGIC_CHECK_INARRAY(array, -1);
@@ -670,7 +670,7 @@ eina_inarray_search(const Eina_Inarray *array, const void *data, Eina_Compare_Cb
    return _eina_inarray_search(array, data, compare);
 }
 
-EAPI int
+EINA_API int
 eina_inarray_search_sorted(const Eina_Inarray *array, const void *data, Eina_Compare_Cb compare)
 {
    unsigned int pos;
@@ -686,7 +686,7 @@ eina_inarray_search_sorted(const Eina_Inarray *array, const void *data, Eina_Com
    return -1;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_inarray_foreach(const Eina_Inarray *array, Eina_Each_Cb function, const void *user_data)
 {
    unsigned char *itr, *itr_end;
@@ -704,7 +704,7 @@ eina_inarray_foreach(const Eina_Inarray *array, Eina_Each_Cb function, const voi
    return ret;
 }
 
-EAPI int
+EINA_API int
 eina_inarray_foreach_remove(Eina_Inarray *array, Eina_Each_Cb match, const void *user_data)
 {
    unsigned int i = 0, count = 0;
@@ -728,14 +728,14 @@ eina_inarray_foreach_remove(Eina_Inarray *array, Eina_Each_Cb match, const void 
    return count;
 }
 
-EAPI unsigned int
+EINA_API unsigned int
 eina_inarray_count(const Eina_Inarray *array)
 {
    EINA_MAGIC_CHECK_INARRAY(array, 0);
    return array->len;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_inarray_iterator_new(const Eina_Inarray *array)
 {
    Eina_Iterator_Inarray *it;
@@ -759,7 +759,7 @@ eina_inarray_iterator_new(const Eina_Inarray *array)
    return &it->iterator;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_inarray_iterator_reversed_new(const Eina_Inarray *array)
 {
    Eina_Iterator_Inarray *it;
@@ -784,7 +784,7 @@ eina_inarray_iterator_reversed_new(const Eina_Inarray *array)
    return &it->iterator;
 }
 
-EAPI Eina_Accessor *
+EINA_API Eina_Accessor *
 eina_inarray_accessor_new(const Eina_Inarray *array)
 {
    Eina_Accessor_Inarray *ac;

--- a/src/lib/eina/eina_inarray.h
+++ b/src/lib/eina/eina_inarray.h
@@ -252,7 +252,7 @@ struct _Eina_Inarray
  *
  * @since 1.2
  */
-EAPI Eina_Inarray *eina_inarray_new(unsigned int member_size,
+EINA_API Eina_Inarray *eina_inarray_new(unsigned int member_size,
                                     unsigned int step) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -264,7 +264,7 @@ EAPI Eina_Inarray *eina_inarray_new(unsigned int member_size,
  *
  * @since 1.2
  */
-EAPI void eina_inarray_free(Eina_Inarray *array) EINA_ARG_NONNULL(1);
+EINA_API void eina_inarray_free(Eina_Inarray *array) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Initializes an inline array.
@@ -284,7 +284,7 @@ EAPI void eina_inarray_free(Eina_Inarray *array) EINA_ARG_NONNULL(1);
  *
  * @since 1.2
  */
-EAPI void eina_inarray_step_set(Eina_Inarray *array,
+EINA_API void eina_inarray_step_set(Eina_Inarray *array,
                                 unsigned int sizeof_eina_inarray,
                                 unsigned int member_size,
                                 unsigned int step) EINA_ARG_NONNULL(1);
@@ -296,7 +296,7 @@ EAPI void eina_inarray_step_set(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI void eina_inarray_flush(Eina_Inarray *array) EINA_ARG_NONNULL(1);
+EINA_API void eina_inarray_flush(Eina_Inarray *array) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Copies the data as the last member of the array.
@@ -312,7 +312,7 @@ EAPI void eina_inarray_flush(Eina_Inarray *array) EINA_ARG_NONNULL(1);
  *
  * @since 1.2
  */
-EAPI int eina_inarray_push(Eina_Inarray *array,
+EINA_API int eina_inarray_push(Eina_Inarray *array,
                            const void *data) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -326,7 +326,7 @@ EAPI int eina_inarray_push(Eina_Inarray *array,
  *
  * @since 1.8
  */
-EAPI void *eina_inarray_grow(Eina_Inarray *array, unsigned int size);
+EINA_API void *eina_inarray_grow(Eina_Inarray *array, unsigned int size);
 
 /**
  * @brief Copies the data to the array at a position found by the comparison function.
@@ -349,7 +349,7 @@ EAPI void *eina_inarray_grow(Eina_Inarray *array, unsigned int size);
  *
  * @since 1.2
  */
-EAPI int eina_inarray_insert(Eina_Inarray *array,
+EINA_API int eina_inarray_insert(Eina_Inarray *array,
                              const void *data,
                              Eina_Compare_Cb compare) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -375,7 +375,7 @@ EAPI int eina_inarray_insert(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI int eina_inarray_insert_sorted(Eina_Inarray *array,
+EINA_API int eina_inarray_insert_sorted(Eina_Inarray *array,
                                     const void *data,
                                     Eina_Compare_Cb compare) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -394,7 +394,7 @@ EAPI int eina_inarray_insert_sorted(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI int eina_inarray_remove(Eina_Inarray *array,
+EINA_API int eina_inarray_remove(Eina_Inarray *array,
                              const void *data) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -407,7 +407,7 @@ EAPI int eina_inarray_remove(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI void *eina_inarray_pop(Eina_Inarray *array) EINA_ARG_NONNULL(1);
+EINA_API void *eina_inarray_pop(Eina_Inarray *array) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets the member at the given position.
@@ -422,7 +422,7 @@ EAPI void *eina_inarray_pop(Eina_Inarray *array) EINA_ARG_NONNULL(1);
  *
  * @since 1.2
  */
-EAPI void *eina_inarray_nth(const Eina_Inarray *array,
+EINA_API void *eina_inarray_nth(const Eina_Inarray *array,
                             unsigned int position) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -447,7 +447,7 @@ EAPI void *eina_inarray_nth(const Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI Eina_Bool eina_inarray_insert_at(Eina_Inarray *array,
+EINA_API Eina_Bool eina_inarray_insert_at(Eina_Inarray *array,
                                       unsigned int position,
                                       const void *data) EINA_ARG_NONNULL(1, 3);
 
@@ -477,7 +477,7 @@ EAPI Eina_Bool eina_inarray_insert_at(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI void *eina_inarray_alloc_at(Eina_Inarray *array,
+EINA_API void *eina_inarray_alloc_at(Eina_Inarray *array,
                                  unsigned int position,
                                  unsigned int member_count) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
@@ -497,7 +497,7 @@ EAPI void *eina_inarray_alloc_at(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI Eina_Bool eina_inarray_replace_at(Eina_Inarray *array,
+EINA_API Eina_Bool eina_inarray_replace_at(Eina_Inarray *array,
                                        unsigned int position,
                                        const void *data) EINA_ARG_NONNULL(1, 3);
 
@@ -516,7 +516,7 @@ EAPI Eina_Bool eina_inarray_replace_at(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI Eina_Bool eina_inarray_remove_at(Eina_Inarray *array,
+EINA_API Eina_Bool eina_inarray_remove_at(Eina_Inarray *array,
                                       unsigned int position) EINA_ARG_NONNULL(1);
 
 /**
@@ -531,7 +531,7 @@ EAPI Eina_Bool eina_inarray_remove_at(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI void eina_inarray_reverse(Eina_Inarray *array) EINA_ARG_NONNULL(1);
+EINA_API void eina_inarray_reverse(Eina_Inarray *array) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Applies a quick sort to the array.
@@ -547,7 +547,7 @@ EAPI void eina_inarray_reverse(Eina_Inarray *array) EINA_ARG_NONNULL(1);
  *
  * @since 1.2
  */
-EAPI void eina_inarray_sort(Eina_Inarray *array,
+EINA_API void eina_inarray_sort(Eina_Inarray *array,
                             Eina_Compare_Cb compare) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -565,7 +565,7 @@ EAPI void eina_inarray_sort(Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI int eina_inarray_search(const Eina_Inarray *array,
+EINA_API int eina_inarray_search(const Eina_Inarray *array,
                              const void *data,
                              Eina_Compare_Cb compare) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -584,7 +584,7 @@ EAPI int eina_inarray_search(const Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI int eina_inarray_search_sorted(const Eina_Inarray *array,
+EINA_API int eina_inarray_search_sorted(const Eina_Inarray *array,
                                     const void *data,
                                     Eina_Compare_Cb compare) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -607,7 +607,7 @@ EAPI int eina_inarray_search_sorted(const Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI Eina_Bool eina_inarray_foreach(const Eina_Inarray *array,
+EINA_API Eina_Bool eina_inarray_foreach(const Eina_Inarray *array,
                                     Eina_Each_Cb function,
                                     const void *user_data) EINA_ARG_NONNULL(1, 2);
 
@@ -623,7 +623,7 @@ EAPI Eina_Bool eina_inarray_foreach(const Eina_Inarray *array,
  *
  * @since 1.2
  */
-EAPI int eina_inarray_foreach_remove(Eina_Inarray *array,
+EINA_API int eina_inarray_foreach_remove(Eina_Inarray *array,
                                      Eina_Each_Cb match,
                                      const void *user_data) EINA_ARG_NONNULL(1, 2);
 
@@ -636,7 +636,7 @@ EAPI int eina_inarray_foreach_remove(Eina_Inarray *array,
  *
  * @since 1.10
  */
-EAPI Eina_Bool eina_inarray_resize(Eina_Inarray *array, unsigned int new_size);
+EINA_API Eina_Bool eina_inarray_resize(Eina_Inarray *array, unsigned int new_size);
 
 /**
  * @brief Counts the number of members in an array.
@@ -646,7 +646,7 @@ EAPI Eina_Bool eina_inarray_resize(Eina_Inarray *array, unsigned int new_size);
  *
  * @since 1.2
  */
-EAPI unsigned int eina_inarray_count(const Eina_Inarray *array) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API unsigned int eina_inarray_count(const Eina_Inarray *array) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Returns a new iterator associated to an array.
@@ -665,7 +665,7 @@ EAPI unsigned int eina_inarray_count(const Eina_Inarray *array) EINA_ARG_NONNULL
  *
  * @since 1.2
  */
-EAPI Eina_Iterator *eina_inarray_iterator_new(const Eina_Inarray *array) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Iterator *eina_inarray_iterator_new(const Eina_Inarray *array) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Returns a new reversed iterator associated to an array.
@@ -686,7 +686,7 @@ EAPI Eina_Iterator *eina_inarray_iterator_new(const Eina_Inarray *array) EINA_MA
  *
  * @since 1.2
  */
-EAPI Eina_Iterator *eina_inarray_iterator_reversed_new(const Eina_Inarray *array) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Iterator *eina_inarray_iterator_reversed_new(const Eina_Inarray *array) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Returns a new accessor associated to an array.
@@ -701,7 +701,7 @@ EAPI Eina_Iterator *eina_inarray_iterator_reversed_new(const Eina_Inarray *array
  *
  * @since 1.2
  */
-EAPI Eina_Accessor *eina_inarray_accessor_new(const Eina_Inarray *array) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Accessor *eina_inarray_accessor_new(const Eina_Inarray *array) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @def EINA_INARRAY_FOREACH

--- a/src/lib/eina/eina_inline_array.x
+++ b/src/lib/eina/eina_inline_array.x
@@ -27,7 +27,7 @@
  * @cond LOCAL
  */
 
-EAPI Eina_Bool eina_array_grow(Eina_Array *array);
+EINA_API Eina_Bool eina_array_grow(Eina_Array *array);
 
 /**
  * @endcond

--- a/src/lib/eina/eina_inline_crc.x
+++ b/src/lib/eina/eina_inline_crc.x
@@ -19,7 +19,7 @@
 #ifndef EINA_INLINE_CRC_X_
 #define EINA_INLINE_CRC_X_
 
-EAPI unsigned int _eina_crc(const char *data, int len, unsigned int seed, Eina_Bool start_stream);
+EINA_API unsigned int _eina_crc(const char *data, int len, unsigned int seed, Eina_Bool start_stream);
 
 static inline unsigned int
 eina_crc(const char *key, int len, unsigned int seed, Eina_Bool start_stream)

--- a/src/lib/eina/eina_inline_hash.x
+++ b/src/lib/eina/eina_inline_hash.x
@@ -21,7 +21,7 @@
 
 #include "eina_crc.h"
 
-EAPI extern unsigned int eina_seed;
+EINA_API extern unsigned int eina_seed;
 
 /*
   djb2 hash algorithm was first reported by dan bernstein, and was the old

--- a/src/lib/eina/eina_inline_lock_posix.x
+++ b/src/lib/eina/eina_inline_lock_posix.x
@@ -80,8 +80,8 @@ typedef void (*Eina_Lock_Bt_Func) ();
 #include "eina_inlist.h"
 #endif
 
-EAPI void _eina_lock_debug_abort(int err, const char *fn, const volatile void *ptr);
-EAPI void _eina_lock_debug_deadlock(const char *fn, const volatile void *ptr);
+EINA_API void _eina_lock_debug_abort(int err, const char *fn, const volatile void *ptr);
+EINA_API void _eina_lock_debug_deadlock(const char *fn, const volatile void *ptr);
 
 #define EINA_LOCK_ABORT_DEBUG(err, fn, ptr) \
    _eina_lock_debug_abort(err, #fn, ptr)
@@ -113,7 +113,7 @@ typedef semaphore_t Eina_Semaphore;
 typedef sem_t Eina_Semaphore;
 #endif
 
-EAPI void eina_lock_debug(const Eina_Lock *mutex);
+EINA_API void eina_lock_debug(const Eina_Lock *mutex);
 
 /** @privatesection  @{ */
 struct _Eina_Lock
@@ -147,25 +147,25 @@ struct _Eina_RWLock
 };
 /** @} privatesection */
 
-EAPI extern Eina_Bool _eina_threads_activated;
+EINA_API extern Eina_Bool _eina_threads_activated;
 
 #ifdef EINA_HAVE_DEBUG_THREADS
-EAPI extern int _eina_threads_debug;
-EAPI extern pthread_t _eina_main_loop;
-EAPI extern Eina_Lock _eina_tracking_lock;
-EAPI extern Eina_Inlist *_eina_tracking;
+EINA_API extern int _eina_threads_debug;
+EINA_API extern pthread_t _eina_main_loop;
+EINA_API extern Eina_Lock _eina_tracking_lock;
+EINA_API extern Eina_Inlist *_eina_tracking;
 #endif
 
-EAPI Eina_Bool eina_lock_new(Eina_Lock *mutex);
-EAPI void eina_lock_free(Eina_Lock *mutex);
-EAPI Eina_Lock_Result eina_lock_take(Eina_Lock *mutex);
-EAPI Eina_Lock_Result eina_lock_take_try(Eina_Lock *mutex);
-EAPI Eina_Lock_Result eina_lock_release(Eina_Lock *mutex);
-EAPI Eina_Bool eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex);
-EAPI void eina_condition_free(Eina_Condition *cond);
-EAPI Eina_Bool eina_condition_wait(Eina_Condition *cond);
-EAPI Eina_Bool eina_condition_broadcast(Eina_Condition *cond);
-EAPI Eina_Lock_Result eina_spinlock_take_try(Eina_Spinlock *spinlock);
+EINA_API Eina_Bool eina_lock_new(Eina_Lock *mutex);
+EINA_API void eina_lock_free(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_take(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_take_try(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_release(Eina_Lock *mutex);
+EINA_API Eina_Bool eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex);
+EINA_API void eina_condition_free(Eina_Condition *cond);
+EINA_API Eina_Bool eina_condition_wait(Eina_Condition *cond);
+EINA_API Eina_Bool eina_condition_broadcast(Eina_Condition *cond);
+EINA_API Eina_Lock_Result eina_spinlock_take_try(Eina_Spinlock *spinlock);
 
 static inline Eina_Bool
 _eina_lock_new(Eina_Lock *mutex, Eina_Bool recursive)

--- a/src/lib/eina/eina_inline_lock_win32.x
+++ b/src/lib/eina/eina_inline_lock_win32.x
@@ -47,8 +47,8 @@ typedef void (*Eina_Lock_Bt_Func) ();
 
 #include "eina_hash.h"
 
-EAPI void _eina_lock_debug_abort(int err, const char *fn, const volatile void *ptr);
-EAPI void _eina_lock_debug_deadlock(const char *fn, const volatile void *ptr);
+EINA_API void _eina_lock_debug_abort(int err, const char *fn, const volatile void *ptr);
+EINA_API void _eina_lock_debug_deadlock(const char *fn, const volatile void *ptr);
 
 #define EINA_LOCK_ABORT_DEBUG(err, fn, ptr) \
    _eina_lock_debug_abort(err, #fn, ptr)
@@ -69,7 +69,7 @@ typedef HANDLE Eina_Semaphore;
 
 typedef volatile LONG Eina_Spinlock;
 
-EAPI void eina_lock_debug(const Eina_Lock *mutex);
+EINA_API void eina_lock_debug(const Eina_Lock *mutex);
 
 /** @privatesection  @{ */
 typedef CRITICAL_SECTION _Eina_Mutex_t;
@@ -108,24 +108,24 @@ struct _Eina_RWLock
 };
 /** @} privatesection */
 
-EAPI extern Eina_Bool _eina_threads_activated;
+EINA_API extern Eina_Bool _eina_threads_activated;
 
 #ifdef EINA_HAVE_DEBUG_THREADS
-EAPI extern int _eina_threads_debug;
-EAPI extern _Eina_Thread _eina_main_loop;
-EAPI extern Eina_Lock _eina_tracking_lock;
-EAPI extern Eina_Inlist *_eina_tracking;
+EINA_API extern int _eina_threads_debug;
+EINA_API extern _Eina_Thread _eina_main_loop;
+EINA_API extern Eina_Lock _eina_tracking_lock;
+EINA_API extern Eina_Inlist *_eina_tracking;
 #endif
 
-EAPI Eina_Bool eina_lock_new(Eina_Lock *mutex);
-EAPI void eina_lock_free(Eina_Lock *mutex);
-EAPI Eina_Lock_Result eina_lock_take(Eina_Lock *mutex);
-EAPI Eina_Lock_Result eina_lock_take_try(Eina_Lock *mutex);
-EAPI Eina_Lock_Result eina_lock_release(Eina_Lock *mutex);
-EAPI Eina_Bool eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex);
-EAPI void eina_condition_free(Eina_Condition *cond);
-EAPI Eina_Bool eina_condition_wait(Eina_Condition *cond);
-EAPI Eina_Bool eina_condition_broadcast(Eina_Condition *cond);
+EINA_API Eina_Bool eina_lock_new(Eina_Lock *mutex);
+EINA_API void eina_lock_free(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_take(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_take_try(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_release(Eina_Lock *mutex);
+EINA_API Eina_Bool eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex);
+EINA_API void eina_condition_free(Eina_Condition *cond);
+EINA_API Eina_Bool eina_condition_wait(Eina_Condition *cond);
+EINA_API Eina_Bool eina_condition_broadcast(Eina_Condition *cond);
 
 extern Eina_Hash *_eina_tls_map;
 extern Eina_Lock _eina_tls_map_lock;

--- a/src/lib/eina/eina_inline_modinfo.x
+++ b/src/lib/eina/eina_inline_modinfo.x
@@ -24,7 +24,7 @@
 #define __EINA_MODULE_UNIQUE_ID(id) _EINA_MODINFO_CONCAT(__EINA_MODULE_UNIQUE_ID_, id)
 
 #define _EINA_MODINFO(name, info) \
-  EAPI const char __EINA_MODULE_UNIQUE_ID(name)[] \
+  EINA_API const char __EINA_MODULE_UNIQUE_ID(name)[] \
 __attribute__((__used__)) __attribute__((unused, aligned(1))) = info;
 #define EINA_MODINFO(tag, info) _EINA_MODINFO(tag, info)
 

--- a/src/lib/eina/eina_inline_safepointer.x
+++ b/src/lib/eina/eina_inline_safepointer.x
@@ -119,8 +119,8 @@ struct _Eina_Memory_Table
    Eina_Memory_Entry entries[EINA_MAX_ENTRY_ID];
 };
 
-EAPI extern Eina_Memory_Table **_eina_sp_ids_tables[EINA_MAX_MID_TABLE_ID];
-EAPI extern int _eina_sp_log_dom;
+EINA_API extern Eina_Memory_Table **_eina_sp_ids_tables[EINA_MAX_MID_TABLE_ID];
+EINA_API extern int _eina_sp_log_dom;
 
 #ifdef _EINA_SP_ERR
 #undef _EINA_SP_ERR

--- a/src/lib/eina/eina_inline_unicode.x
+++ b/src/lib/eina/eina_inline_unicode.x
@@ -19,10 +19,10 @@
 #ifndef EINA_INLINE_UNICODE_
 # define EINA_INLINE_UNICODE_
 
-EAPI Eina_Unicode _eina_unicode_utf8_next_get(int ind,
-                                              unsigned char d,
-                                              const char *buf,
-                                              int *iindex);
+EINA_API Eina_Unicode _eina_unicode_utf8_next_get(int ind,
+                                                  unsigned char d,
+                                                  const char *buf,
+                                                  int *iindex);
 
 #define ERROR_REPLACEMENT_BASE  0xDC80
 #define EINA_IS_INVALID_BYTE(x)      ((x == 192) || (x == 193) || (x >= 245))

--- a/src/lib/eina/eina_inline_value.x
+++ b/src/lib/eina/eina_inline_value.x
@@ -37,7 +37,7 @@
  * @since 1.2
  * @private
  */
-EAPI extern const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_START;
+EINA_API extern const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_START;
 
 /**
  * @var _EINA_VALUE_TYPE_BASICS_END
@@ -45,7 +45,7 @@ EAPI extern const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_START;
  * @since 1.2
  * @private
  */
-EAPI extern const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_END;
+EINA_API extern const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_END;
 #define EINA_VALUE_TYPE_DEFAULT(type)           \
   ((_EINA_VALUE_TYPE_BASICS_START <= type) &&   \
    (type <= _EINA_VALUE_TYPE_BASICS_END))
@@ -94,13 +94,13 @@ eina_value_memory_get(const Eina_Value *value)
  * @since 1.2
  * @private
  */
-EAPI void *eina_value_inner_alloc(size_t size);
+EINA_API void *eina_value_inner_alloc(size_t size);
 /**
  * @brief Releases memory for internal value types.
  * @since 1.2
  * @private
  */
-EAPI void eina_value_inner_free(size_t size, void *mem);
+EINA_API void eina_value_inner_free(size_t size, void *mem);
 
 static inline Eina_Bool
 eina_value_setup(Eina_Value *value, const Eina_Value_Type *type)
@@ -1409,7 +1409,7 @@ eina_value_hash_pget(const Eina_Value *value, const char *key, void *ptr)
  * @since 1.2
  * @internal
  */
-EAPI const Eina_Value_Struct_Member *eina_value_struct_member_find(const Eina_Value_Struct *st, const char *name) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
+EINA_API const Eina_Value_Struct_Member *eina_value_struct_member_find(const Eina_Value_Struct *st, const char *name) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 static inline Eina_Bool
 eina_value_struct_setup(Eina_Value *value, const Eina_Value_Struct_Desc *sdesc)

--- a/src/lib/eina/eina_inlist.c
+++ b/src/lib/eina/eina_inlist.c
@@ -223,7 +223,7 @@ _eina_inlist_sorted_state_compact(Eina_Inlist_Sorted_State *state)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_append(Eina_Inlist *list, Eina_Inlist *new_l)
 {
    Eina_Inlist *l;
@@ -250,7 +250,7 @@ eina_inlist_append(Eina_Inlist *list, Eina_Inlist *new_l)
    return list;
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_prepend(Eina_Inlist *list, Eina_Inlist *new_l)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(new_l, list);
@@ -270,7 +270,7 @@ eina_inlist_prepend(Eina_Inlist *list, Eina_Inlist *new_l)
    return new_l;
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_append_relative(Eina_Inlist *list,
                             Eina_Inlist *new_l,
                             Eina_Inlist *relative)
@@ -298,7 +298,7 @@ eina_inlist_append_relative(Eina_Inlist *list,
    return eina_inlist_append(list, new_l);
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_prepend_relative(Eina_Inlist *list,
                              Eina_Inlist *new_l,
                              Eina_Inlist *relative)
@@ -331,7 +331,7 @@ eina_inlist_prepend_relative(Eina_Inlist *list,
    return eina_inlist_prepend(list, new_l);
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_remove(Eina_Inlist *list, Eina_Inlist *item)
 {
    Eina_Inlist *return_l;
@@ -368,7 +368,7 @@ eina_inlist_remove(Eina_Inlist *list, Eina_Inlist *item)
    return return_l;
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_promote(Eina_Inlist *list, Eina_Inlist *item)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(list, NULL);
@@ -395,7 +395,7 @@ eina_inlist_promote(Eina_Inlist *list, Eina_Inlist *item)
    return item;
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_demote(Eina_Inlist *list, Eina_Inlist *item)
 {
    Eina_Inlist *l;
@@ -429,7 +429,7 @@ eina_inlist_demote(Eina_Inlist *list, Eina_Inlist *item)
    return l;
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_find(Eina_Inlist *list, Eina_Inlist *item)
 {
    Eina_Inlist *l;
@@ -444,7 +444,7 @@ eina_inlist_find(Eina_Inlist *list, Eina_Inlist *item)
    return NULL;
 }
 
-EAPI unsigned int
+EINA_API unsigned int
 eina_inlist_count(const Eina_Inlist *list)
 {
    const Eina_Inlist *l;
@@ -456,7 +456,7 @@ eina_inlist_count(const Eina_Inlist *list)
    return i;
 }
 
-EAPI int
+EINA_API int
 eina_inlist_sorted_state_init(Eina_Inlist_Sorted_State *state, Eina_Inlist *list)
 {
    Eina_Inlist *ct = NULL;
@@ -486,7 +486,7 @@ eina_inlist_sorted_state_init(Eina_Inlist_Sorted_State *state, Eina_Inlist *list
    return count;
 }
 
-EAPI Eina_Inlist_Sorted_State *
+EINA_API Eina_Inlist_Sorted_State *
 eina_inlist_sorted_state_new(void)
 {
    Eina_Inlist_Sorted_State *r;
@@ -499,7 +499,7 @@ eina_inlist_sorted_state_new(void)
    return r;
 }
 
-EAPI void
+EINA_API void
 eina_inlist_sorted_state_free(Eina_Inlist_Sorted_State *state)
 {
    free(state);
@@ -554,7 +554,7 @@ _eina_inlist_sorted_state_insert(Eina_Inlist_Sorted_State *state,
      }
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_sorted_insert(Eina_Inlist *list,
                           Eina_Inlist *item,
                           Eina_Compare_Cb func)
@@ -661,7 +661,7 @@ eina_inlist_sorted_insert(Eina_Inlist *list,
    return eina_inlist_prepend_relative(list, item, ct);
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_sorted_state_insert(Eina_Inlist *list,
                                 Eina_Inlist *item,
                                 Eina_Compare_Cb func,
@@ -800,7 +800,7 @@ eina_inlist_sorted_state_insert(Eina_Inlist *list,
    return ct;
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_inlist_sort(Eina_Inlist *head, Eina_Compare_Cb func)
 {
    unsigned int i = 0;
@@ -848,7 +848,7 @@ eina_inlist_sort(Eina_Inlist *head, Eina_Compare_Cb func)
 
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_inlist_iterator_new(const Eina_Inlist *list)
 {
    Eina_Iterator_Inlist *it;
@@ -870,7 +870,7 @@ eina_inlist_iterator_new(const Eina_Inlist *list)
    return &it->iterator;
 }
 
-EAPI Eina_Accessor *
+EINA_API Eina_Accessor *
 eina_inlist_accessor_new(const Eina_Inlist *list)
 {
    Eina_Accessor_Inlist *ac;

--- a/src/lib/eina/eina_inlist.h
+++ b/src/lib/eina/eina_inlist.h
@@ -433,7 +433,7 @@ struct _Eina_Inlist
  *
  * @return The new list head. Use it and not @a in_list anymore.
  */
-EAPI Eina_Inlist *eina_inlist_append(Eina_Inlist *in_list,
+EINA_API Eina_Inlist *eina_inlist_append(Eina_Inlist *in_list,
                                      Eina_Inlist *in_item) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -452,7 +452,7 @@ EAPI Eina_Inlist *eina_inlist_append(Eina_Inlist *in_list,
  *
  * @return The new list head. Use it and not @a in_list anymore.
  */
-EAPI Eina_Inlist *eina_inlist_prepend(Eina_Inlist *in_list,
+EINA_API Eina_Inlist *eina_inlist_prepend(Eina_Inlist *in_list,
                                       Eina_Inlist *in_item) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -477,7 +477,7 @@ EAPI Eina_Inlist *eina_inlist_prepend(Eina_Inlist *in_list,
  *
  * @return The new list head. Use it and not @a list anymore.
  */
-EAPI Eina_Inlist *eina_inlist_append_relative(Eina_Inlist *in_list,
+EINA_API Eina_Inlist *eina_inlist_append_relative(Eina_Inlist *in_list,
                                               Eina_Inlist *in_item,
                                               Eina_Inlist *in_relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
@@ -503,7 +503,7 @@ EAPI Eina_Inlist *eina_inlist_append_relative(Eina_Inlist *in_list,
  *
  * @return The new list head. Use it and not @a in_list anymore.
  */
-EAPI Eina_Inlist *eina_inlist_prepend_relative(Eina_Inlist *in_list,
+EINA_API Eina_Inlist *eina_inlist_prepend_relative(Eina_Inlist *in_list,
                                                Eina_Inlist *in_item,
                                                Eina_Inlist *in_relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
@@ -524,7 +524,7 @@ EAPI Eina_Inlist *eina_inlist_prepend_relative(Eina_Inlist *in_list,
  *
  * @return The new list head. Use it and not @a list anymore.
  */
-EAPI Eina_Inlist   *eina_inlist_remove(Eina_Inlist *in_list,
+EINA_API Eina_Inlist   *eina_inlist_remove(Eina_Inlist *in_list,
                                        Eina_Inlist *in_item) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -538,7 +538,7 @@ EAPI Eina_Inlist   *eina_inlist_remove(Eina_Inlist *in_list,
  *
  * @return @a in_item if found, @c NULL if not.
  */
-EAPI Eina_Inlist   *eina_inlist_find(Eina_Inlist *in_list,
+EINA_API Eina_Inlist   *eina_inlist_find(Eina_Inlist *in_list,
                                      Eina_Inlist *in_item) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -556,7 +556,7 @@ EAPI Eina_Inlist   *eina_inlist_find(Eina_Inlist *in_list,
  *
  * @return The new list head. Use it and not @a list anymore.
  */
-EAPI Eina_Inlist   *eina_inlist_promote(Eina_Inlist *list,
+EINA_API Eina_Inlist   *eina_inlist_promote(Eina_Inlist *list,
                                         Eina_Inlist *item) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -574,7 +574,7 @@ EAPI Eina_Inlist   *eina_inlist_promote(Eina_Inlist *list,
  *
  * @return The new list head. Use it and not @a list anymore.
  */
-EAPI Eina_Inlist   *eina_inlist_demote(Eina_Inlist *list,
+EINA_API Eina_Inlist   *eina_inlist_demote(Eina_Inlist *list,
                                        Eina_Inlist *item) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -622,7 +622,7 @@ static inline Eina_Inlist *eina_inlist_last(const Eina_Inlist *list) EINA_PURE E
  *    on the number of elements on the list, so, it might become
  *    slow for big lists!
  */
-EAPI unsigned int   eina_inlist_count(const Eina_Inlist *list) EINA_WARN_UNUSED_RESULT;
+EINA_API unsigned int   eina_inlist_count(const Eina_Inlist *list) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -644,7 +644,7 @@ EAPI unsigned int   eina_inlist_count(const Eina_Inlist *list) EINA_WARN_UNUSED_
  *    invalid, and if you add or remove nodes iterator
  *    behavior is undefined, and your program may crash!
  */
-EAPI Eina_Iterator *eina_inlist_iterator_new(const Eina_Inlist *in_list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_inlist_iterator_new(const Eina_Inlist *in_list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Returns a new accessor associated to a list.
@@ -658,7 +658,7 @@ EAPI Eina_Iterator *eina_inlist_iterator_new(const Eina_Inlist *in_list) EINA_MA
  * not be allocated, @c NULL is returned and Otherwise, a valid accessor is
  * returned.
  */
-EAPI Eina_Accessor *eina_inlist_accessor_new(const Eina_Inlist *in_list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Accessor *eina_inlist_accessor_new(const Eina_Inlist *in_list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Inserts a new node into a sorted list.
@@ -682,7 +682,7 @@ EAPI Eina_Accessor *eina_inlist_accessor_new(const Eina_Inlist *in_list) EINA_MA
  *
  * @since 1.1.0
  */
-EAPI Eina_Inlist *eina_inlist_sorted_insert(Eina_Inlist *list, Eina_Inlist *item, Eina_Compare_Cb func) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Inlist *eina_inlist_sorted_insert(Eina_Inlist *list, Eina_Inlist *item, Eina_Compare_Cb func) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates state with valid data in it.
@@ -693,7 +693,7 @@ EAPI Eina_Inlist *eina_inlist_sorted_insert(Eina_Inlist *list, Eina_Inlist *item
  *
  * See eina_inlist_sorted_state_insert() for more information.
  */
-EAPI Eina_Inlist_Sorted_State *eina_inlist_sorted_state_new(void);
+EINA_API Eina_Inlist_Sorted_State *eina_inlist_sorted_state_new(void);
 
 /**
  * @brief Forces an Eina_Inlist_Sorted_State to match the content of a list.
@@ -708,7 +708,7 @@ EAPI Eina_Inlist_Sorted_State *eina_inlist_sorted_state_new(void);
  * useful if you didn't use eina_inlist_sorted_state_insert() at some point, but
  * still think you have a sorted list. It will only correctly work on a sorted list.
  */
-EAPI int eina_inlist_sorted_state_init(Eina_Inlist_Sorted_State *state, Eina_Inlist *list);
+EINA_API int eina_inlist_sorted_state_init(Eina_Inlist_Sorted_State *state, Eina_Inlist *list);
 
 /**
  * @brief Frees an Eina_Inlist_Sorted_State.
@@ -719,7 +719,7 @@ EAPI int eina_inlist_sorted_state_init(Eina_Inlist_Sorted_State *state, Eina_Inl
  *
  * See eina_inlist_sorted_state_insert() for more information.
  */
-EAPI void eina_inlist_sorted_state_free(Eina_Inlist_Sorted_State *state);
+EINA_API void eina_inlist_sorted_state_free(Eina_Inlist_Sorted_State *state);
 
 /**
  * @brief Inserts a new node into a sorted list.
@@ -749,7 +749,7 @@ EAPI void eina_inlist_sorted_state_free(Eina_Inlist_Sorted_State *state);
  * linear cost again. Consider worst case to be almost O(n) pointer
  * dereference (list walk).
  */
-EAPI Eina_Inlist *eina_inlist_sorted_state_insert(Eina_Inlist *list,
+EINA_API Eina_Inlist *eina_inlist_sorted_state_insert(Eina_Inlist *list,
 						  Eina_Inlist *item,
 						  Eina_Compare_Cb func,
 						  Eina_Inlist_Sorted_State *state);
@@ -797,7 +797,7 @@ EAPI Eina_Inlist *eina_inlist_sorted_state_insert(Eina_Inlist *list,
  * list = eina_inlist_sort(list, sort_cb);
  * @endcode
  */
-EAPI Eina_Inlist *eina_inlist_sort(Eina_Inlist *head, Eina_Compare_Cb func);
+EINA_API Eina_Inlist *eina_inlist_sort(Eina_Inlist *head, Eina_Compare_Cb func);
 
 /* These two macros are helpers for the _FOREACH ones, don't use them */
 /**

--- a/src/lib/eina/eina_internal.h
+++ b/src/lib/eina/eina_internal.h
@@ -8,6 +8,7 @@
  * not stable API.
  */
 
+#include "eina_types.h"
 #include "eina_prefix.h"
 #include "eina_promise.h"
 
@@ -37,9 +38,9 @@ struct _Eina_Vpath_Interface_User
  *
  * @internal
  */
-EAPI void __eina_promise_cancel_all(void);
+EINA_API void __eina_promise_cancel_all(void);
 
-EAPI void __eina_promise_cancel_data(void *data);
+EINA_API void __eina_promise_cancel_data(void *data);
 
 /**
  * Make the app specific paths accessible as virtual path
@@ -56,7 +57,7 @@ EAPI void __eina_promise_cancel_data(void *data);
  *
  * If you do NOT call this api the virtual paths for app.* will be unset
  */
-EAPI void eina_vpath_interface_app_set(const char *app_name, Eina_Prefix *p);
+EINA_API void eina_vpath_interface_app_set(const char *app_name, Eina_Prefix *p);
 
 /**
  * Create the desktop specific vpaths
@@ -65,11 +66,8 @@ EAPI void eina_vpath_interface_app_set(const char *app_name, Eina_Prefix *p);
  *
  * If you do NOT call this api the virtual paths for usr.* will be unset.
  */
-EAPI void eina_vpath_interface_user_set(Eina_Vpath_Interface_User *user);
+EINA_API void eina_vpath_interface_user_set(Eina_Vpath_Interface_User *user);
 
 void eina_xdg_env_init(void);
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/eina/eina_iterator.c
+++ b/src/lib/eina/eina_iterator.c
@@ -94,7 +94,7 @@ eina_iterator_shutdown(void)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI void
+EINA_API void
 eina_iterator_free(Eina_Iterator *iterator)
 {
    if (!iterator)
@@ -105,7 +105,7 @@ eina_iterator_free(Eina_Iterator *iterator)
    iterator->free(iterator);
 }
 
-EAPI void *
+EINA_API void *
 eina_iterator_container_get(Eina_Iterator *iterator)
 {
    EINA_MAGIC_CHECK_ITERATOR(iterator);
@@ -114,7 +114,7 @@ eina_iterator_container_get(Eina_Iterator *iterator)
    return iterator->get_container(iterator);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_iterator_next(Eina_Iterator *iterator, void **data)
 {
    if (!iterator)
@@ -126,7 +126,7 @@ eina_iterator_next(Eina_Iterator *iterator, void **data)
    return iterator->next(iterator, data);
 }
 
-EAPI void
+EINA_API void
 eina_iterator_foreach(Eina_Iterator *iterator,
                       Eina_Each_Cb cb,
                       const void *fdata)
@@ -155,7 +155,7 @@ on_exit:
    (void) eina_iterator_unlock(iterator);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_iterator_lock(Eina_Iterator *iterator)
 {
    EINA_MAGIC_CHECK_ITERATOR(iterator);
@@ -166,7 +166,7 @@ eina_iterator_lock(Eina_Iterator *iterator)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_iterator_unlock(Eina_Iterator *iterator)
 {
    EINA_MAGIC_CHECK_ITERATOR(iterator);
@@ -210,7 +210,7 @@ eina_carray_iterator_free(Eina_Iterator_CArray *it)
   free(it);
 }
 
-EAPI Eina_Iterator*
+EINA_API Eina_Iterator*
 eina_carray_iterator_new(void** array)
 {
    Eina_Iterator_CArray *it;
@@ -268,7 +268,7 @@ eina_carray_length_iterator_free(Eina_Iterator_CArray_Length *it)
    free(it);
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_carray_length_iterator_new(void** array, unsigned int step, unsigned int length)
 {
    Eina_Iterator_CArray_Length *it;
@@ -336,7 +336,7 @@ eina_multi_iterator_free(Eina_Multi_Iterator *it)
    free(it);
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_multi_iterator_internal_new(Eina_Iterator *itc, ...)
 {
    Eina_Multi_Iterator *it;
@@ -404,7 +404,7 @@ eina_iterator_filter_free(Eina_Iterator_Filter *it)
    free(it);
 }
 
-EAPI Eina_Iterator*
+EINA_API Eina_Iterator*
 eina_iterator_filter_new(Eina_Iterator *iterator, Eina_Each_Cb filter, Eina_Free_Cb free_cb, void *data)
 {
    Eina_Iterator_Filter *it;
@@ -465,7 +465,7 @@ eina_iterator_process_free(Eina_Iterator_Processor *it)
    free(it);
 }
 
-EAPI Eina_Iterator*
+EINA_API Eina_Iterator*
 eina_iterator_processed_new(Eina_Iterator *iterator, Eina_Process_Cb process, Eina_Free_Cb free_cb, void *data)
 {
    Eina_Iterator_Processor *it;

--- a/src/lib/eina/eina_iterator.h
+++ b/src/lib/eina/eina_iterator.h
@@ -203,7 +203,7 @@ struct _Eina_Iterator
  *
  * This function frees @p iterator if it is not @c NULL;
  */
-EAPI void      eina_iterator_free(Eina_Iterator *iterator);
+EINA_API void      eina_iterator_free(Eina_Iterator *iterator);
 
 
 /**
@@ -215,7 +215,7 @@ EAPI void      eina_iterator_free(Eina_Iterator *iterator);
  * This function returns the container which created @p iterator. If
  * @p iterator is @c NULL, this function returns @c NULL.
  */
-EAPI void     *eina_iterator_container_get(Eina_Iterator *iterator) EINA_ARG_NONNULL(1) EINA_PURE;
+EINA_API void     *eina_iterator_container_get(Eina_Iterator *iterator) EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Returns the value of the current element and go to the next one.
@@ -229,7 +229,7 @@ EAPI void     *eina_iterator_container_get(Eina_Iterator *iterator) EINA_ARG_NON
  * iterator is @c NULL or if a problem occurred, #EINA_FALSE is
  * returned, otherwise #EINA_TRUE is returned.
  */
-EAPI Eina_Bool eina_iterator_next(Eina_Iterator *iterator,
+EINA_API Eina_Bool eina_iterator_next(Eina_Iterator *iterator,
                                   void         **data) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
@@ -247,7 +247,7 @@ EAPI Eina_Bool eina_iterator_next(Eina_Iterator *iterator,
  * the iteration stops at that point, if @p cb returns #EINA_TRUE
  * the iteration continues.
  */
-EAPI void eina_iterator_foreach(Eina_Iterator *iterator,
+EINA_API void eina_iterator_foreach(Eina_Iterator *iterator,
                                 Eina_Each_Cb   callback,
                                 const void    *fdata) EINA_ARG_NONNULL(2);
 
@@ -266,7 +266,7 @@ EAPI void eina_iterator_foreach(Eina_Iterator *iterator,
  *
  * @warning None of the existing eina data structures are lockable.
  */
-EAPI Eina_Bool eina_iterator_lock(Eina_Iterator *iterator) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_iterator_lock(Eina_Iterator *iterator) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Unlocks the container of the iterator.
@@ -282,7 +282,7 @@ EAPI Eina_Bool eina_iterator_lock(Eina_Iterator *iterator) EINA_ARG_NONNULL(1);
  *
  * @warning None of the existing eina data structures are lockable.
  */
-EAPI Eina_Bool eina_iterator_unlock(Eina_Iterator *iterator) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_iterator_unlock(Eina_Iterator *iterator) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Creates an Eina_Iterator that iterates through a
@@ -299,7 +299,7 @@ EAPI Eina_Bool eina_iterator_unlock(Eina_Iterator *iterator) EINA_ARG_NONNULL(1)
  *
  * @since 1.18
  */
-EAPI Eina_Iterator *eina_carray_iterator_new(void** array) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_carray_iterator_new(void** array) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates an Eina_Iterator that iterates through a
@@ -315,7 +315,7 @@ EAPI Eina_Iterator *eina_carray_iterator_new(void** array) EINA_ARG_NONNULL(1) E
  *
  * @since 1.22
  */
-EAPI Eina_Iterator *eina_carray_length_iterator_new(void** array, unsigned int step, unsigned int length) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_carray_length_iterator_new(void** array, unsigned int step, unsigned int length) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @def EINA_C_ARRAY_ITERATOR_NEW
@@ -347,7 +347,7 @@ EAPI Eina_Iterator *eina_carray_length_iterator_new(void** array, unsigned int s
  *
  * @since 1.19
  */
-EAPI Eina_Iterator* eina_iterator_filter_new(Eina_Iterator *original, Eina_Each_Cb filter, Eina_Free_Cb free_cb, void *data) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator* eina_iterator_filter_new(Eina_Iterator *original, Eina_Each_Cb filter, Eina_Free_Cb free_cb, void *data) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates an Eina_Iterator that iterates through a series
@@ -363,7 +363,7 @@ EAPI Eina_Iterator* eina_iterator_filter_new(Eina_Iterator *original, Eina_Each_
  *
  * @since 1.22
  */
-EAPI Eina_Iterator *eina_multi_iterator_internal_new(Eina_Iterator *it, ...) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_multi_iterator_internal_new(Eina_Iterator *it, ...) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -381,7 +381,7 @@ EAPI Eina_Iterator *eina_multi_iterator_internal_new(Eina_Iterator *it, ...) EIN
  *
  * @since 1.24
  */
-EAPI Eina_Iterator* eina_iterator_processed_new(Eina_Iterator *iterator, Eina_Process_Cb process, Eina_Free_Cb free_cb, void *fdata) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator* eina_iterator_processed_new(Eina_Iterator *iterator, Eina_Process_Cb process, Eina_Free_Cb free_cb, void *fdata) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @def eina_multi_iterator_new

--- a/src/lib/eina/eina_lalloc.c
+++ b/src/lib/eina/eina_lalloc.c
@@ -65,7 +65,7 @@ struct _Eina_Lalloc
  * @{
  */
 
-EAPI Eina_Lalloc *eina_lalloc_new(void *data,
+EINA_API Eina_Lalloc *eina_lalloc_new(void *data,
                                   Eina_Lalloc_Alloc alloc_cb,
                                   Eina_Lalloc_Free free_cb,
                                   int num_init)
@@ -88,7 +88,7 @@ EAPI Eina_Lalloc *eina_lalloc_new(void *data,
    return a;
 }
 
-EAPI void eina_lalloc_free(Eina_Lalloc *a)
+EINA_API void eina_lalloc_free(Eina_Lalloc *a)
 {
    EINA_SAFETY_ON_NULL_RETURN(a);
    EINA_SAFETY_ON_NULL_RETURN(a->free_cb);
@@ -96,7 +96,7 @@ EAPI void eina_lalloc_free(Eina_Lalloc *a)
    free(a);
 }
 
-EAPI Eina_Bool eina_lalloc_element_add(Eina_Lalloc *a)
+EINA_API Eina_Bool eina_lalloc_element_add(Eina_Lalloc *a)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(a,           EINA_FALSE);
    EINA_SAFETY_ON_NULL_RETURN_VAL(a->alloc_cb, EINA_FALSE);
@@ -117,7 +117,7 @@ EAPI Eina_Bool eina_lalloc_element_add(Eina_Lalloc *a)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool eina_lalloc_elements_add(Eina_Lalloc *a, int num)
+EINA_API Eina_Bool eina_lalloc_elements_add(Eina_Lalloc *a, int num)
 {
    int tmp;
 

--- a/src/lib/eina/eina_lalloc.h
+++ b/src/lib/eina/eina_lalloc.h
@@ -76,7 +76,7 @@ typedef struct _Eina_Lalloc Eina_Lalloc;
  * @return A new lazy allocator.
  *
  */
-EAPI Eina_Lalloc *eina_lalloc_new(void             *data,
+EINA_API Eina_Lalloc *eina_lalloc_new(void             *data,
                                   Eina_Lalloc_Alloc alloc_cb,
                                   Eina_Lalloc_Free  free_cb,
                                   int               num_init) EINA_ARG_NONNULL(2, 3);
@@ -87,7 +87,7 @@ EAPI Eina_Lalloc *eina_lalloc_new(void             *data,
  * @param[in,out] a The lazy allocator to free.
  *
  */
-EAPI void      eina_lalloc_free(Eina_Lalloc *a) EINA_ARG_NONNULL(1);
+EINA_API void      eina_lalloc_free(Eina_Lalloc *a) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Adds several elements to a lazy allocator.
@@ -98,7 +98,7 @@ EAPI void      eina_lalloc_free(Eina_Lalloc *a) EINA_ARG_NONNULL(1);
  * @return #EINA_TRUE on success, else #EINA_FALSE.
  *
  */
-EAPI Eina_Bool eina_lalloc_elements_add(Eina_Lalloc *a,
+EINA_API Eina_Bool eina_lalloc_elements_add(Eina_Lalloc *a,
                                         int          num) EINA_ARG_NONNULL(1);
 
 /**
@@ -109,7 +109,7 @@ EAPI Eina_Bool eina_lalloc_elements_add(Eina_Lalloc *a,
  * @return #EINA_TRUE on success, else #EINA_FALSE.
  *
  */
-EAPI Eina_Bool eina_lalloc_element_add(Eina_Lalloc *a) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_lalloc_element_add(Eina_Lalloc *a) EINA_ARG_NONNULL(1);
 
 /**
  * @}

--- a/src/lib/eina/eina_list.c
+++ b/src/lib/eina/eina_list.c
@@ -580,7 +580,7 @@ eina_list_shutdown(void)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_append(Eina_List *list, const void *data)
 {
    Eina_List *l, *new_l;
@@ -614,7 +614,7 @@ on_error:
 #endif
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_prepend(Eina_List *list, const void *data)
 {
    Eina_List *new_l;
@@ -645,7 +645,7 @@ on_error:
 #endif
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_append_relative(Eina_List *list,
                           const void *data,
                           const void *relative)
@@ -666,7 +666,7 @@ eina_list_append_relative(Eina_List *list,
    return eina_list_append(list, data);
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_append_relative_list(Eina_List *list,
                                const void *data,
                                Eina_List *relative)
@@ -700,7 +700,7 @@ eina_list_append_relative_list(Eina_List *list,
    return list;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_prepend_relative(Eina_List *list,
                            const void *data,
                            const void *relative)
@@ -720,7 +720,7 @@ eina_list_prepend_relative(Eina_List *list,
    return eina_list_prepend(list, data);
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_prepend_relative_list(Eina_List *list,
                                 const void *data,
                                 Eina_List *relative)
@@ -753,7 +753,7 @@ eina_list_prepend_relative_list(Eina_List *list,
    return new_l;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_sorted_insert(Eina_List *list, Eina_Compare_Cb func, const void *data)
 {
    Eina_List *lnear;
@@ -769,7 +769,7 @@ eina_list_sorted_insert(Eina_List *list, Eina_Compare_Cb func, const void *data)
      return eina_list_prepend_relative_list(list, data, lnear);
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_remove(Eina_List *list, const void *data)
 {
    Eina_List *l;
@@ -782,7 +782,7 @@ eina_list_remove(Eina_List *list, const void *data)
    return eina_list_remove_list(list, l);
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_remove_list(Eina_List *list, Eina_List *remove_list)
 {
    Eina_List *return_l;
@@ -819,7 +819,7 @@ eina_list_remove_list(Eina_List *list, Eina_List *remove_list)
    return return_l;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_free(Eina_List *list)
 {
    Eina_List *l, *free_l;
@@ -841,7 +841,7 @@ eina_list_free(Eina_List *list)
    return NULL;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_promote_list(Eina_List *list, Eina_List *move_list)
 {
    if (!list)
@@ -885,7 +885,7 @@ eina_list_promote_list(Eina_List *list, Eina_List *move_list)
    return move_list;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_demote_list(Eina_List *list, Eina_List *move_list)
 {
    if (!list)
@@ -924,7 +924,7 @@ eina_list_demote_list(Eina_List *list, Eina_List *move_list)
    return list;
 }
 
-EAPI void *
+EINA_API void *
 eina_list_data_find(const Eina_List *list, const void *data)
 {
    if (eina_list_data_find_list(list, data))
@@ -933,7 +933,7 @@ eina_list_data_find(const Eina_List *list, const void *data)
    return NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_list_move(Eina_List **to, Eina_List **from, void *data)
 {
    Eina_List *l;
@@ -954,7 +954,7 @@ eina_list_move(Eina_List **to, Eina_List **from, void *data)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_list_move_list(Eina_List **to, Eina_List **from, Eina_List *data)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(to, EINA_FALSE);
@@ -971,7 +971,7 @@ eina_list_move_list(Eina_List **to, Eina_List **from, Eina_List *data)
    return EINA_TRUE;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_data_find_list(const Eina_List *list, const void *data)
 {
    const Eina_List *l;
@@ -990,7 +990,7 @@ eina_list_data_find_list(const Eina_List *list, const void *data)
    return NULL;
 }
 
-EAPI void *
+EINA_API void *
 eina_list_nth(const Eina_List *list, unsigned int n)
 {
    Eina_List *l;
@@ -1002,7 +1002,7 @@ eina_list_nth(const Eina_List *list, unsigned int n)
    return l ? l->data : NULL;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_nth_list(const Eina_List *list, unsigned int n)
 {
    const Eina_List *l;
@@ -1038,7 +1038,7 @@ eina_list_nth_list(const Eina_List *list, unsigned int n)
    abort();
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_reverse(Eina_List *list)
 {
    Eina_List *l1, *l2;
@@ -1068,7 +1068,7 @@ eina_list_reverse(Eina_List *list)
    return list;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_reverse_clone(const Eina_List *list)
 {
    const Eina_List *l;
@@ -1088,7 +1088,7 @@ eina_list_reverse_clone(const Eina_List *list)
    return lclone;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_clone(const Eina_List *list)
 {
    const Eina_List *l;
@@ -1108,7 +1108,7 @@ eina_list_clone(const Eina_List *list)
    return lclone;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_sort(Eina_List *list, unsigned int limit, Eina_Compare_Cb func)
 {
    unsigned int i = 0;
@@ -1178,7 +1178,7 @@ eina_list_sort(Eina_List *list, unsigned int limit, Eina_Compare_Cb func)
    return list;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_shuffle(Eina_List *list, Eina_Random_Cb func)
 {
    unsigned int n, i, j;
@@ -1261,7 +1261,7 @@ eina_list_shuffle(Eina_List *list, Eina_Random_Cb func)
    return shuffled_list;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_merge(Eina_List *left, Eina_List *right)
 {
    unsigned int n_left, n_right;
@@ -1312,7 +1312,7 @@ eina_list_merge(Eina_List *left, Eina_List *right)
 }
 
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_split_list(Eina_List *list, Eina_List *relative, Eina_List **right)
 {
    Eina_List *next;
@@ -1358,7 +1358,7 @@ eina_list_split_list(Eina_List *list, Eina_List *relative, Eina_List **right)
    return list;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_sorted_merge(Eina_List *left, Eina_List *right, Eina_Compare_Cb func)
 {
    Eina_List *ret;
@@ -1435,7 +1435,7 @@ eina_list_sorted_merge(Eina_List *left, Eina_List *right, Eina_Compare_Cb func)
    return ret;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_search_sorted_near_list(const Eina_List *list,
                                   Eina_Compare_Cb func,
                                   const void *data,
@@ -1518,7 +1518,7 @@ end:
    return (Eina_List *)ct;
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_search_sorted_list(const Eina_List *list,
                              Eina_Compare_Cb func,
                              const void *data)
@@ -1537,7 +1537,7 @@ eina_list_search_sorted_list(const Eina_List *list,
 }
 
 
-EAPI void *
+EINA_API void *
 eina_list_search_sorted(const Eina_List *list,
                         Eina_Compare_Cb func,
                         const void *data)
@@ -1545,7 +1545,7 @@ eina_list_search_sorted(const Eina_List *list,
    return eina_list_data_get(eina_list_search_sorted_list(list, func, data));
 }
 
-EAPI Eina_List *
+EINA_API Eina_List *
 eina_list_search_unsorted_list(const Eina_List *list,
                                Eina_Compare_Cb func,
                                const void *data)
@@ -1561,7 +1561,7 @@ eina_list_search_unsorted_list(const Eina_List *list,
    return NULL;
 }
 
-EAPI void *
+EINA_API void *
 eina_list_search_unsorted(const Eina_List *list,
                           Eina_Compare_Cb func,
                           const void *data)
@@ -1570,7 +1570,7 @@ eina_list_search_unsorted(const Eina_List *list,
 }
 
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_list_iterator_new(const Eina_List *list)
 {
    Eina_Iterator_List *it;
@@ -1593,7 +1593,7 @@ eina_list_iterator_new(const Eina_List *list)
    return &it->iterator;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_list_iterator_reversed_new(const Eina_List *list)
 {
    Eina_Iterator_List *it;
@@ -1616,7 +1616,7 @@ eina_list_iterator_reversed_new(const Eina_List *list)
    return &it->iterator;
 }
 
-EAPI Eina_Accessor *
+EINA_API Eina_Accessor *
 eina_list_accessor_new(const Eina_List *list)
 {
    Eina_Accessor_List *ac;
@@ -1643,7 +1643,7 @@ eina_list_accessor_new(const Eina_List *list)
    return &ac->accessor;
 }
 
-EAPI int
+EINA_API int
 eina_list_data_idx(const Eina_List *list, void *data)
 {
    const Eina_List *l;

--- a/src/lib/eina/eina_list.h
+++ b/src/lib/eina/eina_list.h
@@ -363,7 +363,7 @@ struct _Eina_List_Accounting
  *
  * @warning @p list must be a pointer to the first element of the list(or NULL).
  */
-EAPI Eina_List            *eina_list_append(Eina_List *list, const void *data) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_append(Eina_List *list, const void *data) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -391,7 +391,7 @@ EAPI Eina_List            *eina_list_append(Eina_List *list, const void *data) E
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_prepend(Eina_List *list, const void *data) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_prepend(Eina_List *list, const void *data) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -424,7 +424,7 @@ EAPI Eina_List            *eina_list_prepend(Eina_List *list, const void *data) 
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_append_relative(Eina_List *list, const void *data, const void *relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_append_relative(Eina_List *list, const void *data, const void *relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -446,7 +446,7 @@ EAPI Eina_List            *eina_list_append_relative(Eina_List *list, const void
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_append_relative_list(Eina_List *list, const void *data, Eina_List *relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_append_relative_list(Eina_List *list, const void *data, Eina_List *relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -479,7 +479,7 @@ EAPI Eina_List            *eina_list_append_relative_list(Eina_List *list, const
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_prepend_relative(Eina_List *list, const void *data, const void *relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_prepend_relative(Eina_List *list, const void *data, const void *relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -501,7 +501,7 @@ EAPI Eina_List            *eina_list_prepend_relative(Eina_List *list, const voi
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_prepend_relative_list(Eina_List *list, const void *data, Eina_List *relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_prepend_relative_list(Eina_List *list, const void *data, Eina_List *relative) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -527,7 +527,7 @@ EAPI Eina_List            *eina_list_prepend_relative_list(Eina_List *list, cons
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_sorted_insert(Eina_List *list, Eina_Compare_Cb func, const void *data) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_sorted_insert(Eina_List *list, Eina_Compare_Cb func, const void *data) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -545,7 +545,7 @@ EAPI Eina_List            *eina_list_sorted_insert(Eina_List *list, Eina_Compare
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_remove(Eina_List *list, const void *data) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_remove(Eina_List *list, const void *data) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -583,7 +583,7 @@ EAPI Eina_List            *eina_list_remove(Eina_List *list, const void *data) E
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_remove_list(Eina_List *list, Eina_List *remove_list) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_remove_list(Eina_List *list, Eina_List *remove_list) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -617,7 +617,7 @@ EAPI Eina_List            *eina_list_remove_list(Eina_List *list, Eina_List *rem
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_promote_list(Eina_List *list, Eina_List *move_list) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_promote_list(Eina_List *list, Eina_List *move_list) EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -651,7 +651,7 @@ EAPI Eina_List            *eina_list_promote_list(Eina_List *list, Eina_List *mo
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_demote_list(Eina_List *list, Eina_List *move_list);
+EINA_API Eina_List            *eina_list_demote_list(Eina_List *list, Eina_List *move_list);
 
 
 /**
@@ -678,7 +678,7 @@ EAPI Eina_List            *eina_list_demote_list(Eina_List *list, Eina_List *mov
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI void                 *eina_list_data_find(const Eina_List *list, const void *data) EINA_PURE EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API void                 *eina_list_data_find(const Eina_List *list, const void *data) EINA_PURE EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -696,7 +696,7 @@ EAPI void                 *eina_list_data_find(const Eina_List *list, const void
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_data_find_list(const Eina_List *list, const void *data) EINA_PURE EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_data_find_list(const Eina_List *list, const void *data) EINA_PURE EINA_ARG_NONNULL(2) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -713,7 +713,7 @@ EAPI Eina_List            *eina_list_data_find_list(const Eina_List *list, const
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_Bool             eina_list_move(Eina_List **to, Eina_List **from, void *data);
+EINA_API Eina_Bool             eina_list_move(Eina_List **to, Eina_List **from, void *data);
 
 
 /**
@@ -730,7 +730,7 @@ EAPI Eina_Bool             eina_list_move(Eina_List **to, Eina_List **from, void
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_Bool             eina_list_move_list(Eina_List **to, Eina_List **from, Eina_List *data);
+EINA_API Eina_Bool             eina_list_move_list(Eina_List **to, Eina_List **from, Eina_List *data);
 
 
 /**
@@ -742,7 +742,7 @@ EAPI Eina_Bool             eina_list_move_list(Eina_List **to, Eina_List **from,
  * This function frees all the nodes of @p list. It does not free the
  * data of the nodes. To free them, use #EINA_LIST_FREE.
  */
-EAPI Eina_List            *eina_list_free(Eina_List *list);
+EINA_API Eina_List            *eina_list_free(Eina_List *list);
 
 /**
  * @brief Gets the nth member's data pointer in a list, or @c NULL on
@@ -761,7 +761,7 @@ EAPI Eina_List            *eina_list_free(Eina_List *list);
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI void                 *eina_list_nth(const Eina_List *list, unsigned int n) EINA_PURE EINA_WARN_UNUSED_RESULT;
+EINA_API void                 *eina_list_nth(const Eina_List *list, unsigned int n) EINA_PURE EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets the nth member's list node in a list.
@@ -782,7 +782,7 @@ EAPI void                 *eina_list_nth(const Eina_List *list, unsigned int n) 
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_nth_list(const Eina_List *list, unsigned int n) EINA_PURE EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_nth_list(const Eina_List *list, unsigned int n) EINA_PURE EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -804,7 +804,7 @@ EAPI Eina_List            *eina_list_nth_list(const Eina_List *list, unsigned in
  * @see eina_list_reverse_clone()
  * @see eina_list_iterator_reversed_new()
  */
-EAPI Eina_List            *eina_list_reverse(Eina_List *list) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_reverse(Eina_List *list) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -825,7 +825,7 @@ EAPI Eina_List            *eina_list_reverse(Eina_List *list) EINA_WARN_UNUSED_R
  * @see eina_list_reverse()
  * @see eina_list_clone()
  */
-EAPI Eina_List            *eina_list_reverse_clone(const Eina_List *list) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_reverse_clone(const Eina_List *list) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -845,7 +845,7 @@ EAPI Eina_List            *eina_list_reverse_clone(const Eina_List *list) EINA_W
  *
  * @see eina_list_reverse_clone()
  */
-EAPI Eina_List            *eina_list_clone(const Eina_List *list) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_clone(const Eina_List *list) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -888,7 +888,7 @@ EAPI Eina_List            *eina_list_clone(const Eina_List *list) EINA_WARN_UNUS
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_sort(Eina_List *list, unsigned int limit, Eina_Compare_Cb func) EINA_ARG_NONNULL(3) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_sort(Eina_List *list, unsigned int limit, Eina_Compare_Cb func) EINA_ARG_NONNULL(3) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -909,7 +909,7 @@ EAPI Eina_List            *eina_list_sort(Eina_List *list, unsigned int limit, E
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_shuffle(Eina_List *list, Eina_Random_Cb func) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_shuffle(Eina_List *list, Eina_Random_Cb func) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -929,7 +929,7 @@ EAPI Eina_List            *eina_list_shuffle(Eina_List *list, Eina_Random_Cb fun
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_merge(Eina_List *left, Eina_List *right) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_merge(Eina_List *left, Eina_List *right) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -969,7 +969,7 @@ EAPI Eina_List            *eina_list_merge(Eina_List *left, Eina_List *right) EI
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_sorted_merge(Eina_List *left, Eina_List *right, Eina_Compare_Cb func) EINA_ARG_NONNULL(3) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_sorted_merge(Eina_List *left, Eina_List *right, Eina_Compare_Cb func) EINA_ARG_NONNULL(3) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -989,7 +989,7 @@ EAPI Eina_List            *eina_list_sorted_merge(Eina_List *left, Eina_List *ri
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_List            *eina_list_split_list(Eina_List *list, Eina_List *relative, Eina_List **right) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_List            *eina_list_split_list(Eina_List *list, Eina_List *relative, Eina_List **right) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -1051,7 +1051,7 @@ EAPI Eina_List            *eina_list_split_list(Eina_List *list, Eina_List *rela
  * @see eina_list_sort()
  * @see eina_list_sorted_merge()
  */
-EAPI Eina_List            *eina_list_search_sorted_near_list(const Eina_List *list, Eina_Compare_Cb func, const void *data, int *result_cmp);
+EINA_API Eina_List            *eina_list_search_sorted_near_list(const Eina_List *list, Eina_Compare_Cb func, const void *data, int *result_cmp);
 
 
 /**
@@ -1087,7 +1087,7 @@ EAPI Eina_List            *eina_list_search_sorted_near_list(const Eina_List *li
  * @see eina_list_search_unsorted_list()
  * @see eina_list_search_sorted_near_list()
  */
-EAPI Eina_List            *eina_list_search_sorted_list(const Eina_List *list, Eina_Compare_Cb func, const void *data);
+EINA_API Eina_List            *eina_list_search_sorted_list(const Eina_List *list, Eina_Compare_Cb func, const void *data);
 
 
 /**
@@ -1123,7 +1123,7 @@ EAPI Eina_List            *eina_list_search_sorted_list(const Eina_List *list, E
  * @see eina_list_sorted_merge()
  * @see eina_list_search_unsorted_list()
  */
-EAPI void                 *eina_list_search_sorted(const Eina_List *list, Eina_Compare_Cb func, const void *data);
+EINA_API void                 *eina_list_search_sorted(const Eina_List *list, Eina_Compare_Cb func, const void *data);
 
 
 /**
@@ -1149,7 +1149,7 @@ EAPI void                 *eina_list_search_sorted(const Eina_List *list, Eina_C
  * @see eina_list_search_sorted_list()
  * @see eina_list_search_unsorted()
  */
-EAPI Eina_List            *eina_list_search_unsorted_list(const Eina_List *list, Eina_Compare_Cb func, const void *data);
+EINA_API Eina_List            *eina_list_search_unsorted_list(const Eina_List *list, Eina_Compare_Cb func, const void *data);
 
 
 /**
@@ -1176,7 +1176,7 @@ EAPI Eina_List            *eina_list_search_unsorted_list(const Eina_List *list,
  * @see eina_list_search_sorted()
  * @see eina_list_search_unsorted_list()
  */
-EAPI void                 *eina_list_search_unsorted(const Eina_List *list, Eina_Compare_Cb func, const void *data);
+EINA_API void                 *eina_list_search_unsorted(const Eina_List *list, Eina_Compare_Cb func, const void *data);
 
 
 /**
@@ -1304,7 +1304,7 @@ static inline void        *eina_list_last_data_get(const Eina_List *list);
  *    invalid! That is, if you add or remove nodes this iterator
  *    behavior is undefined and your program may crash!
  */
-EAPI Eina_Iterator        *eina_list_iterator_new(const Eina_List *list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator        *eina_list_iterator_new(const Eina_List *list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -1327,7 +1327,7 @@ EAPI Eina_Iterator        *eina_list_iterator_new(const Eina_List *list) EINA_MA
  *    invalid! That is, if you add or remove nodes this iterator
  *    behavior is undefined and your program may crash!
  */
-EAPI Eina_Iterator        *eina_list_iterator_reversed_new(const Eina_List *list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator        *eina_list_iterator_reversed_new(const Eina_List *list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -1344,7 +1344,7 @@ EAPI Eina_Iterator        *eina_list_iterator_reversed_new(const Eina_List *list
  *
  * @warning @p list must be a pointer to the first element of the list.
  */
-EAPI Eina_Accessor        *eina_list_accessor_new(const Eina_List *list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Accessor        *eina_list_accessor_new(const Eina_List *list) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -1362,7 +1362,7 @@ EAPI Eina_Accessor        *eina_list_accessor_new(const Eina_List *list) EINA_MA
  *
  * @since 1.14
  */
-EAPI int                   eina_list_data_idx(const Eina_List *list, void *data);
+EINA_API int                   eina_list_data_idx(const Eina_List *list, void *data);
 
 
 /**

--- a/src/lib/eina/eina_lock.c
+++ b/src/lib/eina/eina_lock.c
@@ -9,7 +9,7 @@
 
 Eina_Bool fork_resetting;
 
-EAPI void
+EINA_API void
 _eina_lock_debug_abort(int err, const char *fn, const volatile void *ptr)
 {
    if (fork_resetting) return;
@@ -19,7 +19,7 @@ _eina_lock_debug_abort(int err, const char *fn, const volatile void *ptr)
 #endif
 }
 
-EAPI void
+EINA_API void
 _eina_lock_debug_deadlock(const char *fn, const volatile void *ptr)
 {
    fprintf(stderr, "EINA ERROR: DEADLOCK on %s %p\n", fn, ptr);
@@ -28,7 +28,7 @@ _eina_lock_debug_deadlock(const char *fn, const volatile void *ptr)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_lock_debug(const Eina_Lock *mutex)
 {
 #ifdef EINA_HAVE_DEBUG_THREADS
@@ -40,7 +40,7 @@ eina_lock_debug(const Eina_Lock *mutex)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_lock_new(Eina_Lock *mutex)
 {
    Eina_Bool ret = _eina_lock_new(mutex, EINA_FALSE);
@@ -53,7 +53,7 @@ eina_lock_new(Eina_Lock *mutex)
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_lock_recursive_new(Eina_Lock *mutex)
 {
    Eina_Bool ret = _eina_lock_new(mutex, EINA_TRUE);
@@ -66,193 +66,193 @@ eina_lock_recursive_new(Eina_Lock *mutex)
    return ret;
 }
 
-EAPI void
+EINA_API void
 eina_lock_free(Eina_Lock *mutex)
 {
    _eina_lock_free(mutex);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_lock_take_try(Eina_Lock *mutex)
 {
    return _eina_lock_take_try(mutex);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_lock_take(Eina_Lock *mutex)
 {
    return _eina_lock_take(mutex);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_lock_release(Eina_Lock *mutex)
 {
    return _eina_lock_release(mutex);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex)
 {
    return _eina_condition_new(cond, mutex);
 }
 
-EAPI void
+EINA_API void
 eina_condition_free(Eina_Condition *cond)
 {
    _eina_condition_free(cond);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_condition_wait(Eina_Condition *cond)
 {
    return _eina_condition_wait(cond);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_condition_timedwait(Eina_Condition *cond, double t)
 {
    return _eina_condition_timedwait(cond, t);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_condition_broadcast(Eina_Condition *cond)
 {
    return _eina_condition_broadcast(cond);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_condition_signal(Eina_Condition *cond)
 {
    return _eina_condition_signal(cond);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_rwlock_new(Eina_RWLock *mutex)
 {
    return _eina_rwlock_new(mutex);
 }
 
-EAPI void
+EINA_API void
 eina_rwlock_free(Eina_RWLock *mutex)
 {
    _eina_rwlock_free(mutex);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_rwlock_take_read(Eina_RWLock *mutex)
 {
    return _eina_rwlock_take_read(mutex);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_rwlock_take_write(Eina_RWLock *mutex)
 {
    return _eina_rwlock_take_write(mutex);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_rwlock_release(Eina_RWLock *mutex)
 {
    return _eina_rwlock_release(mutex);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_tls_cb_new(Eina_TLS *key, Eina_TLS_Delete_Cb delete_cb)
 {
    return _eina_tls_cb_new(key, delete_cb);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_tls_new(Eina_TLS *key)
 {
    return _eina_tls_cb_new(key, NULL);
 }
 
-EAPI void
+EINA_API void
 eina_tls_free(Eina_TLS key)
 {
    _eina_tls_free(key);
 }
 
-EAPI void *
+EINA_API void *
 eina_tls_get(Eina_TLS key)
 {
    return _eina_tls_get(key);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_tls_set(Eina_TLS key, const void *data)
 {
    return _eina_tls_set(key, data);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_barrier_new(Eina_Barrier *barrier, int needed)
 {
    return _eina_barrier_new(barrier, needed);
 }
 
-EAPI void
+EINA_API void
 eina_barrier_free(Eina_Barrier *barrier)
 {
    _eina_barrier_free(barrier);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_barrier_wait(Eina_Barrier *barrier)
 {
    return _eina_barrier_wait(barrier);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_spinlock_new(Eina_Spinlock *spinlock)
 {
    return _eina_spinlock_new(spinlock);
 }
 
-EAPI void
+EINA_API void
 eina_spinlock_free(Eina_Spinlock *spinlock)
 {
    _eina_spinlock_free(spinlock);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_spinlock_take_try(Eina_Spinlock *spinlock)
 {
    return _eina_spinlock_take_try(spinlock);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_spinlock_take(Eina_Spinlock *spinlock)
 {
    return _eina_spinlock_take(spinlock);
 }
 
-EAPI Eina_Lock_Result
+EINA_API Eina_Lock_Result
 eina_spinlock_release(Eina_Spinlock *spinlock)
 {
    return _eina_spinlock_release(spinlock);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_semaphore_new(Eina_Semaphore *sem, int count_init)
 {
    return _eina_semaphore_new(sem, count_init);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_semaphore_free(Eina_Semaphore *sem)
 {
    return _eina_semaphore_free(sem);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_semaphore_lock(Eina_Semaphore *sem)
 {
    return _eina_semaphore_lock(sem);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_semaphore_release(Eina_Semaphore *sem, int count_release EINA_UNUSED)
 {
    return _eina_semaphore_release(sem, count_release);

--- a/src/lib/eina/eina_lock.h
+++ b/src/lib/eina/eina_lock.h
@@ -107,7 +107,7 @@ typedef void (*Eina_TLS_Delete_Cb)(void *ptr);
  * @brief A type definition for warning that a function was called from
  *        somewhere other than the EFL main loop.
  */
-EAPI extern Eina_Error EINA_ERROR_NOT_MAIN_LOOP;
+EINA_API extern Eina_Error EINA_ERROR_NOT_MAIN_LOOP;
 
 /**
  * @brief Initializes a new #Eina_Lock.
@@ -121,7 +121,7 @@ EAPI extern Eina_Error EINA_ERROR_NOT_MAIN_LOOP;
  *
  * @see eina_lock_free()
  */
-EAPI Eina_Bool eina_lock_new(Eina_Lock *mutex);
+EINA_API Eina_Bool eina_lock_new(Eina_Lock *mutex);
 
 /**
  * @brief Initializes a new #Eina_Lock that is recursive.
@@ -137,7 +137,7 @@ EAPI Eina_Bool eina_lock_new(Eina_Lock *mutex);
  * @see eina_lock_free()
  * @since 1.19
  */
-EAPI Eina_Bool eina_lock_recursive_new(Eina_Lock *mutex);
+EINA_API Eina_Bool eina_lock_recursive_new(Eina_Lock *mutex);
 
 /**
  * @brief Deallocates an #Eina_Lock.
@@ -148,7 +148,7 @@ EAPI Eina_Bool eina_lock_recursive_new(Eina_Lock *mutex);
  *
  * @see eina_lock_new()
  */
-EAPI void eina_lock_free(Eina_Lock *mutex);
+EINA_API void eina_lock_free(Eina_Lock *mutex);
 
 /**
  * @brief Attempts to take a lock.
@@ -166,7 +166,7 @@ EAPI void eina_lock_free(Eina_Lock *mutex);
  * @see eina_lock_take_try()
  * @see eina_lock_release()
  */
-EAPI Eina_Lock_Result eina_lock_take(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_take(Eina_Lock *mutex);
 
 /**
  * @brief Attempts to take a lock if possible.
@@ -182,7 +182,7 @@ EAPI Eina_Lock_Result eina_lock_take(Eina_Lock *mutex);
  * @see eina_lock_take()
  * @see eina_lock_release()
  */
-EAPI Eina_Lock_Result eina_lock_take_try(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_take_try(Eina_Lock *mutex);
 
 /**
  * @brief Releases a lock.
@@ -198,7 +198,7 @@ EAPI Eina_Lock_Result eina_lock_take_try(Eina_Lock *mutex);
  * @see eina_lock_take()
  * @see eina_lock_take_try()
  */
-EAPI Eina_Lock_Result eina_lock_release(Eina_Lock *mutex);
+EINA_API Eina_Lock_Result eina_lock_release(Eina_Lock *mutex);
 
 /**
  * @brief Prints debug information about a lock.
@@ -212,7 +212,7 @@ EAPI Eina_Lock_Result eina_lock_release(Eina_Lock *mutex);
  *
  * @since 1.19
  */
-EAPI void eina_lock_debug(const Eina_Lock *mutex);
+EINA_API void eina_lock_debug(const Eina_Lock *mutex);
 
 /**
  * @brief Initializes a new condition variable.
@@ -230,7 +230,7 @@ EAPI void eina_lock_debug(const Eina_Lock *mutex);
  *
  * @see eina_condition_free()
  */
-EAPI Eina_Bool eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex);
+EINA_API Eina_Bool eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex);
 
 /**
  * @brief Deallocates a condition variable.
@@ -241,7 +241,7 @@ EAPI Eina_Bool eina_condition_new(Eina_Condition *cond, Eina_Lock *mutex);
  *
  * @see eina_condition_new()
  */
-EAPI void eina_condition_free(Eina_Condition *cond);
+EINA_API void eina_condition_free(Eina_Condition *cond);
 
 /**
  * @brief Causes a thread to wait until signaled by the condition.
@@ -253,7 +253,7 @@ EAPI void eina_condition_free(Eina_Condition *cond);
  *
  * @see eina_condition_timedwait()
  */
-EAPI Eina_Bool eina_condition_wait(Eina_Condition *cond);
+EINA_API Eina_Bool eina_condition_wait(Eina_Condition *cond);
 
 /**
  * @brief Causes a thread to wait until signaled by the condition or a
@@ -269,7 +269,7 @@ EAPI Eina_Bool eina_condition_wait(Eina_Condition *cond);
  *
  * @see eina_condition_wait()
  */
-EAPI Eina_Bool eina_condition_timedwait(Eina_Condition *cond, double t);
+EINA_API Eina_Bool eina_condition_timedwait(Eina_Condition *cond, double t);
 
 /**
  * @brief Signals all threads waiting for a condition.
@@ -283,7 +283,7 @@ EAPI Eina_Bool eina_condition_timedwait(Eina_Condition *cond, double t);
  *
  * @see eina_condition_signal()
  */
-EAPI Eina_Bool eina_condition_broadcast(Eina_Condition *cond);
+EINA_API Eina_Bool eina_condition_broadcast(Eina_Condition *cond);
 
 /**
  * @brief Signals a thread waiting for a condition.
@@ -300,7 +300,7 @@ EAPI Eina_Bool eina_condition_broadcast(Eina_Condition *cond);
  *
  * @see eina_condition_broadcast()
  */
-EAPI Eina_Bool eina_condition_signal(Eina_Condition *cond);
+EINA_API Eina_Bool eina_condition_signal(Eina_Condition *cond);
 
 
 /**
@@ -315,7 +315,7 @@ EAPI Eina_Bool eina_condition_signal(Eina_Condition *cond);
  *
  * @see eina_rwlock_free()
  */
-EAPI Eina_Bool eina_rwlock_new(Eina_RWLock *mutex);
+EINA_API Eina_Bool eina_rwlock_new(Eina_RWLock *mutex);
 
 /**
  * @brief Deallocates an #Eina_RWLock.
@@ -326,7 +326,7 @@ EAPI Eina_Bool eina_rwlock_new(Eina_RWLock *mutex);
  *
  * @see eina_rwlock_new()
  */
-EAPI void eina_rwlock_free(Eina_RWLock *mutex);
+EINA_API void eina_rwlock_free(Eina_RWLock *mutex);
 
 /**
  * @brief Attempts to take a read lock.
@@ -342,7 +342,7 @@ EAPI void eina_rwlock_free(Eina_RWLock *mutex);
  *
  * @see eina_rwlock_release()
  */
-EAPI Eina_Lock_Result eina_rwlock_take_read(Eina_RWLock *mutex);
+EINA_API Eina_Lock_Result eina_rwlock_take_read(Eina_RWLock *mutex);
 
 /**
  * @brief Attempts to take a write lock.
@@ -358,7 +358,7 @@ EAPI Eina_Lock_Result eina_rwlock_take_read(Eina_RWLock *mutex);
  *
  * @see eina_rwlock_release()
  */
-EAPI Eina_Lock_Result eina_rwlock_take_write(Eina_RWLock *mutex);
+EINA_API Eina_Lock_Result eina_rwlock_take_write(Eina_RWLock *mutex);
 
 /**
  * @brief Releases a lock.
@@ -372,7 +372,7 @@ EAPI Eina_Lock_Result eina_rwlock_take_write(Eina_RWLock *mutex);
  * @see eina_rwlock_take_read()
  * @see eina_rwlock_take_write()
  */
-EAPI Eina_Lock_Result eina_rwlock_release(Eina_RWLock *mutex);
+EINA_API Eina_Lock_Result eina_rwlock_release(Eina_RWLock *mutex);
 
 /**
  * @brief Initializes a new #Eina_TLS, or thread level storage, to store thread
@@ -390,7 +390,7 @@ EAPI Eina_Lock_Result eina_rwlock_release(Eina_RWLock *mutex);
  * @see eina_tls_cb_new()
  * @see eina_tls_free()
  */
-EAPI Eina_Bool eina_tls_new(Eina_TLS *key);
+EINA_API Eina_Bool eina_tls_new(Eina_TLS *key);
 
 /**
  * @brief Initializes a new #Eina_TLS, or thread level storage, to store thread
@@ -407,7 +407,7 @@ EAPI Eina_Bool eina_tls_new(Eina_TLS *key);
  * @see eina_tls_new()
  * @see eina_tls_free()
  */
-EAPI Eina_Bool eina_tls_cb_new(Eina_TLS *key, Eina_TLS_Delete_Cb delete_cb);
+EINA_API Eina_Bool eina_tls_cb_new(Eina_TLS *key, Eina_TLS_Delete_Cb delete_cb);
 
 /**
  * @brief Frees an allocated #Eina_TLS.
@@ -419,7 +419,7 @@ EAPI Eina_Bool eina_tls_cb_new(Eina_TLS *key, Eina_TLS_Delete_Cb delete_cb);
  * @see eina_tls_new()
  * @see eina_tls_cb_new()
  */
-EAPI void eina_tls_free(Eina_TLS key);
+EINA_API void eina_tls_free(Eina_TLS key);
 
 /**
  * @brief Gets the value in #Eina_TLS for this thread.
@@ -432,7 +432,7 @@ EAPI void eina_tls_free(Eina_TLS key);
  *
  * @see  eina_tls_set()
  */
-EAPI void *eina_tls_get(Eina_TLS key);
+EINA_API void *eina_tls_get(Eina_TLS key);
 
 /**
  * @brief Sets the value in Eina_TLS for this thread.
@@ -446,7 +446,7 @@ EAPI void *eina_tls_get(Eina_TLS key);
  *
  * @see eina_tls_get()
  */
-EAPI Eina_Bool eina_tls_set(Eina_TLS key, const void *data);
+EINA_API Eina_Bool eina_tls_set(Eina_TLS key, const void *data);
 
 /**
  * @brief Initializes a new #Eina_Semaphore.
@@ -460,7 +460,7 @@ EAPI Eina_Bool eina_tls_set(Eina_TLS key, const void *data);
  *
  * @see eina_semaphore_free()
  */
-EAPI Eina_Bool eina_semaphore_new(Eina_Semaphore *sem, int count_init);
+EINA_API Eina_Bool eina_semaphore_new(Eina_Semaphore *sem, int count_init);
 
 /**
  * @brief Frees an allocated #Eina_Semaphore.
@@ -473,7 +473,7 @@ EAPI Eina_Bool eina_semaphore_new(Eina_Semaphore *sem, int count_init);
  *
  * @see eina_semaphore_new()
  */
-EAPI Eina_Bool eina_semaphore_free(Eina_Semaphore *sem);
+EINA_API Eina_Bool eina_semaphore_free(Eina_Semaphore *sem);
 
 /**
  * @brief Gets a lock on an #Eina_Semaphore.
@@ -486,7 +486,7 @@ EAPI Eina_Bool eina_semaphore_free(Eina_Semaphore *sem);
  *
  * @see eina_semaphore_release()
  */
-EAPI Eina_Bool eina_semaphore_lock(Eina_Semaphore *sem);
+EINA_API Eina_Bool eina_semaphore_lock(Eina_Semaphore *sem);
 
 /**
  * @brief Releases a lock on an #Eina_Semaphore.
@@ -500,7 +500,7 @@ EAPI Eina_Bool eina_semaphore_lock(Eina_Semaphore *sem);
  *
  * @see eina_semaphore_lock()
  */
-EAPI Eina_Bool eina_semaphore_release(Eina_Semaphore *sem, int count_release);
+EINA_API Eina_Bool eina_semaphore_release(Eina_Semaphore *sem, int count_release);
 
 /**
  * @brief Initializes a new #Eina_Barrier.
@@ -515,7 +515,7 @@ EAPI Eina_Bool eina_semaphore_release(Eina_Semaphore *sem, int count_release);
  *
  * @see eina_barrier_free()
  */
-EAPI Eina_Bool eina_barrier_new(Eina_Barrier *barrier, int needed);
+EINA_API Eina_Bool eina_barrier_new(Eina_Barrier *barrier, int needed);
 
 /**
  * @brief Frees an allocated #Eina_Barrier.
@@ -525,7 +525,7 @@ EAPI Eina_Bool eina_barrier_new(Eina_Barrier *barrier, int needed);
  *
  * @see eina_barrier_new()
  */
-EAPI void eina_barrier_free(Eina_Barrier *barrier);
+EINA_API void eina_barrier_free(Eina_Barrier *barrier);
 
 /**
  * @brief Increments the count of threads that are waiting on @p barrier.
@@ -536,7 +536,7 @@ EAPI void eina_barrier_free(Eina_Barrier *barrier);
  * @return #EINA_TRUE on success, else #EINA_FALSE otherwise.
  *
  */
-EAPI Eina_Bool eina_barrier_wait(Eina_Barrier *barrier);
+EINA_API Eina_Bool eina_barrier_wait(Eina_Barrier *barrier);
 
 
 /**
@@ -553,7 +553,7 @@ EAPI Eina_Bool eina_barrier_wait(Eina_Barrier *barrier);
  *
  * @see eina_spinlock_free()
  */
-EAPI Eina_Bool eina_spinlock_new(Eina_Spinlock *spinlock);
+EINA_API Eina_Bool eina_spinlock_new(Eina_Spinlock *spinlock);
 
 /**
  * @brief Attempts to take a spinlock.
@@ -571,7 +571,7 @@ EAPI Eina_Bool eina_spinlock_new(Eina_Spinlock *spinlock);
  * @see eina_spinlock_take_try()
  * @see eina_spinlock_release()
  */
-EAPI Eina_Lock_Result eina_spinlock_take(Eina_Spinlock *spinlock);
+EINA_API Eina_Lock_Result eina_spinlock_take(Eina_Spinlock *spinlock);
 
 /**
  * @brief Attempts to take a spinlock if possible.
@@ -587,7 +587,7 @@ EAPI Eina_Lock_Result eina_spinlock_take(Eina_Spinlock *spinlock);
  * @see eina_spinlock_take_try()
  * @see eina_spinlock_release()
  */
-EAPI Eina_Lock_Result eina_spinlock_take_try(Eina_Spinlock *spinlock);
+EINA_API Eina_Lock_Result eina_spinlock_take_try(Eina_Spinlock *spinlock);
 
 /**
  * @brief Releases a spinlock.
@@ -603,7 +603,7 @@ EAPI Eina_Lock_Result eina_spinlock_take_try(Eina_Spinlock *spinlock);
  * @see eina_spinlock_take_try()
 
  */
-EAPI Eina_Lock_Result eina_spinlock_release(Eina_Spinlock *spinlock);
+EINA_API Eina_Lock_Result eina_spinlock_release(Eina_Spinlock *spinlock);
 
 /**
  * @brief Deallocates an #Eina_Spinlock.
@@ -613,7 +613,7 @@ EAPI Eina_Lock_Result eina_spinlock_release(Eina_Spinlock *spinlock);
  * @param[in] spinlock The #Eina_Spinlock to be deallocated.
  *
  */
-EAPI void eina_spinlock_free(Eina_Spinlock *spinlock);
+EINA_API void eina_spinlock_free(Eina_Spinlock *spinlock);
 
 #ifdef EINA_HAVE_DEBUG_THREADS
 # define EINA_MAIN_LOOP_CHECK_RETURN_VAL(val)				\

--- a/src/lib/eina/eina_log.c
+++ b/src/lib/eina/eina_log.c
@@ -103,8 +103,8 @@ struct _Eina_Log_Timing
    Eina_Log_State state;
 };
 
-EAPI const char *_eina_log_state_init = "init";
-EAPI const char *_eina_log_state_shutdown = "shutdown";
+EINA_API const char *_eina_log_state_init = "init";
+EINA_API const char *_eina_log_state_shutdown = "shutdown";
 
 /*
  * List of levels for domains set by the user before the domains are registered,
@@ -1683,13 +1683,13 @@ eina_log_threads_shutdown(void)
  * @cond LOCAL
  */
 
-EAPI int EINA_LOG_DOMAIN_GLOBAL = 0;
+EINA_API int EINA_LOG_DOMAIN_GLOBAL = 0;
 
 /**
  * @endcond
  */
 
-EAPI void
+EINA_API void
 eina_log_threads_enable(void)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1700,7 +1700,7 @@ eina_log_threads_enable(void)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_print_cb_set(Eina_Log_Print_Cb cb, void *data)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1718,7 +1718,7 @@ eina_log_print_cb_set(Eina_Log_Print_Cb cb, void *data)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_level_set(int level)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1731,7 +1731,7 @@ eina_log_level_set(int level)
 #endif
 }
 
-EAPI int
+EINA_API int
 eina_log_level_get(void)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1741,7 +1741,7 @@ eina_log_level_get(void)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_log_main_thread_check(void)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1751,7 +1751,7 @@ eina_log_main_thread_check(void)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_color_disable_set(Eina_Bool disabled)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1780,7 +1780,7 @@ eina_log_color_disable_set(Eina_Bool disabled)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_log_color_disable_get(void)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1790,7 +1790,7 @@ eina_log_color_disable_get(void)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_file_disable_set(Eina_Bool disabled)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1800,7 +1800,7 @@ eina_log_file_disable_set(Eina_Bool disabled)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_log_file_disable_get(void)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1810,7 +1810,7 @@ eina_log_file_disable_get(void)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_function_disable_set(Eina_Bool disabled)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1820,7 +1820,7 @@ eina_log_function_disable_set(Eina_Bool disabled)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_log_function_disable_get(void)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1830,7 +1830,7 @@ eina_log_function_disable_get(void)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_abort_on_critical_set(Eina_Bool abort_on_critical)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1840,7 +1840,7 @@ eina_log_abort_on_critical_set(Eina_Bool abort_on_critical)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_log_abort_on_critical_get(void)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1850,7 +1850,7 @@ eina_log_abort_on_critical_get(void)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_abort_on_critical_level_set(int critical_level)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1860,7 +1860,7 @@ eina_log_abort_on_critical_level_set(int critical_level)
 #endif
 }
 
-EAPI int
+EINA_API int
 eina_log_abort_on_critical_level_get(void)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1870,7 +1870,7 @@ eina_log_abort_on_critical_level_get(void)
 #endif
 }
 
-EAPI int
+EINA_API int
 eina_log_domain_register(const char *name, const char *color)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1889,7 +1889,7 @@ eina_log_domain_register(const char *name, const char *color)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_domain_unregister(int domain)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1902,7 +1902,7 @@ eina_log_domain_unregister(int domain)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_domain_level_set(const char *domain_name, int level)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1952,7 +1952,7 @@ eina_log_domain_level_set(const char *domain_name, int level)
 #endif
 }
 
-EAPI int
+EINA_API int
 eina_log_domain_level_get(const char *domain_name)
 {
 #ifdef EINA_ENABLE_LOG
@@ -1996,7 +1996,7 @@ eina_log_domain_level_get(const char *domain_name)
 #endif
 }
 
-EAPI int
+EINA_API int
 eina_log_domain_registered_level_get(int domain)
 {
 #ifdef EINA_ENABLE_LOG
@@ -2012,7 +2012,7 @@ eina_log_domain_registered_level_get(int domain)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_domain_registered_level_set(int domain, int level)
 {
 #ifdef EINA_ENABLE_LOG
@@ -2026,7 +2026,7 @@ eina_log_domain_registered_level_set(int domain, int level)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_print_cb_stderr(const Eina_Log_Domain *d,
                          Eina_Log_Level level,
                          const char *file,
@@ -2053,7 +2053,7 @@ eina_log_print_cb_stderr(const Eina_Log_Domain *d,
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_print_cb_stdout(const Eina_Log_Domain *d,
                          Eina_Log_Level level,
                          const char *file,
@@ -2117,7 +2117,7 @@ _eina_sd_init(void)
 
 #endif
 
-EAPI void
+EINA_API void
 eina_log_print_cb_journald(const Eina_Log_Domain *d,
                            Eina_Log_Level level,
                            const char *file,
@@ -2208,7 +2208,7 @@ nosystemd:
    eina_log_print_cb_stderr(d, level, file, fnc, line, fmt, data, args);
 }
 
-EAPI void
+EINA_API void
 eina_log_print_cb_file(const Eina_Log_Domain *d,
                        EINA_UNUSED Eina_Log_Level level,
                        const char *file,
@@ -2252,7 +2252,7 @@ end:
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_print(int domain, Eina_Log_Level level, const char *file,
                const char *fnc, int line, const char *fmt, ...)
 {
@@ -2294,7 +2294,7 @@ eina_log_print(int domain, Eina_Log_Level level, const char *file,
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_vprint(int domain, Eina_Log_Level level, const char *file,
                 const char *fnc, int line, const char *fmt, va_list args)
 {
@@ -2334,7 +2334,7 @@ eina_log_vprint(int domain, Eina_Log_Level level, const char *file,
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_console_color_set(FILE *fp, const char *color)
 {
 #ifdef EINA_ENABLE_LOG
@@ -2370,7 +2370,7 @@ eina_log_console_color_set(FILE *fp, const char *color)
 #endif
 }
 
-EAPI void
+EINA_API void
 eina_log_timing(int domain,
                 Eina_Log_State state,
                 const char *phase)

--- a/src/lib/eina/eina_log.h
+++ b/src/lib/eina/eina_log.h
@@ -230,7 +230,7 @@
  * EINA_LOG_DOMAIN_GLOBAL is the general purpose log domain to be
  * used, it is always registered and available everywhere.
  */
-EAPI extern int EINA_LOG_DOMAIN_GLOBAL;
+EINA_API extern int EINA_LOG_DOMAIN_GLOBAL;
 
 #ifndef EINA_LOG_DOMAIN_DEFAULT
 
@@ -441,7 +441,7 @@ struct _Eina_Log_Domain
  * The main thread is considered the thread where the first
  * eina_init() was called.
  */
-EAPI void eina_log_threads_enable(void);
+EINA_API void eina_log_threads_enable(void);
 
 
 /**
@@ -504,7 +504,7 @@ typedef enum _Eina_Log_State
  *       This means you're safe from other calls but you should never
  *       call eina_log_print(), directly or indirectly.
  */
-EAPI void eina_log_print_cb_set(Eina_Log_Print_Cb cb, void *data) EINA_ARG_NONNULL(1);
+EINA_API void eina_log_print_cb_set(Eina_Log_Print_Cb cb, void *data) EINA_ARG_NONNULL(1);
 
 
 /**
@@ -519,7 +519,7 @@ EAPI void eina_log_print_cb_set(Eina_Log_Print_Cb cb, void *data) EINA_ARG_NONNU
  *
  * @see eina_log_level_get()
  */
-EAPI void eina_log_level_set(int level);
+EINA_API void eina_log_level_set(int level);
 
 /**
  * @brief Gets the default log level.
@@ -528,7 +528,7 @@ EAPI void eina_log_level_set(int level);
  *
  * @see eina_log_level_set()
  */
-EAPI int  eina_log_level_get(void) EINA_WARN_UNUSED_RESULT;
+EINA_API int  eina_log_level_get(void) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Determines if a given @p level should be logged.
@@ -553,7 +553,7 @@ static inline Eina_Bool eina_log_level_check(int level);
  * @return #EINA_TRUE if the current thread is the one that called 
  * eina_log_threads_init(), otherwise #EINA_FALSE. 
  */
-EAPI Eina_Bool          eina_log_main_thread_check(void) EINA_CONST EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool          eina_log_main_thread_check(void) EINA_CONST EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -565,7 +565,7 @@ EAPI Eina_Bool          eina_log_main_thread_check(void) EINA_CONST EINA_WARN_UN
  *
  * @see eina_log_color_disable_get()
  */
-EAPI void               eina_log_color_disable_set(Eina_Bool disabled);
+EINA_API void               eina_log_color_disable_set(Eina_Bool disabled);
 
 /**
  * @brief Determines if color logging is enabled or disabled.
@@ -574,7 +574,7 @@ EAPI void               eina_log_color_disable_set(Eina_Bool disabled);
  *
  * @see eina_log_color_disable_set()
  */
-EAPI Eina_Bool          eina_log_color_disable_get(void) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool          eina_log_color_disable_get(void) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Sets if originating file name logging should be disabled.
@@ -585,7 +585,7 @@ EAPI Eina_Bool          eina_log_color_disable_get(void) EINA_WARN_UNUSED_RESULT
  *
  * @see eina_log_file_disable_get()
  */
-EAPI void               eina_log_file_disable_set(Eina_Bool disabled);
+EINA_API void               eina_log_file_disable_set(Eina_Bool disabled);
 
 /**
  * @brief Gets if originating file name logging should be disabled.
@@ -594,7 +594,7 @@ EAPI void               eina_log_file_disable_set(Eina_Bool disabled);
  *
  * @see eina_log_file_disable_set()
  */
-EAPI Eina_Bool          eina_log_file_disable_get(void) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool          eina_log_file_disable_get(void) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Sets if originating function name logging should be disabled.
@@ -606,7 +606,7 @@ EAPI Eina_Bool          eina_log_file_disable_get(void) EINA_WARN_UNUSED_RESULT;
  *
  * @see eina_log_function_disable_get()
  */
-EAPI void               eina_log_function_disable_set(Eina_Bool disabled);
+EINA_API void               eina_log_function_disable_set(Eina_Bool disabled);
 
 /**
  * @brief Gets if originating function name logging should be disabled.
@@ -615,7 +615,7 @@ EAPI void               eina_log_function_disable_set(Eina_Bool disabled);
  *
  * @see eina_log_function_disable_set()
  */
-EAPI Eina_Bool          eina_log_function_disable_get(void) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool          eina_log_function_disable_get(void) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Sets if critical messages should abort the program.
@@ -630,7 +630,7 @@ EAPI Eina_Bool          eina_log_function_disable_get(void) EINA_WARN_UNUSED_RES
  * @see eina_log_abort_on_critical_get()
  * @see eina_log_abort_on_critical_level_set()
  */
-EAPI void               eina_log_abort_on_critical_set(Eina_Bool abort_on_critical);
+EINA_API void               eina_log_abort_on_critical_set(Eina_Bool abort_on_critical);
 
 /**
  * @brief Gets if critical messages should abort the program.
@@ -642,7 +642,7 @@ EAPI void               eina_log_abort_on_critical_set(Eina_Bool abort_on_critic
  * @see eina_log_abort_on_critical_set()
  * @see eina_log_abort_on_critical_level_set()
  */
-EAPI Eina_Bool          eina_log_abort_on_critical_get(void) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool          eina_log_abort_on_critical_get(void) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Sets level that triggers abort if abort-on-critical is set.
@@ -657,7 +657,7 @@ EAPI Eina_Bool          eina_log_abort_on_critical_get(void) EINA_WARN_UNUSED_RE
  * @see eina_log_abort_on_critical_level_get()
  * @see eina_log_abort_on_critical_get()
  */
-EAPI void               eina_log_abort_on_critical_level_set(int critical_level);
+EINA_API void               eina_log_abort_on_critical_level_set(int critical_level);
 
 /**
  * @brief Gets level that triggers abort if abort-on-critical is set.
@@ -669,7 +669,7 @@ EAPI void               eina_log_abort_on_critical_level_set(int critical_level)
  * @see eina_log_abort_on_critical_level_set()
  * @see eina_log_abort_on_critical_get()
  */
-EAPI int                eina_log_abort_on_critical_level_get(void) EINA_WARN_UNUSED_RESULT;
+EINA_API int                eina_log_abort_on_critical_level_get(void) EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -684,7 +684,7 @@ EAPI int                eina_log_abort_on_critical_level_get(void) EINA_WARN_UNU
  *        registration.
  * @param[in] level Level to use to limit eina_log_print() for given domain.
  */
-EAPI void               eina_log_domain_level_set(const char *domain_name, int level) EINA_ARG_NONNULL(1);
+EINA_API void               eina_log_domain_level_set(const char *domain_name, int level) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets the domain level given its name.
@@ -704,7 +704,7 @@ EAPI void               eina_log_domain_level_set(const char *domain_name, int l
  * @see eina_log_domain_level_set()
  * @see eina_log_domain_registered_level_get()
  */
-EAPI int                eina_log_domain_level_get(const char *domain_name) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API int                eina_log_domain_level_get(const char *domain_name) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets the domain level given its identifier.
@@ -717,7 +717,7 @@ EAPI int                eina_log_domain_level_get(const char *domain_name) EINA_
  * @return #EINA_TRUE if level should be printed, #EINA_FALSE if not.
  *         (domain's level is greater or equal @a level).
  */
-EAPI int                eina_log_domain_registered_level_get(int domain) EINA_WARN_UNUSED_RESULT;
+EINA_API int                eina_log_domain_registered_level_get(int domain) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Sets the domain level given its identifier.
@@ -729,7 +729,7 @@ EAPI int                eina_log_domain_registered_level_get(int domain) EINA_WA
  * @param[in] level Level to use to limit eina_log_print() for given domain.
  * @since 1.10
  */
-EAPI void                eina_log_domain_registered_level_set(int domain, int level);
+EINA_API void                eina_log_domain_registered_level_set(int domain, int level);
 
 static inline Eina_Bool eina_log_domain_level_check(int domain, int level);
 
@@ -746,7 +746,7 @@ static inline Eina_Bool eina_log_domain_level_check(int domain, int level);
  *
  * @note MT: Safe to call from any thread.
  */
-EAPI int  eina_log_domain_register(const char *name, const char *color) EINA_ARG_NONNULL(1);
+EINA_API int  eina_log_domain_register(const char *name, const char *color) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Forgets about a logging domain registered by eina_log_domain_register()
@@ -756,7 +756,7 @@ EAPI int  eina_log_domain_register(const char *name, const char *color) EINA_ARG
  *
  * @note MT: Safe to call from any thread.
  */
-EAPI void eina_log_domain_unregister(int domain);
+EINA_API void eina_log_domain_unregister(int domain);
 
 /*
  * Logging functions.
@@ -785,7 +785,7 @@ EAPI void eina_log_domain_unregister(int domain);
  * @note MT: This function may be called from different threads if
  *       eina_log_threads_enable() was called before.
  */
-EAPI void eina_log_print(int            domain,
+EINA_API void eina_log_print(int            domain,
                          Eina_Log_Level level,
                          const char    *file,
                          const char    *function,
@@ -818,7 +818,7 @@ EAPI void eina_log_print(int            domain,
  *
  * @see eina_log_print()
  */
-EAPI void eina_log_vprint(int            domain,
+EINA_API void eina_log_vprint(int            domain,
                           Eina_Log_Level level,
                           const char    *file,
                           const char    *fnc,
@@ -856,7 +856,7 @@ EAPI void eina_log_vprint(int            domain,
  * @note MT: Threads different from main thread will have thread id
  *       appended to domain name.
  */
-EAPI void eina_log_print_cb_stdout(const Eina_Log_Domain *d,
+EINA_API void eina_log_print_cb_stdout(const Eina_Log_Domain *d,
                                    Eina_Log_Level         level,
                                    const char            *file,
                                    const char            *fnc,
@@ -898,7 +898,7 @@ EAPI void eina_log_print_cb_stdout(const Eina_Log_Domain *d,
  * @note MT: Threads different from main thread will have thread id
  *       appended to domain name.
  */
-EAPI void eina_log_print_cb_stderr(const Eina_Log_Domain *d,
+EINA_API void eina_log_print_cb_stderr(const Eina_Log_Domain *d,
                                    Eina_Log_Level         level,
                                    const char            *file,
                                    const char            *fnc,
@@ -925,7 +925,7 @@ EAPI void eina_log_print_cb_stderr(const Eina_Log_Domain *d,
  * @note MT: Threads different from main thread will have thread id
  *       appended to domain name.
  */
-EAPI void eina_log_print_cb_file(const Eina_Log_Domain *d,
+EINA_API void eina_log_print_cb_file(const Eina_Log_Domain *d,
                                  Eina_Log_Level         level,
                                  const char            *file,
                                  const char            *fnc,
@@ -954,7 +954,7 @@ EAPI void eina_log_print_cb_file(const Eina_Log_Domain *d,
  *
  * @since 1.8
  */
-EAPI void eina_log_print_cb_journald(const Eina_Log_Domain *d,
+EINA_API void eina_log_print_cb_journald(const Eina_Log_Domain *d,
 				     Eina_Log_Level level,
 				     const char *file,
 				     const char *fnc,
@@ -975,13 +975,13 @@ EAPI void eina_log_print_cb_journald(const Eina_Log_Domain *d,
  *
  * @since 1.7
  */
-EAPI void eina_log_console_color_set(FILE *fp,
+EINA_API void eina_log_console_color_set(FILE *fp,
                                      const char *color) EINA_ARG_NONNULL(1, 2);
 
 /** String that indicates the log system is initializing. */
-extern EAPI const char *_eina_log_state_init;
+EINA_API extern const char *_eina_log_state_init;
 /** String that indicates the log system is shutting down. */
-extern EAPI const char *_eina_log_state_shutdown;
+EINA_API extern const char *_eina_log_state_shutdown;
 /**
  * @def EINA_LOG_STATE_INIT
  * String that indicates the log system is initializing 
@@ -1006,7 +1006,7 @@ extern EAPI const char *_eina_log_state_shutdown;
  * @note The phase name should be available for all the life of the timing.
  * @since 1.8
  */
-EAPI void eina_log_timing(int domain,
+EINA_API void eina_log_timing(int domain,
                           Eina_Log_State state,
                           const char *phase) EINA_ARG_NONNULL(1, 3);
 

--- a/src/lib/eina/eina_magic.c
+++ b/src/lib/eina/eina_magic.c
@@ -119,7 +119,7 @@ _eina_magic_strings_alloc(void)
 *                                 Global                                     *
 *============================================================================*/
 
-EAPI Eina_Error EINA_ERROR_MAGIC_FAILED = 0;
+EINA_API Eina_Error EINA_ERROR_MAGIC_FAILED = 0;
 
 /**
  * @internal
@@ -185,7 +185,7 @@ eina_magic_string_shutdown(void)
 /*============================================================================*
 *                                   API                                      *
 *============================================================================*/
-EAPI const char *
+EINA_API const char *
 eina_magic_string_get(Eina_Magic magic)
 {
    Eina_Magic_String *ems;
@@ -209,7 +209,7 @@ eina_magic_string_get(Eina_Magic magic)
    return "(unknown)";
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_magic_string_set(Eina_Magic magic, const char *magic_name)
 {
    Eina_Magic_String *ems;
@@ -234,7 +234,7 @@ eina_magic_string_set(Eina_Magic magic, const char *magic_name)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_magic_string_static_set(Eina_Magic magic, const char *magic_name)
 {
    Eina_Magic_String *ems;
@@ -257,7 +257,7 @@ eina_magic_string_static_set(Eina_Magic magic, const char *magic_name)
 # undef eina_magic_fail
 #endif
 
-EAPI void
+EINA_API void
 eina_magic_fail(void *d,
                 Eina_Magic m,
                 Eina_Magic req_m,

--- a/src/lib/eina/eina_magic.h
+++ b/src/lib/eina/eina_magic.h
@@ -150,7 +150,7 @@ typedef unsigned int Eina_Magic;
  *
  * @warning The returned value must not be freed.
  */
-EAPI const char *eina_magic_string_get(Eina_Magic magic) EINA_WARN_UNUSED_RESULT;
+EINA_API const char *eina_magic_string_get(Eina_Magic magic) EINA_WARN_UNUSED_RESULT;
 /**
  * @brief Sets the string associated with the given magic identifier.
  * @details This function sets the string @p magic_name to @p magic. It is not
@@ -165,7 +165,7 @@ EAPI const char *eina_magic_string_get(Eina_Magic magic) EINA_WARN_UNUSED_RESULT
  *
  * @see eina_magic_string_static_set()
  */
-EAPI Eina_Bool   eina_magic_string_set(Eina_Magic  magic,
+EINA_API Eina_Bool   eina_magic_string_set(Eina_Magic  magic,
                                        const char *magic_name) EINA_ARG_NONNULL(2);
 
 /**
@@ -183,7 +183,7 @@ EAPI Eina_Bool   eina_magic_string_set(Eina_Magic  magic,
  *
  * @see eina_magic_string_set()
  */
-EAPI Eina_Bool   eina_magic_string_static_set(Eina_Magic  magic,
+EINA_API Eina_Bool   eina_magic_string_static_set(Eina_Magic  magic,
                                               const char *magic_name) EINA_ARG_NONNULL(2);
 
 /**
@@ -200,7 +200,7 @@ EAPI Eina_Bool   eina_magic_string_static_set(Eina_Magic  magic,
  * @var EINA_ERROR_MAGIC_FAILED
  * @brief The error identifier corresponding to the magic check failure.
  */
-EAPI extern Eina_Error EINA_ERROR_MAGIC_FAILED;
+EINA_API extern Eina_Error EINA_ERROR_MAGIC_FAILED;
 
 #ifdef EINA_MAGIC_DEBUG
 
@@ -289,7 +289,7 @@ EAPI extern Eina_Error EINA_ERROR_MAGIC_FAILED;
  *       called and the program stops. It is useful for debugging programs
  *       with gdb.
  */
-EAPI void eina_magic_fail(void *d, Eina_Magic m, Eina_Magic req_m,
+EINA_API void eina_magic_fail(void *d, Eina_Magic m, Eina_Magic req_m,
                           const char *file, const char *fnc,
                           int line) EINA_ARG_NONNULL(4, 5);
 

--- a/src/lib/eina/eina_main.c
+++ b/src/lib/eina/eina_main.c
@@ -97,13 +97,13 @@ static int _eina_log_dom = -1;
 #endif
 #define DBG(...) EINA_LOG_DOM_DBG(_eina_log_dom, __VA_ARGS__)
 
-EAPI Eina_Bool _eina_threads_activated = EINA_FALSE;
-EAPI Eina_Error EINA_ERROR_NOT_MAIN_LOOP = 0;
-EAPI Eina_Error EINA_ERROR_NOT_IMPLEMENTED = 0;
-EAPI unsigned int eina_seed = 0;
+EINA_API Eina_Bool _eina_threads_activated = EINA_FALSE;
+EINA_API Eina_Error EINA_ERROR_NOT_MAIN_LOOP = 0;
+EINA_API Eina_Error EINA_ERROR_NOT_IMPLEMENTED = 0;
+EINA_API unsigned int eina_seed = 0;
 
 #ifdef EFL_HAVE_THREADS
-EAPI Eina_Thread _eina_main_loop;
+EINA_API Eina_Thread _eina_main_loop;
 #endif
 
 #ifdef MT
@@ -111,9 +111,9 @@ static int _mt_enabled = 0;
 #endif
 
 #ifdef EFL_HAVE_THREADS
-EAPI int _eina_threads_debug = 0;
-EAPI Eina_Lock _eina_tracking_lock;
-EAPI Eina_Inlist *_eina_tracking = NULL;
+EINA_API int _eina_threads_debug = 0;
+EINA_API Eina_Lock _eina_tracking_lock;
+EINA_API Eina_Inlist *_eina_tracking = NULL;
 extern Eina_Lock       _sysmon_lock;
 #endif
 
@@ -278,9 +278,9 @@ _eina_threads_do_shutdown(void)
  * @var eina_version
  * @brief Eina version (defined at configuration time)
  */
-EAPI Eina_Version *eina_version = &_version;
+EINA_API Eina_Version *eina_version = &_version;
 
-EAPI int
+EINA_API int
 eina_init(void)
 {
    const struct eina_desc_setup *itr, *itr_end;
@@ -351,7 +351,7 @@ eina_init(void)
    return 1;
 }
 
-EAPI int
+EINA_API int
 eina_shutdown(void)
 {
    if (_eina_main_count <= 0)
@@ -389,7 +389,7 @@ eina_shutdown(void)
 }
 
 
-EAPI int
+EINA_API int
 eina_threads_init(void)
 {
 #ifdef EFL_HAVE_THREADS
@@ -414,7 +414,7 @@ eina_threads_init(void)
 #endif
 }
 
-EAPI int
+EINA_API int
 eina_threads_shutdown(void)
 {
 #ifdef EFL_HAVE_THREADS
@@ -438,7 +438,7 @@ eina_threads_shutdown(void)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_main_loop_is(void)
 {
 #ifdef EFL_HAVE_THREADS
@@ -455,7 +455,7 @@ eina_main_loop_is(void)
 }
 
 /** The purpose of this API should not be documented, it is used only by the one who know what they are doing. */
-EAPI void
+EINA_API void
 eina_main_loop_define(void)
 {
 #ifdef EFL_HAVE_THREADS

--- a/src/lib/eina/eina_main.h
+++ b/src/lib/eina/eina_main.h
@@ -66,9 +66,9 @@ typedef struct _Eina_Version
    int revision; /**< Revision component of the version */
 } Eina_Version;
 
-EAPI extern Eina_Version *eina_version;
+EINA_API extern Eina_Version *eina_version;
 
-EAPI extern Eina_Error EINA_ERROR_NOT_IMPLEMENTED;
+EINA_API extern Eina_Error EINA_ERROR_NOT_IMPLEMENTED;
 
 /**
  * @brief Initializes the Eina library.
@@ -175,7 +175,7 @@ EAPI extern Eina_Error EINA_ERROR_NOT_IMPLEMENTED;
  *      threads, but requires Eina to be compiled with such feature.
  *
  */
-EAPI int eina_init(void);
+EINA_API int eina_init(void);
 
 /**
  * @brief Shuts down the Eina library.
@@ -191,7 +191,7 @@ EAPI int eina_init(void);
  * not call any of the Eina functions anymore. You must call
  * eina_init() again to use the Eina functions again.
  */
-EAPI int eina_shutdown(void);
+EINA_API int eina_shutdown(void);
 
 /**
  * @brief Initializes the mutexes of the Eina library.
@@ -208,7 +208,7 @@ EAPI int eina_shutdown(void);
  *
  * This function should never be called outside of the main loop.
  */
-EAPI int eina_threads_init(void);
+EINA_API int eina_threads_init(void);
 
 /**
  * @brief Shuts down mutexes in the Eina library.
@@ -226,7 +226,7 @@ EAPI int eina_threads_init(void);
  *
  * This function should never be called outside of the main loop.
  */
-EAPI int eina_threads_shutdown(void);
+EINA_API int eina_threads_shutdown(void);
 
 /**
  * @brief Checks if you are calling this function from the same thread Eina was initialized or not.
@@ -239,7 +239,7 @@ EAPI int eina_threads_shutdown(void);
  * the main loop. With this call you could know if you can call an EFL
  * function or not.
  */
-EAPI Eina_Bool eina_main_loop_is(void);
+EINA_API Eina_Bool eina_main_loop_is(void);
 
 /**
  * @brief You should never use this function except if you really really know what your are doing.
@@ -248,7 +248,7 @@ EAPI Eina_Bool eina_main_loop_is(void);
  * If you are reading this documentation, that certainly means you don't know what is the purpose of
  * this call and you should just not use it.
  */
-EAPI void eina_main_loop_define(void);
+EINA_API void eina_main_loop_define(void);
 
 /**
  * @}

--- a/src/lib/eina/eina_matrix.c
+++ b/src/lib/eina/eina_matrix.c
@@ -107,7 +107,7 @@ _cos(double x)
 /*============================================================================*
  *                                   API                                      *
  *============================================================================*/
-EAPI Eina_Matrix_Type
+EINA_API Eina_Matrix_Type
 eina_matrix3_type_get(const Eina_Matrix3 *m)
 {
    if (!EINA_DBL_EQ(MATRIX_ZX(m), 0.0) ||
@@ -128,7 +128,7 @@ eina_matrix3_type_get(const Eina_Matrix3 *m)
      }
 }
 
-EAPI Eina_Matrix_Type
+EINA_API Eina_Matrix_Type
 eina_matrix4_type_get(const Eina_Matrix4 *m)
 {
    if (EINA_DBL_EQ(MATRIX_XX(m), 1.0) &&
@@ -151,7 +151,7 @@ eina_matrix4_type_get(const Eina_Matrix4 *m)
    return EINA_MATRIX_TYPE_AFFINE;
 }
 
-EAPI Eina_Matrix_Type
+EINA_API Eina_Matrix_Type
 eina_matrix3_f16p16_type_get(const Eina_Matrix3_F16p16 *m)
 {
    if ((MATRIX_ZX(m) != 0) || (MATRIX_ZY(m) != 0) || (MATRIX_ZZ(m) != 65536))
@@ -166,7 +166,7 @@ eina_matrix3_f16p16_type_get(const Eina_Matrix3_F16p16 *m)
      }
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_values_set(Eina_Matrix3 *m,
                         double xx, double xy, double xz,
                         double yx, double yy, double yz,
@@ -183,7 +183,7 @@ eina_matrix3_values_set(Eina_Matrix3 *m,
    MATRIX_ZZ(m) = zz;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_values_get(const Eina_Matrix3 *m,
                         double *xx, double *xy, double *xz,
                         double *yx, double *yy, double *yz,
@@ -200,7 +200,7 @@ eina_matrix3_values_get(const Eina_Matrix3 *m,
    if (zz) *zz = MATRIX_ZZ(m);
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_values_set(Eina_Matrix4 *m,
                         double xx, double xy, double xz, double xw,
                         double yx, double yy, double yz, double yw,
@@ -225,7 +225,7 @@ eina_matrix4_values_set(Eina_Matrix4 *m,
    MATRIX_WW(m) = ww;
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_values_get(const Eina_Matrix4 *m,
                         double *xx, double *xy, double *xz, double *xw,
                         double *yx, double *yy, double *yz, double *yw,
@@ -250,7 +250,7 @@ eina_matrix4_values_get(const Eina_Matrix4 *m,
    if (ww) *ww = MATRIX_WW(m);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_fixed_values_get(const Eina_Matrix3 *m,
                               Eina_F16p16 *xx, Eina_F16p16 *xy, Eina_F16p16 *xz,
                               Eina_F16p16 *yx, Eina_F16p16 *yy, Eina_F16p16 *yz,
@@ -267,7 +267,7 @@ eina_matrix3_fixed_values_get(const Eina_Matrix3 *m,
    if (zz) *zz = eina_f16p16_double_from(MATRIX_ZZ(m));
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_matrix3_f16p16_to(const Eina_Matrix3 *m,
                                Eina_Matrix3_F16p16 *fm)
 {
@@ -277,7 +277,7 @@ eina_matrix3_matrix3_f16p16_to(const Eina_Matrix3 *m,
                                  &fm->zx, &fm->zy, &fm->zz);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_point_transform(const Eina_Matrix3 *m,
                              double x, double y,
                              double *xr, double *yr)
@@ -302,7 +302,7 @@ eina_matrix3_point_transform(const Eina_Matrix3 *m,
    if (yr) *yr = yrr;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_rectangle_transform(const Eina_Matrix3 *m,
                                  const Eina_Rectangle *r,
                                  const Eina_Quad *q)
@@ -313,7 +313,7 @@ eina_matrix3_rectangle_transform(const Eina_Matrix3 *m,
    eina_matrix3_point_transform(m, r->x, r->y + r->h, &((Eina_Quad *)q)->x3, &((Eina_Quad *)q)->y3);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_cofactor(const Eina_Matrix3 *m, Eina_Matrix3 *a)
 {
    double a11, a12, a13, a21, a22, a23, a31, a32, a33;
@@ -343,7 +343,7 @@ eina_matrix3_cofactor(const Eina_Matrix3 *m, Eina_Matrix3 *a)
    MATRIX_ZZ(a) = a33;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_transpose(const Eina_Matrix3 *m, Eina_Matrix3 *a)
 {
    MATRIX_XX(a) = MATRIX_XX(m);
@@ -359,7 +359,7 @@ eina_matrix3_transpose(const Eina_Matrix3 *m, Eina_Matrix3 *a)
    MATRIX_ZZ(a) = MATRIX_ZZ(m);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_adjoint(const Eina_Matrix3 *m, Eina_Matrix3 *a)
 {
    Eina_Matrix3 cofactor;
@@ -370,7 +370,7 @@ eina_matrix3_adjoint(const Eina_Matrix3 *m, Eina_Matrix3 *a)
    eina_matrix3_transpose(&cofactor, a);
 }
 
-EAPI double
+EINA_API double
 eina_matrix3_determinant(const Eina_Matrix3 *m)
 {
    double det;
@@ -382,7 +382,7 @@ eina_matrix3_determinant(const Eina_Matrix3 *m)
    return det;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_divide(Eina_Matrix3 *m, double scalar)
 {
    MATRIX_XX(m) /= scalar;
@@ -398,7 +398,7 @@ eina_matrix3_divide(Eina_Matrix3 *m, double scalar)
    MATRIX_ZZ(m) /= scalar;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_inverse(const Eina_Matrix3 *m, Eina_Matrix3 *m2)
 {
    double scalar;
@@ -416,7 +416,7 @@ eina_matrix3_inverse(const Eina_Matrix3 *m, Eina_Matrix3 *m2)
    eina_matrix3_divide(m2, scalar);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_compose(const Eina_Matrix3 *m1,
                      const Eina_Matrix3 *m2,
                      Eina_Matrix3 *dst)
@@ -446,7 +446,7 @@ eina_matrix3_compose(const Eina_Matrix3 *m1,
    MATRIX_ZZ(dst) = a33;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrix3_equal(const Eina_Matrix3 *m1, const Eina_Matrix3 *m2)
 {
    if (!EINA_DBL_EQ(m1->xx, m2->xx) ||
@@ -462,7 +462,7 @@ eina_matrix3_equal(const Eina_Matrix3 *m1, const Eina_Matrix3 *m2)
    return EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_f16p16_compose(const Eina_Matrix3_F16p16 *m1,
                             const Eina_Matrix3_F16p16 *m2,
                             Eina_Matrix3_F16p16 *dst)
@@ -510,7 +510,7 @@ eina_matrix3_f16p16_compose(const Eina_Matrix3_F16p16 *m1,
    MATRIX_ZZ(dst) = a33;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_translate(Eina_Matrix3 *m, double tx, double ty)
 {
    Eina_Matrix3 tmp;
@@ -526,7 +526,7 @@ eina_matrix3_translate(Eina_Matrix3 *m, double tx, double ty)
    eina_matrix3_compose(m, &tmp, m);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_scale(Eina_Matrix3 *m, double sx, double sy)
 {
    Eina_Matrix3 tmp;
@@ -542,7 +542,7 @@ eina_matrix3_scale(Eina_Matrix3 *m, double sx, double sy)
    eina_matrix3_compose(m, &tmp, m);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_rotate(Eina_Matrix3 *m, double rad)
 {
    double c, s;
@@ -577,7 +577,7 @@ eina_matrix3_rotate(Eina_Matrix3 *m, double rad)
    eina_matrix3_compose(m, &tmp, m);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_identity(Eina_Matrix3 *m)
 {
    MATRIX_XX(m) = 1;
@@ -591,7 +591,7 @@ eina_matrix3_identity(Eina_Matrix3 *m)
    MATRIX_ZZ(m) = 1;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_f16p16_identity(Eina_Matrix3_F16p16 *m)
 {
    MATRIX_XX(m) = 65536;
@@ -605,7 +605,7 @@ eina_matrix3_f16p16_identity(Eina_Matrix3_F16p16 *m)
    MATRIX_ZZ(m) = 65536;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrix3_square_quad_map(Eina_Matrix3 *m, const Eina_Quad *q)
 {
    // x0 - x1 + x2 - x3
@@ -656,7 +656,7 @@ eina_matrix3_square_quad_map(Eina_Matrix3 *m, const Eina_Quad *q)
      }
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrix3_quad_square_map(Eina_Matrix3 *m,
                              const Eina_Quad *q)
 {
@@ -676,7 +676,7 @@ eina_matrix3_quad_square_map(Eina_Matrix3 *m,
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrix3_quad_quad_map(Eina_Matrix3 *m,
                            const Eina_Quad *src,
                            const Eina_Quad *dst)
@@ -693,7 +693,7 @@ eina_matrix3_quad_quad_map(Eina_Matrix3 *m,
    return EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_matrix3_to(Eina_Matrix3 *m3, const Eina_Matrix4 *m4)
 {
    MATRIX_XX(m3) = MATRIX_XX(m4);
@@ -707,7 +707,7 @@ eina_matrix4_matrix3_to(Eina_Matrix3 *m3, const Eina_Matrix4 *m4)
    MATRIX_ZZ(m3) = MATRIX_WW(m4);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_matrix4_to(Eina_Matrix4 *m4, const Eina_Matrix3 *m3)
 {
    MATRIX_XX(m4) = MATRIX_XX(m3);
@@ -728,7 +728,7 @@ eina_matrix3_matrix4_to(Eina_Matrix4 *m4, const Eina_Matrix3 *m3)
    MATRIX_WW(m4) = MATRIX_ZZ(m3);
 }
 
-EAPI double
+EINA_API double
 eina_matrix4_determinant(const Eina_Matrix4 *m)
 {
    return
@@ -758,7 +758,7 @@ eina_matrix4_determinant(const Eina_Matrix4 *m)
      + MATRIX_XX(m) * MATRIX_YY(m) * MATRIX_ZZ(m) * MATRIX_WW(m);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrix4_normalized(Eina_Matrix4 *out, const Eina_Matrix4 *in)
 {
    double det;
@@ -786,7 +786,7 @@ eina_matrix4_normalized(Eina_Matrix4 *out, const Eina_Matrix4 *in)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrix4_inverse(Eina_Matrix4 *out, const Eina_Matrix4 *in)
 {
    double det;
@@ -949,7 +949,7 @@ eina_matrix4_inverse(Eina_Matrix4 *out, const Eina_Matrix4 *in)
    return EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_transpose(Eina_Matrix4 *out, const Eina_Matrix4 *in)
 {
    MATRIX_XX(out) = MATRIX_XX(in);
@@ -970,7 +970,7 @@ eina_matrix4_transpose(Eina_Matrix4 *out, const Eina_Matrix4 *in)
    MATRIX_WW(out) = MATRIX_WW(in);
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_multiply_copy(Eina_Matrix4 *out,
                       const Eina_Matrix4 *mat_a, const Eina_Matrix4 *mat_b)
 {
@@ -987,7 +987,7 @@ eina_matrix4_multiply_copy(Eina_Matrix4 *out,
      }
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_identity(Eina_Matrix4 *out)
 {
    memset(out, 0, sizeof (Eina_Matrix4));
@@ -998,7 +998,7 @@ eina_matrix4_identity(Eina_Matrix4 *out)
    MATRIX_WW(out) = 1.0;
 }
 
-EAPI Eina_Matrix_Type
+EINA_API Eina_Matrix_Type
 eina_matrix2_type_get(const Eina_Matrix2 *m)
 {
    if (EINA_DBL_EQ(MATRIX_XX(m), 1.0) &&
@@ -1009,19 +1009,19 @@ eina_matrix2_type_get(const Eina_Matrix2 *m)
    return EINA_MATRIX_TYPE_AFFINE;
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_array_set(Eina_Matrix4 *m, const double *v)
 {
    memcpy(&MATRIX_XX(m), v, sizeof(double) * 16);
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_copy(Eina_Matrix4 *dst, const Eina_Matrix4 *src)
 {
    memcpy(dst, src, sizeof(Eina_Matrix4));
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_multiply(Eina_Matrix4 *out, const Eina_Matrix4 *mat_a,
                            const Eina_Matrix4 *mat_b)
 {
@@ -1040,7 +1040,7 @@ eina_matrix4_multiply(Eina_Matrix4 *out, const Eina_Matrix4 *mat_a,
    eina_matrix4_compose(mat_a, mat_b, out);
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_ortho_set(Eina_Matrix4 *m,
                     double left, double right, double bottom, double top,
                     double dnear, double dfar)
@@ -1070,7 +1070,7 @@ eina_matrix4_ortho_set(Eina_Matrix4 *m,
    MATRIX_WW(m) = 1.0f;
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_compose(const Eina_Matrix4 *mat_a,
                      const Eina_Matrix4 *mat_b,
                      Eina_Matrix4 *out)
@@ -1137,7 +1137,7 @@ eina_matrix4_compose(const Eina_Matrix4 *mat_a,
    MATRIX_WW(out) = ww;
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_translate(Eina_Matrix4 *t, double tx, double ty, double tz)
 {
    Eina_Matrix4 tmp;
@@ -1164,7 +1164,7 @@ eina_matrix4_translate(Eina_Matrix4 *t, double tx, double ty, double tz)
    eina_matrix4_compose(&tmp, t, t);
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_scale(Eina_Matrix4 *t, double sx, double sy, double sz)
 {
    Eina_Matrix4 tmp;
@@ -1191,7 +1191,7 @@ eina_matrix4_scale(Eina_Matrix4 *t, double sx, double sy, double sz)
    eina_matrix4_compose(&tmp, t, t);
 }
 
-EAPI void
+EINA_API void
 eina_matrix4_rotate(Eina_Matrix4 *t, double rad, Eina_Matrix_Axis axis)
 {
    double c, s;
@@ -1240,19 +1240,19 @@ eina_matrix4_rotate(Eina_Matrix4 *t, double rad, Eina_Matrix_Axis axis)
    eina_matrix4_compose(&tmp, t, t);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_array_set(Eina_Matrix3 *m, const double *v)
 {
    memcpy(&MATRIX_XX(m), v, sizeof(double) * 9);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_copy(Eina_Matrix3 *dst, const Eina_Matrix3 *src)
 {
    memcpy(dst, src, sizeof(Eina_Matrix3));
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_multiply(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a, const Eina_Matrix3 *mat_b)
 {
    if (eina_matrix3_type_get(mat_a) == EINA_MATRIX_TYPE_IDENTITY)
@@ -1270,7 +1270,7 @@ eina_matrix3_multiply(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a, const Eina_M
    eina_matrix3_compose(mat_a, mat_b, out);
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_multiply_copy(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a, const Eina_Matrix3 *mat_b)
 {
    if (out != mat_a && out != mat_b)
@@ -1286,7 +1286,7 @@ eina_matrix3_multiply_copy(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a, const E
      }
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_position_transform_set(Eina_Matrix3 *out, const double p_x,
 								 const double p_y)
 {
@@ -1295,7 +1295,7 @@ eina_matrix3_position_transform_set(Eina_Matrix3 *out, const double p_x,
    MATRIX_YZ(out) = p_y;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_scale_transform_set(Eina_Matrix3 *out, double s_x, double s_y)
 {
    eina_matrix3_identity(out);
@@ -1303,7 +1303,7 @@ eina_matrix3_scale_transform_set(Eina_Matrix3 *out, double s_x, double s_y)
    MATRIX_YY(out) = s_y;
 }
 
-EAPI void
+EINA_API void
 eina_normal3_matrix_get(Eina_Matrix3 *out, const Eina_Matrix4 *m)
 {
    /* Normal matrix is a transposed matrix of inversed modelview.
@@ -1341,7 +1341,7 @@ eina_normal3_matrix_get(Eina_Matrix3 *out, const Eina_Matrix4 *m)
    MATRIX_ZZ(out) = (a * e - d * b) * det;
 }
 
-EAPI void
+EINA_API void
 eina_matrix2_values_set(Eina_Matrix2 *m,
                         double xx, double xy,
                         double yx, double yy)
@@ -1352,7 +1352,7 @@ eina_matrix2_values_set(Eina_Matrix2 *m,
    MATRIX_YY(m) = yy;
 }
 
-EAPI void
+EINA_API void
 eina_matrix2_values_get(const Eina_Matrix2 *m,
                         double *xx, double *xy,
                         double *yx, double *yy)
@@ -1363,7 +1363,7 @@ eina_matrix2_values_get(const Eina_Matrix2 *m,
    if (yy) *yy = MATRIX_YY(m);
 }
 
-EAPI void
+EINA_API void
 eina_matrix2_inverse(Eina_Matrix2 *out, const Eina_Matrix2 *mat)
 {
    double         det;
@@ -1387,7 +1387,7 @@ eina_matrix2_inverse(Eina_Matrix2 *out, const Eina_Matrix2 *mat)
    MATRIX_YY(out) =  MATRIX_XX(mat) * det;
 }
 
-EAPI void
+EINA_API void
 eina_matrix2_identity(Eina_Matrix2 *m)
 {
    MATRIX_XX(m) = 1.0;
@@ -1397,19 +1397,19 @@ eina_matrix2_identity(Eina_Matrix2 *m)
    MATRIX_YY(m) = 1.0;
 }
 
-EAPI void
+EINA_API void
 eina_matrix2_array_set(Eina_Matrix2 *m, const double *v)
 {
    memcpy(&MATRIX_XX(m), v, sizeof(double) * 4);
 }
 
-EAPI void
+EINA_API void
 eina_matrix2_copy(Eina_Matrix2 *dst, const Eina_Matrix2 *src)
 {
    memcpy(dst, src, sizeof(Eina_Matrix2));
 }
 
-EAPI void
+EINA_API void
 eina_matrix2_multiply(Eina_Matrix2 *out, const Eina_Matrix2 *mat_a, const Eina_Matrix2 *mat_b)
 {
    if (eina_matrix2_type_get(mat_a) == EINA_MATRIX_TYPE_IDENTITY)
@@ -1431,7 +1431,7 @@ eina_matrix2_multiply(Eina_Matrix2 *out, const Eina_Matrix2 *mat_a, const Eina_M
    MATRIX_YY(out) = MATRIX_XY(mat_a) * MATRIX_YX(mat_b) + MATRIX_YY(mat_a) * MATRIX_YY(mat_b);
 }
 
-EAPI void
+EINA_API void
 eina_matrix2_multiply_copy(Eina_Matrix2 *out, const Eina_Matrix2 *mat_a, const Eina_Matrix2 *mat_b)
 {
    if (out != mat_a && out != mat_b)

--- a/src/lib/eina/eina_matrix.h
+++ b/src/lib/eina/eina_matrix.h
@@ -188,7 +188,7 @@ struct _Eina_Matrix3_F16p16
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_f16p16_identity(Eina_Matrix3_F16p16 *m);
+EINA_API void eina_matrix3_f16p16_identity(Eina_Matrix3_F16p16 *m);
 
 /**
  * @brief Sets dst as the matrix multiplication (composition) of two
@@ -205,7 +205,7 @@ EAPI void eina_matrix3_f16p16_identity(Eina_Matrix3_F16p16 *m);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_f16p16_compose(const Eina_Matrix3_F16p16 *m1,
+EINA_API void eina_matrix3_f16p16_compose(const Eina_Matrix3_F16p16 *m1,
                                       const Eina_Matrix3_F16p16 *m2,
                                       Eina_Matrix3_F16p16 *dst);
 
@@ -220,7 +220,7 @@ EAPI void eina_matrix3_f16p16_compose(const Eina_Matrix3_F16p16 *m1,
  *
  * @since 1.14
  */
-EAPI Eina_Matrix_Type eina_matrix3_f16p16_type_get(const Eina_Matrix3_F16p16 *m);
+EINA_API Eina_Matrix_Type eina_matrix3_f16p16_type_get(const Eina_Matrix3_F16p16 *m);
 
 /**
  * @}
@@ -252,7 +252,7 @@ EAPI Eina_Matrix_Type eina_matrix3_f16p16_type_get(const Eina_Matrix3_F16p16 *m)
  *
  * @since 1.14
  */
-EAPI Eina_Matrix_Type eina_matrix3_type_get(const Eina_Matrix3 *m);
+EINA_API Eina_Matrix_Type eina_matrix3_type_get(const Eina_Matrix3 *m);
 
 /**
  * @brief Sets the values of the coefficients of the given floating
@@ -276,7 +276,7 @@ EAPI Eina_Matrix_Type eina_matrix3_type_get(const Eina_Matrix3 *m);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_values_set(Eina_Matrix3 *m,
+EINA_API void eina_matrix3_values_set(Eina_Matrix3 *m,
                                   double xx, double xy, double xz,
                                   double yx, double yy, double yz,
                                   double zx, double zy, double zz);
@@ -303,7 +303,7 @@ EAPI void eina_matrix3_values_set(Eina_Matrix3 *m,
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_values_get(const Eina_Matrix3 *m,
+EINA_API void eina_matrix3_values_get(const Eina_Matrix3 *m,
                                   double *xx, double *xy, double *xz,
                                   double *yx, double *yy, double *yz,
                                   double *zx, double *zy, double *zz);
@@ -330,7 +330,7 @@ EAPI void eina_matrix3_values_get(const Eina_Matrix3 *m,
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_fixed_values_get(const Eina_Matrix3 *m,
+EINA_API void eina_matrix3_fixed_values_get(const Eina_Matrix3 *m,
                                         Eina_F16p16 *xx, Eina_F16p16 *xy, Eina_F16p16 *xz,
                                         Eina_F16p16 *yx, Eina_F16p16 *yy, Eina_F16p16 *yz,
                                         Eina_F16p16 *zx, Eina_F16p16 *zy, Eina_F16p16 *zz);
@@ -348,7 +348,7 @@ EAPI void eina_matrix3_fixed_values_get(const Eina_Matrix3 *m,
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_matrix3_f16p16_to(const Eina_Matrix3 *m,
+EINA_API void eina_matrix3_matrix3_f16p16_to(const Eina_Matrix3 *m,
                                          Eina_Matrix3_F16p16 *fm);
 
 /**
@@ -363,7 +363,7 @@ EAPI void eina_matrix3_matrix3_f16p16_to(const Eina_Matrix3 *m,
  *
  * @since 1.14
  */
-EAPI Eina_Bool eina_matrix3_equal(const Eina_Matrix3 *m1, const Eina_Matrix3 *m2);
+EINA_API Eina_Bool eina_matrix3_equal(const Eina_Matrix3 *m1, const Eina_Matrix3 *m2);
 
 /**
  * @brief Sets dst as the matrix multiplication (composition) of two matrices.
@@ -379,7 +379,7 @@ EAPI Eina_Bool eina_matrix3_equal(const Eina_Matrix3 *m1, const Eina_Matrix3 *m2
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_compose(const Eina_Matrix3 *m1,
+EINA_API void eina_matrix3_compose(const Eina_Matrix3 *m1,
                                const Eina_Matrix3 *m2,
                                Eina_Matrix3 *dst);
 
@@ -392,7 +392,7 @@ EAPI void eina_matrix3_compose(const Eina_Matrix3 *m1,
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_translate(Eina_Matrix3 *m, double tx, double ty);
+EINA_API void eina_matrix3_translate(Eina_Matrix3 *m, double tx, double ty);
 
 /**
  * @brief Sets the matrix values for a scaling operation.
@@ -403,7 +403,7 @@ EAPI void eina_matrix3_translate(Eina_Matrix3 *m, double tx, double ty);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_scale(Eina_Matrix3 *m, double sx, double sy);
+EINA_API void eina_matrix3_scale(Eina_Matrix3 *m, double sx, double sy);
 
 /**
  * @brief Sets the matrix values for a rotation operation.
@@ -412,7 +412,7 @@ EAPI void eina_matrix3_scale(Eina_Matrix3 *m, double sx, double sy);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_rotate(Eina_Matrix3 *m, double rad);
+EINA_API void eina_matrix3_rotate(Eina_Matrix3 *m, double rad);
 
 /**
  * @brief Sets the given floating point matrix to the identity matrix.
@@ -424,7 +424,7 @@ EAPI void eina_matrix3_rotate(Eina_Matrix3 *m, double rad);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_identity(Eina_Matrix3 *m);
+EINA_API void eina_matrix3_identity(Eina_Matrix3 *m);
 
 /**
  * @brief Calculates the determinant of the given matrix.
@@ -437,7 +437,7 @@ EAPI void eina_matrix3_identity(Eina_Matrix3 *m);
  *
  * @since 1.14
  */
-EAPI double eina_matrix3_determinant(const Eina_Matrix3 *m);
+EINA_API double eina_matrix3_determinant(const Eina_Matrix3 *m);
 
 /**
  * @brief Divides the given matrix by a scalar number.
@@ -450,7 +450,7 @@ EAPI double eina_matrix3_determinant(const Eina_Matrix3 *m);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_divide(Eina_Matrix3 *m, double scalar);
+EINA_API void eina_matrix3_divide(Eina_Matrix3 *m, double scalar);
 
 /**
  * @brief Computes the inverse of the given matrix.
@@ -464,7 +464,7 @@ EAPI void eina_matrix3_divide(Eina_Matrix3 *m, double scalar);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_inverse(const Eina_Matrix3 *m, Eina_Matrix3 *m2);
+EINA_API void eina_matrix3_inverse(const Eina_Matrix3 *m, Eina_Matrix3 *m2);
 
 /**
  * @brief Computes the transpose of the given matrix.
@@ -478,7 +478,7 @@ EAPI void eina_matrix3_inverse(const Eina_Matrix3 *m, Eina_Matrix3 *m2);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_transpose(const Eina_Matrix3 *m, Eina_Matrix3 *a);
+EINA_API void eina_matrix3_transpose(const Eina_Matrix3 *m, Eina_Matrix3 *a);
 
 /**
  * @brief Computes the cofactor of the given matrix.
@@ -494,7 +494,7 @@ EAPI void eina_matrix3_transpose(const Eina_Matrix3 *m, Eina_Matrix3 *a);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_cofactor(const Eina_Matrix3 *m, Eina_Matrix3 *a);
+EINA_API void eina_matrix3_cofactor(const Eina_Matrix3 *m, Eina_Matrix3 *a);
 
 /**
  * @brief Computes the adjoint of the given matrix.
@@ -508,7 +508,7 @@ EAPI void eina_matrix3_cofactor(const Eina_Matrix3 *m, Eina_Matrix3 *a);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_adjoint(const Eina_Matrix3 *m, Eina_Matrix3 *a);
+EINA_API void eina_matrix3_adjoint(const Eina_Matrix3 *m, Eina_Matrix3 *a);
 
 /**
  * @brief Computes the transform of a 2D point using the given matrix.
@@ -526,7 +526,7 @@ EAPI void eina_matrix3_adjoint(const Eina_Matrix3 *m, Eina_Matrix3 *a);
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_point_transform(const Eina_Matrix3 *m,
+EINA_API void eina_matrix3_point_transform(const Eina_Matrix3 *m,
                                        double x, double y,
                                        double *xr, double *yr);
 /**
@@ -542,7 +542,7 @@ EAPI void eina_matrix3_point_transform(const Eina_Matrix3 *m,
  *
  * @since 1.14
  */
-EAPI void eina_matrix3_rectangle_transform(const Eina_Matrix3 *m,
+EINA_API void eina_matrix3_rectangle_transform(const Eina_Matrix3 *m,
                                            const Eina_Rectangle *r,
                                            const Eina_Quad *q);
 
@@ -557,7 +557,7 @@ EAPI void eina_matrix3_rectangle_transform(const Eina_Matrix3 *m,
  * Calculates a matrix @p m that can be used to transform from an arbitrary
  * source quadrangle @p src to another arbitrary quadrangle @p dst.
  */
-EAPI Eina_Bool eina_matrix3_quad_quad_map(Eina_Matrix3 *m,
+EINA_API Eina_Bool eina_matrix3_quad_quad_map(Eina_Matrix3 *m,
                                           const Eina_Quad *src,
                                           const Eina_Quad *dst);
 
@@ -576,7 +576,7 @@ EAPI Eina_Bool eina_matrix3_quad_quad_map(Eina_Matrix3 *m,
  *
  * @since 1.14
  */
-EAPI Eina_Bool eina_matrix3_square_quad_map(Eina_Matrix3 *m,
+EINA_API Eina_Bool eina_matrix3_square_quad_map(Eina_Matrix3 *m,
                                             const Eina_Quad *q);
 
 /**
@@ -593,7 +593,7 @@ EAPI Eina_Bool eina_matrix3_square_quad_map(Eina_Matrix3 *m,
  *
  * @since 1.14
  */
-EAPI Eina_Bool eina_matrix3_quad_square_map(Eina_Matrix3 *m,
+EINA_API Eina_Bool eina_matrix3_quad_square_map(Eina_Matrix3 *m,
                                             const Eina_Quad *q);
 
 /**
@@ -608,7 +608,7 @@ EAPI Eina_Bool eina_matrix3_quad_square_map(Eina_Matrix3 *m,
  *
  * @since 1.17
  */
-EAPI void eina_matrix3_array_set(Eina_Matrix3 *m, const double *v);
+EINA_API void eina_matrix3_array_set(Eina_Matrix3 *m, const double *v);
 
 /**
  * @brief Copies a matrix.
@@ -618,7 +618,7 @@ EAPI void eina_matrix3_array_set(Eina_Matrix3 *m, const double *v);
  *
  * @since 1.16
  */
-EAPI void eina_matrix3_copy(Eina_Matrix3 *dst, const Eina_Matrix3 *src);
+EINA_API void eina_matrix3_copy(Eina_Matrix3 *dst, const Eina_Matrix3 *src);
 
 /**
  * @brief Multiplies two matrices.
@@ -633,7 +633,7 @@ EAPI void eina_matrix3_copy(Eina_Matrix3 *dst, const Eina_Matrix3 *src);
  *
  * @since 1.17
  */
-EAPI void eina_matrix3_multiply(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a,
+EINA_API void eina_matrix3_multiply(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a,
                                 const Eina_Matrix3 *mat_b);
 
 /**
@@ -649,7 +649,7 @@ EAPI void eina_matrix3_multiply(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a,
  *
  * @since 1.17
  */
-EAPI void eina_matrix3_multiply_copy(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a,
+EINA_API void eina_matrix3_multiply_copy(Eina_Matrix3 *out, const Eina_Matrix3 *mat_a,
                                      const Eina_Matrix3 *mat_b);
 
 /**
@@ -664,7 +664,7 @@ EAPI void eina_matrix3_multiply_copy(Eina_Matrix3 *out, const Eina_Matrix3 *mat_
  *
  * @since 1.17
  */
-EAPI void eina_matrix3_scale_transform_set(Eina_Matrix3 *out, double s_x, double s_y);
+EINA_API void eina_matrix3_scale_transform_set(Eina_Matrix3 *out, double s_x, double s_y);
 
 /**
  * @brief Sets the positional parameters (XZ, YZ) of a matrix.
@@ -678,7 +678,7 @@ EAPI void eina_matrix3_scale_transform_set(Eina_Matrix3 *out, double s_x, double
 
  * @since 1.17
  */
-EAPI void eina_matrix3_position_transform_set(Eina_Matrix3 *out, const double p_x,
+EINA_API void eina_matrix3_position_transform_set(Eina_Matrix3 *out, const double p_x,
                                               const double p_y);
 
 /**
@@ -689,7 +689,7 @@ EAPI void eina_matrix3_position_transform_set(Eina_Matrix3 *out, const double p_
  *
  * @since 1.17
  */
-EAPI void eina_normal3_matrix_get(Eina_Matrix3 *out, const Eina_Matrix4 *m);
+EINA_API void eina_normal3_matrix_get(Eina_Matrix3 *out, const Eina_Matrix4 *m);
 
 /**
  * @brief Converts an Eina_Matrix3 into an Eina_Matrix4.
@@ -699,7 +699,7 @@ EAPI void eina_normal3_matrix_get(Eina_Matrix3 *out, const Eina_Matrix4 *m);
  *
  * @since 1.15
  */
-EAPI void eina_matrix3_matrix4_to(Eina_Matrix4 *m4, const Eina_Matrix3 *m3);
+EINA_API void eina_matrix3_matrix4_to(Eina_Matrix4 *m4, const Eina_Matrix3 *m3);
 
 /**
  * @}
@@ -722,7 +722,7 @@ EAPI void eina_matrix3_matrix4_to(Eina_Matrix4 *m4, const Eina_Matrix3 *m3);
  *
  * @since 1.15
  */
-EAPI Eina_Matrix_Type eina_matrix4_type_get(const Eina_Matrix4 *m);
+EINA_API Eina_Matrix_Type eina_matrix4_type_get(const Eina_Matrix4 *m);
 
 /**
  * @brief Sets the values of the coefficients of the given floating
@@ -753,7 +753,7 @@ EAPI Eina_Matrix_Type eina_matrix4_type_get(const Eina_Matrix4 *m);
  *
  * @since 1.15
  */
-EAPI void eina_matrix4_values_set(Eina_Matrix4 *m,
+EINA_API void eina_matrix4_values_set(Eina_Matrix4 *m,
                                   double xx, double xy, double xz, double xw,
                                   double yx, double yy, double yz, double yw,
                                   double zx, double zy, double zz, double zw,
@@ -788,7 +788,7 @@ EAPI void eina_matrix4_values_set(Eina_Matrix4 *m,
  *
  * @since 1.15
  */
-EAPI void eina_matrix4_values_get(const Eina_Matrix4 *m,
+EINA_API void eina_matrix4_values_get(const Eina_Matrix4 *m,
                                   double *xx, double *xy, double *xz, double *xw,
                                   double *yx, double *yy, double *yz, double *yw,
                                   double *zx, double *zy, double *zz, double *zw,
@@ -805,7 +805,7 @@ EAPI void eina_matrix4_values_get(const Eina_Matrix4 *m,
  *
  * @since 1.16
  */
-EAPI double eina_matrix4_determinant(const Eina_Matrix4 *m);
+EINA_API double eina_matrix4_determinant(const Eina_Matrix4 *m);
 
 /**
  * @brief Normalizes the given matrix.
@@ -820,7 +820,7 @@ EAPI double eina_matrix4_determinant(const Eina_Matrix4 *m);
  *
  * @since 1.16
  */
-EAPI Eina_Bool eina_matrix4_normalized(Eina_Matrix4 *out,
+EINA_API Eina_Bool eina_matrix4_normalized(Eina_Matrix4 *out,
                                        const Eina_Matrix4 *in);
 
 /**
@@ -836,7 +836,7 @@ EAPI Eina_Bool eina_matrix4_normalized(Eina_Matrix4 *out,
  *
  * @since 1.16
  */
-EAPI Eina_Bool eina_matrix4_inverse(Eina_Matrix4 *out, const Eina_Matrix4 *in);
+EINA_API Eina_Bool eina_matrix4_inverse(Eina_Matrix4 *out, const Eina_Matrix4 *in);
 
 /**
  * @brief Computes the transpose of the given matrix.
@@ -850,7 +850,7 @@ EAPI Eina_Bool eina_matrix4_inverse(Eina_Matrix4 *out, const Eina_Matrix4 *in);
  *
  * @since 1.16
  */
-EAPI void eina_matrix4_transpose(Eina_Matrix4 *out, const Eina_Matrix4 *in);
+EINA_API void eina_matrix4_transpose(Eina_Matrix4 *out, const Eina_Matrix4 *in);
 
 /**
  * @brief Converts an Eina_Matrix4 into an Eina_Matrix3.
@@ -860,7 +860,7 @@ EAPI void eina_matrix4_transpose(Eina_Matrix4 *out, const Eina_Matrix4 *in);
  *
  * @since 1.15
  */
-EAPI void eina_matrix4_matrix3_to(Eina_Matrix3 *m3, const Eina_Matrix4 *m4);
+EINA_API void eina_matrix4_matrix3_to(Eina_Matrix3 *m3, const Eina_Matrix4 *m4);
 
 /**
  * @brief Sets the given matrix to identity.
@@ -869,7 +869,7 @@ EAPI void eina_matrix4_matrix3_to(Eina_Matrix3 *m3, const Eina_Matrix4 *m4);
  *
  * @since 1.16
  */
-EAPI void eina_matrix4_identity(Eina_Matrix4 *out);
+EINA_API void eina_matrix4_identity(Eina_Matrix4 *out);
 
 /**
  * @brief Multiplies two matrix.
@@ -884,7 +884,7 @@ EAPI void eina_matrix4_identity(Eina_Matrix4 *out);
  *
  * @since 1.17
  */
-EAPI void eina_matrix4_multiply_copy(Eina_Matrix4 *out,
+EINA_API void eina_matrix4_multiply_copy(Eina_Matrix4 *out,
                                      const Eina_Matrix4 *mat_a, const Eina_Matrix4 *mat_b);
 
 /**
@@ -899,7 +899,7 @@ EAPI void eina_matrix4_multiply_copy(Eina_Matrix4 *out,
  *
  * @since 1.17
  */
-EAPI void eina_matrix4_array_set(Eina_Matrix4 *m, const double *v);
+EINA_API void eina_matrix4_array_set(Eina_Matrix4 *m, const double *v);
 
 /**
  * @brief Copies matrix.
@@ -909,7 +909,7 @@ EAPI void eina_matrix4_array_set(Eina_Matrix4 *m, const double *v);
  *
  * @since 1.17
  */
-EAPI void eina_matrix4_copy(Eina_Matrix4 *dst, const Eina_Matrix4 *src);
+EINA_API void eina_matrix4_copy(Eina_Matrix4 *dst, const Eina_Matrix4 *src);
 
 /**
  * @brief Multiplies two matrices with check.
@@ -920,7 +920,7 @@ EAPI void eina_matrix4_copy(Eina_Matrix4 *dst, const Eina_Matrix4 *src);
  *
  * @since 1.17
  */
-EAPI void eina_matrix4_multiply(Eina_Matrix4 *out, const Eina_Matrix4 *mat_a,
+EINA_API void eina_matrix4_multiply(Eina_Matrix4 *out, const Eina_Matrix4 *mat_a,
                                 const Eina_Matrix4 *mat_b);
 
 /**
@@ -936,7 +936,7 @@ EAPI void eina_matrix4_multiply(Eina_Matrix4 *out, const Eina_Matrix4 *mat_a,
  *
  * @since 1.17
  */
-EAPI void eina_matrix4_ortho_set(Eina_Matrix4 *m,
+EINA_API void eina_matrix4_ortho_set(Eina_Matrix4 *m,
                                  double left, double right, double bottom, double top,
                                  double dnear, double dfar);
 
@@ -955,7 +955,7 @@ EAPI void eina_matrix4_ortho_set(Eina_Matrix4 *m,
  *
  * @since 1.24
  */
-EAPI void eina_matrix4_compose(const Eina_Matrix4 *mat_a,
+EINA_API void eina_matrix4_compose(const Eina_Matrix4 *mat_a,
                                const Eina_Matrix4 *mat_b,
                                Eina_Matrix4 *out);
 
@@ -969,7 +969,7 @@ EAPI void eina_matrix4_compose(const Eina_Matrix4 *mat_a,
  *
  * @since 1.24
  */
-EAPI void eina_matrix4_translate(Eina_Matrix4 *t, double tx, double ty, double tz);
+EINA_API void eina_matrix4_translate(Eina_Matrix4 *t, double tx, double ty, double tz);
 
 /**
  * @brief Sets the matrix values for a scaling operation.
@@ -981,7 +981,7 @@ EAPI void eina_matrix4_translate(Eina_Matrix4 *t, double tx, double ty, double t
  *
  * @since 1.24
  */
-EAPI void eina_matrix4_scale(Eina_Matrix4 *t, double sx, double sy, double sz);
+EINA_API void eina_matrix4_scale(Eina_Matrix4 *t, double sx, double sy, double sz);
 
 /**
  * @brief Sets the matrix values for a rotation operation.
@@ -991,7 +991,7 @@ EAPI void eina_matrix4_scale(Eina_Matrix4 *t, double sx, double sy, double sz);
  *
  * @since 1.24
  */
-EAPI void eina_matrix4_rotate(Eina_Matrix4 *t, double rad, Eina_Matrix_Axis axis);
+EINA_API void eina_matrix4_rotate(Eina_Matrix4 *t, double rad, Eina_Matrix_Axis axis);
 
 /**
  * @}
@@ -1041,7 +1041,7 @@ struct _Eina_Matrix2
  *
  * @since 1.17
  */
-EAPI void eina_matrix2_values_set(Eina_Matrix2 *m, double xx, double xy,
+EINA_API void eina_matrix2_values_set(Eina_Matrix2 *m, double xx, double xy,
                     double yx, double yy);
 
 /**
@@ -1061,7 +1061,7 @@ EAPI void eina_matrix2_values_set(Eina_Matrix2 *m, double xx, double xy,
  *
  * @since 1.17
  */
-EAPI void eina_matrix2_values_get(const Eina_Matrix2 *m, double *xx, double *xy,
+EINA_API void eina_matrix2_values_get(const Eina_Matrix2 *m, double *xx, double *xy,
                     double *yx, double *yy);
 
 /**
@@ -1076,7 +1076,7 @@ EAPI void eina_matrix2_values_get(const Eina_Matrix2 *m, double *xx, double *xy,
  *
  * @since 1.17
  */
-EAPI void eina_matrix2_inverse(Eina_Matrix2 *out, const Eina_Matrix2 *mat);
+EINA_API void eina_matrix2_inverse(Eina_Matrix2 *out, const Eina_Matrix2 *mat);
 
 /**
  * @brief Sets the given floating point matrix to the identity matrix.
@@ -1088,7 +1088,7 @@ EAPI void eina_matrix2_inverse(Eina_Matrix2 *out, const Eina_Matrix2 *mat);
  *
  * @since 1.17
  */
-EAPI void eina_matrix2_identity(Eina_Matrix2 *m);
+EINA_API void eina_matrix2_identity(Eina_Matrix2 *m);
 
 /**
  * @brief Sets array to matrix.
@@ -1100,7 +1100,7 @@ EAPI void eina_matrix2_identity(Eina_Matrix2 *m);
  *
  * @since 1.17
  */
-EAPI void eina_matrix2_array_set(Eina_Matrix2 *m, const double *v);
+EINA_API void eina_matrix2_array_set(Eina_Matrix2 *m, const double *v);
 
 /**
  * @brief Copies matrix.
@@ -1110,7 +1110,7 @@ EAPI void eina_matrix2_array_set(Eina_Matrix2 *m, const double *v);
  *
  * @since 1.17
  */
-EAPI void eina_matrix2_copy(Eina_Matrix2 *dst, const Eina_Matrix2 *src);
+EINA_API void eina_matrix2_copy(Eina_Matrix2 *dst, const Eina_Matrix2 *src);
 
 /**
  * @brief Multiplies two matrices.
@@ -1121,7 +1121,7 @@ EAPI void eina_matrix2_copy(Eina_Matrix2 *dst, const Eina_Matrix2 *src);
  *
  * @since 1.17
  */
-EAPI void eina_matrix2_multiply(Eina_Matrix2 *out, const Eina_Matrix2 *mat_a,
+EINA_API void eina_matrix2_multiply(Eina_Matrix2 *out, const Eina_Matrix2 *mat_a,
                                 const Eina_Matrix2 *mat_b);
 
 /**
@@ -1133,7 +1133,7 @@ EAPI void eina_matrix2_multiply(Eina_Matrix2 *out, const Eina_Matrix2 *mat_a,
  *
  * @since 1.17
  */
-EAPI void eina_matrix2_multiply_copy(Eina_Matrix2 *out, const Eina_Matrix2 *mat_a,
+EINA_API void eina_matrix2_multiply_copy(Eina_Matrix2 *out, const Eina_Matrix2 *mat_a,
                     const Eina_Matrix2 *mat_b);
 
 /**
@@ -1147,7 +1147,7 @@ EAPI void eina_matrix2_multiply_copy(Eina_Matrix2 *out, const Eina_Matrix2 *mat_
  *
  * @since 1.17
  */
-EAPI Eina_Matrix_Type eina_matrix2_type_get(const Eina_Matrix2 *m);
+EINA_API Eina_Matrix_Type eina_matrix2_type_get(const Eina_Matrix2 *m);
 
 /**
  * @}

--- a/src/lib/eina/eina_matrixsparse.c
+++ b/src/lib/eina/eina_matrixsparse.c
@@ -927,7 +927,7 @@ eina_matrixsparse_shutdown(void)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Matrixsparse *
+EINA_API Eina_Matrixsparse *
 eina_matrixsparse_new(unsigned long rows, unsigned long cols, void (*free_func)(
                          void *user_data,
                          void *cell_data), const void *user_data)
@@ -954,7 +954,7 @@ eina_matrixsparse_new(unsigned long rows, unsigned long cols, void (*free_func)(
    return m;
 }
 
-EAPI void
+EINA_API void
 eina_matrixsparse_free(Eina_Matrixsparse *m)
 {
    void (*free_func)(void *, void *);
@@ -982,7 +982,7 @@ eina_matrixsparse_free(Eina_Matrixsparse *m)
    free(m);
 }
 
-EAPI void
+EINA_API void
 eina_matrixsparse_size_get(const Eina_Matrixsparse *m,
                            unsigned long *rows,
                            unsigned long *cols)
@@ -1001,7 +1001,7 @@ eina_matrixsparse_size_get(const Eina_Matrixsparse *m,
       *cols = m->size.cols;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_size_set(Eina_Matrixsparse *m,
                            unsigned long rows,
                            unsigned long cols)
@@ -1107,7 +1107,7 @@ eina_matrixsparse_size_set(Eina_Matrixsparse *m,
    return 1;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_cell_idx_get(const Eina_Matrixsparse *m,
                                unsigned long row,
                                unsigned long col,
@@ -1122,14 +1122,14 @@ eina_matrixsparse_cell_idx_get(const Eina_Matrixsparse *m,
    return 1;
 }
 
-EAPI void *
+EINA_API void *
 eina_matrixsparse_cell_data_get(const Eina_Matrixsparse_Cell *cell)
 {
    EINA_MAGIC_CHECK_MATRIXSPARSE_CELL(cell, NULL);
    return cell->data;
 }
 
-EAPI void *
+EINA_API void *
 eina_matrixsparse_data_idx_get(const Eina_Matrixsparse *m,
                                unsigned long row,
                                unsigned long col)
@@ -1143,7 +1143,7 @@ eina_matrixsparse_data_idx_get(const Eina_Matrixsparse *m,
       return NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_cell_position_get(const Eina_Matrixsparse_Cell *cell,
                                     unsigned long *row,
                                     unsigned long *col)
@@ -1165,7 +1165,7 @@ eina_matrixsparse_cell_position_get(const Eina_Matrixsparse_Cell *cell,
    return 1;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_cell_data_replace(Eina_Matrixsparse_Cell *cell,
                                     const void *data,
                                     void **p_old)
@@ -1182,7 +1182,7 @@ eina_matrixsparse_cell_data_replace(Eina_Matrixsparse_Cell *cell,
    return 1;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_cell_data_set(Eina_Matrixsparse_Cell *cell, const void *data)
 {
    Eina_Matrixsparse *m;
@@ -1200,7 +1200,7 @@ eina_matrixsparse_cell_data_set(Eina_Matrixsparse_Cell *cell, const void *data)
    return 1;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_data_idx_replace(Eina_Matrixsparse *m,
                                    unsigned long row,
                                    unsigned long col,
@@ -1229,7 +1229,7 @@ eina_matrixsparse_data_idx_replace(Eina_Matrixsparse *m,
    return _eina_matrixsparse_cell_idx_add(m, row, col, data);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_data_idx_set(Eina_Matrixsparse *m,
                                unsigned long row,
                                unsigned long col,
@@ -1254,7 +1254,7 @@ eina_matrixsparse_data_idx_set(Eina_Matrixsparse *m,
    return _eina_matrixsparse_cell_idx_add(m, row, col, data);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_row_idx_clear(Eina_Matrixsparse *m, unsigned long row)
 {
    Eina_Matrixsparse_Row *r;
@@ -1272,7 +1272,7 @@ eina_matrixsparse_row_idx_clear(Eina_Matrixsparse *m, unsigned long row)
    return 1;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_column_idx_clear(Eina_Matrixsparse *m, unsigned long col)
 {
    Eina_Matrixsparse_Row *r;
@@ -1311,7 +1311,7 @@ eina_matrixsparse_column_idx_clear(Eina_Matrixsparse *m, unsigned long col)
    return 1;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_cell_idx_clear(Eina_Matrixsparse *m,
                                  unsigned long row,
                                  unsigned long col)
@@ -1332,7 +1332,7 @@ eina_matrixsparse_cell_idx_clear(Eina_Matrixsparse *m,
    return 1;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrixsparse_cell_clear(Eina_Matrixsparse_Cell *cell)
 {
    Eina_Matrixsparse *m;
@@ -1348,7 +1348,7 @@ eina_matrixsparse_cell_clear(Eina_Matrixsparse_Cell *cell)
    return 1;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_matrixsparse_iterator_new(const Eina_Matrixsparse *m)
 {
    Eina_Matrixsparse_Iterator *it;
@@ -1371,7 +1371,7 @@ eina_matrixsparse_iterator_new(const Eina_Matrixsparse *m)
    return &it->iterator;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_matrixsparse_iterator_complete_new(const Eina_Matrixsparse *m)
 {
    Eina_Matrixsparse_Iterator_Complete *it;

--- a/src/lib/eina/eina_matrixsparse.h
+++ b/src/lib/eina/eina_matrixsparse.h
@@ -95,7 +95,7 @@ typedef struct _Eina_Matrixsparse_Cell      Eina_Matrixsparse_Cell;
  *
  * @return Newly allocated matrix, or @c NULL if allocation failed.
  */
-EAPI Eina_Matrixsparse *eina_matrixsparse_new(unsigned long rows,
+EINA_API Eina_Matrixsparse *eina_matrixsparse_new(unsigned long rows,
                                               unsigned long cols,
                                               void (*free_func)(void *user_data,
                                                                 void *cell_data),
@@ -106,7 +106,7 @@ EAPI Eina_Matrixsparse *eina_matrixsparse_new(unsigned long rows,
  *
  * @param[in] m The Sparse Matrix instance to free; must @b not be @c NULL.
  */
-EAPI void eina_matrixsparse_free(Eina_Matrixsparse *m);
+EINA_API void eina_matrixsparse_free(Eina_Matrixsparse *m);
 
 /* size manipulation */
 
@@ -123,7 +123,7 @@ EAPI void eina_matrixsparse_free(Eina_Matrixsparse *m);
  * @param[out] cols Returns the number of columns; may be @c NULL. If @a m is
  *        invalid, returned value is zero, otherwise it's a positive integer.
  */
-EAPI void eina_matrixsparse_size_get(const Eina_Matrixsparse *m,
+EINA_API void eina_matrixsparse_size_get(const Eina_Matrixsparse *m,
                                      unsigned long           *rows,
                                      unsigned long           *cols);
 
@@ -141,7 +141,7 @@ EAPI void eina_matrixsparse_size_get(const Eina_Matrixsparse *m,
  * @warning Cells, rows or columns are not reference counted and thus
  *     references to freed instances may become invalid.
  */
-EAPI Eina_Bool eina_matrixsparse_size_set(Eina_Matrixsparse *m,
+EINA_API Eina_Bool eina_matrixsparse_size_set(Eina_Matrixsparse *m,
                                           unsigned long      rows,
                                           unsigned long      cols);
 
@@ -161,7 +161,7 @@ EAPI Eina_Bool eina_matrixsparse_size_set(Eina_Matrixsparse *m,
  * @see eina_matrixsparse_cell_data_get()
  * @see eina_matrixsparse_data_idx_get()
  */
-EAPI Eina_Bool eina_matrixsparse_cell_idx_get(const Eina_Matrixsparse *m, unsigned long row, unsigned long col, Eina_Matrixsparse_Cell **cell);
+EINA_API Eina_Bool eina_matrixsparse_cell_idx_get(const Eina_Matrixsparse *m, unsigned long row, unsigned long col, Eina_Matrixsparse_Cell **cell);
 
 /**
  * @brief Gets data associated with given cell reference.
@@ -173,7 +173,7 @@ EAPI Eina_Bool eina_matrixsparse_cell_idx_get(const Eina_Matrixsparse *m, unsign
  * @see eina_matrixsparse_cell_idx_get()
  * @see eina_matrixsparse_data_idx_get()
  */
-EAPI void     *eina_matrixsparse_cell_data_get(const Eina_Matrixsparse_Cell *cell);
+EINA_API void     *eina_matrixsparse_cell_data_get(const Eina_Matrixsparse_Cell *cell);
 
 /**
  * @brief Gets data associated with given cell given its indexes.
@@ -187,7 +187,7 @@ EAPI void     *eina_matrixsparse_cell_data_get(const Eina_Matrixsparse_Cell *cel
  * @see eina_matrixsparse_cell_idx_get()
  * @see eina_matrixsparse_cell_data_get()
  */
-EAPI void     *eina_matrixsparse_data_idx_get(const Eina_Matrixsparse *m, unsigned long row, unsigned long col);
+EINA_API void     *eina_matrixsparse_data_idx_get(const Eina_Matrixsparse *m, unsigned long row, unsigned long col);
 
 /**
  * @brief Gets the row and column position of the given cell.
@@ -198,7 +198,7 @@ EAPI void     *eina_matrixsparse_data_idx_get(const Eina_Matrixsparse *m, unsign
  *
  * @return #EINA_TRUE on success, #EINA_FALSE otherwise (@c cell is @c NULL).
  */
-EAPI Eina_Bool eina_matrixsparse_cell_position_get(const Eina_Matrixsparse_Cell *cell, unsigned long *row, unsigned long *col);
+EINA_API Eina_Bool eina_matrixsparse_cell_position_get(const Eina_Matrixsparse_Cell *cell, unsigned long *row, unsigned long *col);
 
 
 /* Data setting */
@@ -215,7 +215,7 @@ EAPI Eina_Bool eina_matrixsparse_cell_position_get(const Eina_Matrixsparse_Cell 
  * @see eina_matrixsparse_cell_data_set()
  * @see eina_matrixsparse_data_idx_replace()
  */
-EAPI Eina_Bool eina_matrixsparse_cell_data_replace(Eina_Matrixsparse_Cell *cell, const void *data, void **p_old);
+EINA_API Eina_Bool eina_matrixsparse_cell_data_replace(Eina_Matrixsparse_Cell *cell, const void *data, void **p_old);
 
 /**
  * @brief Changes cell value, freeing any previously existing value.
@@ -231,7 +231,7 @@ EAPI Eina_Bool eina_matrixsparse_cell_data_replace(Eina_Matrixsparse_Cell *cell,
  * @see eina_matrixsparse_cell_data_replace()
  * @see eina_matrixsparse_data_idx_set()
  */
-EAPI Eina_Bool eina_matrixsparse_cell_data_set(Eina_Matrixsparse_Cell *cell, const void *data);
+EINA_API Eina_Bool eina_matrixsparse_cell_data_set(Eina_Matrixsparse_Cell *cell, const void *data);
 
 /**
  * @brief Changes cell value at a given row and column position, without
@@ -249,7 +249,7 @@ EAPI Eina_Bool eina_matrixsparse_cell_data_set(Eina_Matrixsparse_Cell *cell, con
  * @see eina_matrixsparse_cell_data_replace()
  * @see eina_matrixsparse_data_idx_set()
  */
-EAPI Eina_Bool eina_matrixsparse_data_idx_replace(Eina_Matrixsparse *m, unsigned long row, unsigned long col, const void *data, void **p_old);
+EINA_API Eina_Bool eina_matrixsparse_data_idx_replace(Eina_Matrixsparse *m, unsigned long row, unsigned long col, const void *data, void **p_old);
 
 /**
  * @brief Changes cell value at a given row and column position, freeing
@@ -267,7 +267,7 @@ EAPI Eina_Bool eina_matrixsparse_data_idx_replace(Eina_Matrixsparse *m, unsigned
  *
  * @see eina_matrixsparse_cell_data_replace()
  */
-EAPI Eina_Bool eina_matrixsparse_data_idx_set(Eina_Matrixsparse *m, unsigned long row, unsigned long col, const void *data);
+EINA_API Eina_Bool eina_matrixsparse_data_idx_set(Eina_Matrixsparse *m, unsigned long row, unsigned long col, const void *data);
 
 /* data deleting */
 
@@ -287,7 +287,7 @@ EAPI Eina_Bool eina_matrixsparse_data_idx_set(Eina_Matrixsparse *m, unsigned lon
  * @warning Cells, rows or columns are not reference counted and thus
  *     references to freed instances may become invalid.
  */
-EAPI Eina_Bool eina_matrixsparse_row_idx_clear(Eina_Matrixsparse *m, unsigned long row);
+EINA_API Eina_Bool eina_matrixsparse_row_idx_clear(Eina_Matrixsparse *m, unsigned long row);
 
 /**
  * @brief Clears (erases all cells) of column given its index.
@@ -305,7 +305,7 @@ EAPI Eina_Bool eina_matrixsparse_row_idx_clear(Eina_Matrixsparse *m, unsigned lo
  * @warning Cells, rows or columns are not reference counted and thus
  *     references to freed instances may become invalid.
  */
-EAPI Eina_Bool eina_matrixsparse_column_idx_clear(Eina_Matrixsparse *m, unsigned long col);
+EINA_API Eina_Bool eina_matrixsparse_column_idx_clear(Eina_Matrixsparse *m, unsigned long col);
 
 /**
  * @brief Clears (erases) cell at a given row, column position.
@@ -328,7 +328,7 @@ EAPI Eina_Bool eina_matrixsparse_column_idx_clear(Eina_Matrixsparse *m, unsigned
  * @note This call might also free the column and/or row if this was the
  * last remaining cell contained.
  */
-EAPI Eina_Bool eina_matrixsparse_cell_idx_clear(Eina_Matrixsparse *m, unsigned long row, unsigned long col);
+EINA_API Eina_Bool eina_matrixsparse_cell_idx_clear(Eina_Matrixsparse *m, unsigned long row, unsigned long col);
 
 /**
  * @brief Clears (erases) cell given its reference.
@@ -343,7 +343,7 @@ EAPI Eina_Bool eina_matrixsparse_cell_idx_clear(Eina_Matrixsparse *m, unsigned l
  * @note This call might also free the column and/or row if this was the
  * last remaining cell contained.
  */
-EAPI Eina_Bool eina_matrixsparse_cell_clear(Eina_Matrixsparse_Cell *cell);
+EINA_API Eina_Bool eina_matrixsparse_cell_clear(Eina_Matrixsparse_Cell *cell);
 
 /* Iterators */
 
@@ -366,7 +366,7 @@ EAPI Eina_Bool eina_matrixsparse_cell_clear(Eina_Matrixsparse_Cell *cell);
  *    invalid! That is, if you add or remove cells this iterator
  *    behavior is undefined and your program may crash!
  */
-EAPI Eina_Iterator *eina_matrixsparse_iterator_new(const Eina_Matrixsparse *m);
+EINA_API Eina_Iterator *eina_matrixsparse_iterator_new(const Eina_Matrixsparse *m);
 
 /**
  * @brief Creates a new iterator over all matrix cells.
@@ -394,7 +394,7 @@ EAPI Eina_Iterator *eina_matrixsparse_iterator_new(const Eina_Matrixsparse *m);
  *    invalid! That is, if you add or remove cells this iterator
  *    behavior is undefined and your program may crash!
  */
-EAPI Eina_Iterator *eina_matrixsparse_iterator_complete_new(const Eina_Matrixsparse *m);
+EINA_API Eina_Iterator *eina_matrixsparse_iterator_complete_new(const Eina_Matrixsparse *m);
 
 /**
  * @}

--- a/src/lib/eina/eina_mempool.c
+++ b/src/lib/eina/eina_mempool.c
@@ -148,13 +148,13 @@ void      pass_through_shutdown(void);
  * @cond LOCAL
  */
 
-EAPI Eina_Error EINA_ERROR_NOT_MEMPOOL_MODULE = 0;
+EINA_API Eina_Error EINA_ERROR_NOT_MEMPOOL_MODULE = 0;
 
 /**
  * @endcond
  */
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_mempool_register(Eina_Mempool_Backend *be)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(be, 0);
@@ -162,7 +162,7 @@ eina_mempool_register(Eina_Mempool_Backend *be)
    return eina_hash_add(_backends, be->name, be);
 }
 
-EAPI void
+EINA_API void
 eina_mempool_unregister(Eina_Mempool_Backend *be)
 {
    EINA_SAFETY_ON_NULL_RETURN(be);
@@ -259,7 +259,7 @@ eina_mempool_shutdown(void)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Mempool *
+EINA_API Eina_Mempool *
 eina_mempool_add(const char *name,
                  const char *context,
                  const char *options,
@@ -282,7 +282,7 @@ eina_mempool_add(const char *name,
    return mp;
 }
 
-EAPI void eina_mempool_del(Eina_Mempool *mp)
+EINA_API void eina_mempool_del(Eina_Mempool *mp)
 {
    EINA_SAFETY_ON_NULL_RETURN(mp);
    EINA_SAFETY_ON_NULL_RETURN(mp->backend.shutdown);
@@ -292,7 +292,7 @@ EAPI void eina_mempool_del(Eina_Mempool *mp)
    free(mp);
 }
 
-EAPI void eina_mempool_repack(Eina_Mempool *mp, Eina_Mempool_Repack_Cb cb, void *data)
+EINA_API void eina_mempool_repack(Eina_Mempool *mp, Eina_Mempool_Repack_Cb cb, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(mp);
    EINA_SAFETY_ON_NULL_RETURN(mp->backend2);
@@ -301,7 +301,7 @@ EAPI void eina_mempool_repack(Eina_Mempool *mp, Eina_Mempool_Repack_Cb cb, void 
    mp->backend2->repack(mp->backend_data, cb, data);
 }
 
-EAPI void eina_mempool_gc(Eina_Mempool *mp)
+EINA_API void eina_mempool_gc(Eina_Mempool *mp)
 {
    EINA_SAFETY_ON_NULL_RETURN(mp);
    EINA_SAFETY_ON_NULL_RETURN(mp->backend.garbage_collect);
@@ -309,7 +309,7 @@ EAPI void eina_mempool_gc(Eina_Mempool *mp)
    mp->backend.garbage_collect(mp->backend_data);
 }
 
-EAPI void eina_mempool_statistics(Eina_Mempool *mp)
+EINA_API void eina_mempool_statistics(Eina_Mempool *mp)
 {
    EINA_SAFETY_ON_NULL_RETURN(mp);
    EINA_SAFETY_ON_NULL_RETURN(mp->backend.statistics);

--- a/src/lib/eina/eina_mempool.h
+++ b/src/lib/eina/eina_mempool.h
@@ -73,7 +73,7 @@ typedef struct _Eina_Mempool_Backend Eina_Mempool_Backend;
  */
 typedef void (*Eina_Mempool_Repack_Cb)(void *dst, void *src, void *data);
 
-EAPI extern Eina_Error EINA_ERROR_NOT_MEMPOOL_MODULE;
+EINA_API extern Eina_Error EINA_ERROR_NOT_MEMPOOL_MODULE;
 
 /**
  * @brief Creates a new mempool of the given type
@@ -84,14 +84,14 @@ EAPI extern Eina_Error EINA_ERROR_NOT_MEMPOOL_MODULE;
  * @param[in] ... Additional options to pass to the allocator; depends entirely on the type of mempool ("int pool size" for chained and "int item_size" for one_big.
  * @return Newly allocated mempool instance, NULL otherwise.
  */
-EAPI Eina_Mempool  *eina_mempool_add(const char *name, const char *context, const char *options, ...) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Mempool  *eina_mempool_add(const char *name, const char *context, const char *options, ...) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Deletes the given mempool.
  *
  * @param[in] mp The mempool to delete
  */
-EAPI void           eina_mempool_del(Eina_Mempool *mp) EINA_ARG_NONNULL(1);
+EINA_API void           eina_mempool_del(Eina_Mempool *mp) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Re-allocates an amount memory by the given mempool.
@@ -192,14 +192,14 @@ static inline void  eina_mempool_free(Eina_Mempool *mp, void *element) EINA_ARG_
  * @see Eina_Mempool_Repack_Cb
  * @see _Eina_Mempool_Backend
  */
-EAPI void           eina_mempool_repack(Eina_Mempool *mp, Eina_Mempool_Repack_Cb cb, void *data) EINA_ARG_NONNULL(1, 2);
+EINA_API void           eina_mempool_repack(Eina_Mempool *mp, Eina_Mempool_Repack_Cb cb, void *data) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Runs a garbage collection cycle.
  *
  * @param[in] mp The mempool
  */
-EAPI void           eina_mempool_gc(Eina_Mempool *mp) EINA_ARG_NONNULL(1);
+EINA_API void           eina_mempool_gc(Eina_Mempool *mp) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Check if a pointer is a valid element from the mempool
@@ -218,7 +218,7 @@ static inline Eina_Bool eina_mempool_from(Eina_Mempool *mp, void *element);
  * @param[in] mp The mempool
  *
  */
-EAPI void           eina_mempool_statistics(Eina_Mempool *mp) EINA_ARG_NONNULL(1);
+EINA_API void           eina_mempool_statistics(Eina_Mempool *mp) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Provide an iterator to walk all allocated elements from a specified mempool.
@@ -238,14 +238,14 @@ static inline Eina_Iterator *eina_mempool_iterator_new(Eina_Mempool *mp);
  * @return #EINA_TRUE if backend has been correctly registered, #EINA_FALSE
  *         otherwise.
  */
-EAPI Eina_Bool      eina_mempool_register(Eina_Mempool_Backend *be) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool      eina_mempool_register(Eina_Mempool_Backend *be) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Unregisters the given memory pool backend.
  *
  * @param[in] be The backend
  */
-EAPI void           eina_mempool_unregister(Eina_Mempool_Backend *be) EINA_ARG_NONNULL(1);
+EINA_API void           eina_mempool_unregister(Eina_Mempool_Backend *be) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Computes the alignment that would be used when allocating a object of size @p size.

--- a/src/lib/eina/eina_mmap.c
+++ b/src/lib/eina/eina_mmap.c
@@ -167,7 +167,7 @@ _eina_mmap_safe_sigbus(int sig, siginfo_t *siginfo, void *ptr)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_mmap_safety_enabled_set(Eina_Bool enabled)
 {
 #ifndef HAVE_SIGINFO_T
@@ -235,7 +235,7 @@ done:
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_mmap_safety_enabled_get(void)
 {
    return mmap_safe;

--- a/src/lib/eina/eina_mmap.h
+++ b/src/lib/eina/eina_mmap.h
@@ -39,7 +39,7 @@
  *
  * @since 1.1.0
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_mmap_safety_enabled_set(Eina_Bool enabled);
 
 /**
@@ -52,7 +52,7 @@ eina_mmap_safety_enabled_set(Eina_Bool enabled);
  *
  * @since 1.1.0
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_mmap_safety_enabled_get(void);
 
 /**

--- a/src/lib/eina/eina_module.c
+++ b/src/lib/eina/eina_module.c
@@ -183,8 +183,8 @@ static void _dir_arch_list_cb(const char *name, const char *path, void *data)
  * @cond LOCAL
  */
 
-EAPI Eina_Error EINA_ERROR_WRONG_MODULE = 0;
-EAPI Eina_Error EINA_ERROR_MODULE_INIT_FAILED = 0;
+EINA_API Eina_Error EINA_ERROR_WRONG_MODULE = 0;
+EINA_API Eina_Error EINA_ERROR_MODULE_INIT_FAILED = 0;
 
 /**
  * @endcond
@@ -243,7 +243,7 @@ eina_module_shutdown(void)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Module *eina_module_new(const char *file)
+EINA_API Eina_Module *eina_module_new(const char *file)
 {
    Eina_Module *m;
    size_t len;
@@ -286,7 +286,7 @@ EAPI Eina_Module *eina_module_new(const char *file)
    return m;
 }
 
-EAPI Eina_Bool eina_module_free(Eina_Module *m)
+EINA_API Eina_Bool eina_module_free(Eina_Module *m)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(m, EINA_FALSE);
 
@@ -300,7 +300,7 @@ EAPI Eina_Bool eina_module_free(Eina_Module *m)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool eina_module_load(Eina_Module *m)
+EINA_API Eina_Bool eina_module_load(Eina_Module *m)
 {
 #ifdef HAVE_DLOPEN
    void *dl_handle;
@@ -355,7 +355,7 @@ loaded:
 #endif
 }
 
-EAPI Eina_Bool eina_module_unload(Eina_Module *m)
+EINA_API Eina_Bool eina_module_unload(Eina_Module *m)
 {
 #ifdef HAVE_DLOPEN
    Eina_Module_Shutdown *shut;
@@ -383,7 +383,7 @@ EAPI Eina_Bool eina_module_unload(Eina_Module *m)
 #endif
 }
 
-EAPI void *eina_module_symbol_get(const Eina_Module *m, const char *symbol)
+EINA_API void *eina_module_symbol_get(const Eina_Module *m, const char *symbol)
 {
 #ifdef HAVE_DLOPEN
    EINA_SAFETY_ON_NULL_RETURN_VAL(m,         NULL);
@@ -396,19 +396,19 @@ EAPI void *eina_module_symbol_get(const Eina_Module *m, const char *symbol)
 #endif
 }
 
-EAPI const char *eina_module_file_get(const Eina_Module *m)
+EINA_API const char *eina_module_file_get(const Eina_Module *m)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(m, NULL);
    return m->file;
 }
 
-EAPI void eina_module_symbol_global_set(Eina_Module *module, Eina_Bool global)
+EINA_API void eina_module_symbol_global_set(Eina_Module *module, Eina_Bool global)
 {
    EINA_SAFETY_ON_NULL_RETURN(module);
    module->global = !!global;
 }
 
-EAPI char *eina_module_symbol_path_get(const void *symbol, const char *sub_dir)
+EINA_API char *eina_module_symbol_path_get(const void *symbol, const char *sub_dir)
 {
 #ifdef HAVE_DLADDR
    Dl_info eina_dl;
@@ -450,7 +450,7 @@ EAPI char *eina_module_symbol_path_get(const void *symbol, const char *sub_dir)
    return NULL;
 }
 
-EAPI char *eina_module_environment_path_get(const char *env,
+EINA_API char *eina_module_environment_path_get(const char *env,
                                             const char *sub_dir)
 {
    const char *env_dir;
@@ -486,7 +486,7 @@ EAPI char *eina_module_environment_path_get(const char *env,
    return NULL;
 }
 
-EAPI Eina_Array *eina_module_arch_list_get(Eina_Array *array,
+EINA_API Eina_Array *eina_module_arch_list_get(Eina_Array *array,
                                            const char *path,
                                            const char *arch)
 {
@@ -504,7 +504,7 @@ EAPI Eina_Array *eina_module_arch_list_get(Eina_Array *array,
    return list_get_cb_data.array;
 }
 
-EAPI Eina_Array *eina_module_list_get(Eina_Array *array,
+EINA_API Eina_Array *eina_module_list_get(Eina_Array *array,
                                       const char *path,
                                       Eina_Bool recursive,
                                       Eina_Module_Cb cb,
@@ -528,7 +528,7 @@ EAPI Eina_Array *eina_module_list_get(Eina_Array *array,
    return list_get_cb_data.array;
 }
 
-EAPI Eina_Module *
+EINA_API Eina_Module *
 eina_module_find(const Eina_Array *array, const char *module)
 {
    unsigned int i;
@@ -559,7 +559,7 @@ eina_module_find(const Eina_Array *array, const char *module)
    return NULL;
 }
 
-EAPI void eina_module_list_load(Eina_Array *array)
+EINA_API void eina_module_list_load(Eina_Array *array)
 {
    Eina_Array_Iterator iterator;
    Eina_Module *m;
@@ -574,7 +574,7 @@ EAPI void eina_module_list_load(Eina_Array *array)
      }
 }
 
-EAPI void eina_module_list_unload(Eina_Array *array)
+EINA_API void eina_module_list_unload(Eina_Array *array)
 {
    Eina_Array_Iterator iterator;
    Eina_Module *m;
@@ -586,7 +586,7 @@ EAPI void eina_module_list_unload(Eina_Array *array)
      eina_module_unload(m);
 }
 
-EAPI void eina_module_list_free(Eina_Array *array)
+EINA_API void eina_module_list_free(Eina_Array *array)
 {
    Eina_Array_Iterator iterator;
    Eina_Module *m;

--- a/src/lib/eina/eina_module.h
+++ b/src/lib/eina/eina_module.h
@@ -106,8 +106,8 @@ typedef void (*Eina_Module_Shutdown)(void);
  */
 #define EINA_MODULE_SHUTDOWN(f) EXPORTAPI Eina_Module_Shutdown __eina_module_shutdown = &f
 
-extern EAPI Eina_Error EINA_ERROR_WRONG_MODULE;
-extern EAPI Eina_Error EINA_ERROR_MODULE_INIT_FAILED;
+EINA_API extern Eina_Error EINA_ERROR_WRONG_MODULE;
+EINA_API extern Eina_Error EINA_ERROR_MODULE_INIT_FAILED;
 
 /**
  * @brief Returns a new module.
@@ -123,7 +123,7 @@ extern EAPI Eina_Error EINA_ERROR_MODULE_INIT_FAILED;
  *
  * @see eina_module_load
  */
-EAPI Eina_Module *
+EINA_API Eina_Module *
  eina_module_new(const char *file) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
@@ -137,7 +137,7 @@ EAPI Eina_Module *
  * returns #EINA_TRUE and #EINA_FALSE otherwise. If @p module is @c NULL, the
  * function returns immediately.
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
  eina_module_free(Eina_Module *module) EINA_ARG_NONNULL(1);
 
 /**
@@ -158,7 +158,7 @@ EAPI Eina_Bool
  * When the symbols of the shared file objects are not needed
  * anymore, call eina_module_unload() to unload the module.
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
  eina_module_load(Eina_Module *module) EINA_ARG_NONNULL(1);
 
 /**
@@ -175,7 +175,7 @@ EAPI Eina_Bool
  * returned. In all case, the reference counter is decreased. If @p module
  * is @c NULL, the function returns immediately #EINA_FALSE.
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
  eina_module_unload(Eina_Module *module) EINA_ARG_NONNULL(1);
 
 /**
@@ -190,7 +190,7 @@ EAPI Eina_Bool
  * is @c NULL, or if it has not been correctly loaded before, the
  * function returns immediately @c NULL.
  */
-EAPI void *
+EINA_API void *
  eina_module_symbol_get(const Eina_Module *module, const char *symbol) EINA_PURE EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -203,7 +203,7 @@ EAPI void *
  * @p module is @c NULL, the function returns immediately @c NULL. The
  * returned value must no be freed.
  */
-EAPI const char *
+EINA_API const char *
  eina_module_file_get(const Eina_Module *module) EINA_PURE EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
@@ -214,7 +214,7 @@ EAPI const char *
  *
  * @since 1.11
  */
-EAPI void eina_module_symbol_global_set(Eina_Module *module, Eina_Bool global) EINA_ARG_NONNULL(1);
+EINA_API void eina_module_symbol_global_set(Eina_Module *module, Eina_Bool global) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Returns the path built from the location of a library and a
@@ -230,7 +230,7 @@ EAPI void eina_module_symbol_global_set(Eina_Module *module, Eina_Bool global) E
  * anymore. If the symbol is not found, or dl_addr() is not supported,
  * or allocation fails, this function returns @c NULL.
  */
-EAPI char *
+EINA_API char *
  eina_module_symbol_path_get(const void *symbol, const char *sub_dir) EINA_MALLOC EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -247,7 +247,7 @@ EAPI char *
  * anymore. If the symbol is not found, or @p env does not exist, or
  * allocation fails, this function returns @c NULL.
  */
-EAPI char *
+EINA_API char *
  eina_module_environment_path_get(const char *env, const char *sub_dir) EINA_MALLOC EINA_ARG_NONNULL(1, 2);
 
 
@@ -264,7 +264,7 @@ EAPI char *
  * @c NULL, the function returns immediately @p array. @p array can be
  * @c NULL. In that case, it is created with 4 elements.
  */
-EAPI Eina_Array *
+EINA_API Eina_Array *
  eina_module_arch_list_get(Eina_Array *array, const char *path, const char *arch);
 
 /**
@@ -286,7 +286,7 @@ EAPI Eina_Array *
  * @p array can be @c NULL. In that case, it is created with 4
  * elements. @p cb can be @c NULL.
  */
-EAPI Eina_Array *
+EINA_API Eina_Array *
  eina_module_list_get(Eina_Array *array, const char *path, Eina_Bool recursive, Eina_Module_Cb cb, void *data) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -297,7 +297,7 @@ EAPI Eina_Array *
  * This function calls eina_module_load() on each element found in
  * @p array. If @p array is @c NULL, this function does nothing.
  */
-EAPI void
+EINA_API void
  eina_module_list_load(Eina_Array *array) EINA_ARG_NONNULL(1);
 
 /**
@@ -308,7 +308,7 @@ EAPI void
  * This function calls eina_module_unload() on each element found in
  * @p array. If @p array is @c NULL, this function does nothing.
  */
-EAPI void
+EINA_API void
  eina_module_list_unload(Eina_Array *array) EINA_ARG_NONNULL(1);
 
 /**
@@ -319,7 +319,7 @@ EAPI void
  * This function calls eina_module_free() on each element found in
  * @p array. If @p array is @c NULL, this function does nothing.
  */
-EAPI void
+EINA_API void
  eina_module_list_free(Eina_Array *array) EINA_ARG_NONNULL(1);
 
 /**
@@ -333,7 +333,7 @@ EAPI void
  * If the element is found  the function returns the module, else
  * @c NULL is returned.
  */
-EAPI Eina_Module *
+EINA_API Eina_Module *
  eina_module_find(const Eina_Array *array, const char *module) EINA_ARG_NONNULL(1, 2);
 
 /**

--- a/src/lib/eina/eina_prefix.c
+++ b/src/lib/eina/eina_prefix.c
@@ -463,7 +463,7 @@ _common_prefix_find(const char *bin, const char *lib, const char *data, const ch
  *============================================================================*/
 
 
-EAPI Eina_Prefix *
+EINA_API Eina_Prefix *
 eina_prefix_new(const char *argv0, void *symbol, const char *envprefix,
                 const char *sharedir, const char *magicsharefile,
                 const char *pkg_bin, const char *pkg_lib,
@@ -749,7 +749,7 @@ eina_prefix_new(const char *argv0, void *symbol, const char *envprefix,
    return pfx;
 }
 
-EAPI void
+EINA_API void
 eina_prefix_free(Eina_Prefix *pfx)
 {
    EINA_SAFETY_ON_NULL_RETURN(pfx);
@@ -763,35 +763,35 @@ eina_prefix_free(Eina_Prefix *pfx)
    free(pfx);
 }
 
-EAPI const char *
+EINA_API const char *
 eina_prefix_get(Eina_Prefix *pfx)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(pfx, "");
    return pfx->prefix_path;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_prefix_bin_get(Eina_Prefix *pfx)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(pfx, "");
    return pfx->prefix_path_bin;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_prefix_lib_get(Eina_Prefix *pfx)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(pfx, "");
    return pfx->prefix_path_lib;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_prefix_data_get(Eina_Prefix *pfx)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(pfx, "");
    return pfx->prefix_path_data;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_prefix_locale_get(Eina_Prefix *pfx)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(pfx, "");

--- a/src/lib/eina/eina_prefix.h
+++ b/src/lib/eina/eina_prefix.h
@@ -150,7 +150,7 @@ typedef struct _Eina_Prefix Eina_Prefix;
  *
  * @see eina_prefix_free()
  */
-EAPI Eina_Prefix *eina_prefix_new(const char *argv0, void *symbol, const char *envprefix,
+EINA_API Eina_Prefix *eina_prefix_new(const char *argv0, void *symbol, const char *envprefix,
                                   const char *sharedir, const char *magicsharefile,
                                   const char *pkg_bin, const char *pkg_lib,
                                   const char *pkg_data, const char *pkg_locale) EINA_ARG_NONNULL(6, 7, 8, 9) EINA_WARN_UNUSED_RESULT;
@@ -167,7 +167,7 @@ EAPI Eina_Prefix *eina_prefix_new(const char *argv0, void *symbol, const char *e
  *
  * @see eina_prefix_new()
  */
-EAPI void eina_prefix_free(Eina_Prefix *pfx) EINA_ARG_NONNULL(1);
+EINA_API void eina_prefix_free(Eina_Prefix *pfx) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets the prefix base directory.
@@ -178,7 +178,7 @@ EAPI void eina_prefix_free(Eina_Prefix *pfx) EINA_ARG_NONNULL(1);
  *
  * @since 1.1.0
  */
-EAPI const char *eina_prefix_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+EINA_API const char *eina_prefix_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief Gets the binary installation directory.
@@ -189,7 +189,7 @@ EAPI const char *eina_prefix_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN
  *
  * @since 1.1.0
  */
-EAPI const char *eina_prefix_bin_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+EINA_API const char *eina_prefix_bin_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief Gets the library installation directory.
@@ -200,7 +200,7 @@ EAPI const char *eina_prefix_bin_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_
  *
  * @since 1.1.0
  */
-EAPI const char *eina_prefix_lib_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+EINA_API const char *eina_prefix_lib_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief Gets the data installation directory.
@@ -211,7 +211,7 @@ EAPI const char *eina_prefix_lib_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_
  *
  * @since 1.1.0
  */
-EAPI const char *eina_prefix_data_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+EINA_API const char *eina_prefix_data_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief Gets the locale installation directory.
@@ -222,7 +222,7 @@ EAPI const char *eina_prefix_data_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA
  *
  * @since 1.1.0
  */
-EAPI const char *eina_prefix_locale_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+EINA_API const char *eina_prefix_locale_get(Eina_Prefix *pfx) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @}

--- a/src/lib/eina/eina_promise.c
+++ b/src/lib/eina/eina_promise.c
@@ -140,7 +140,7 @@ static const Eina_Value_Struct_Desc RACE_STRUCT_DESC = {
 };
 
 /** @cond local */
-EAPI const Eina_Value_Struct_Desc *EINA_PROMISE_RACE_STRUCT_DESC = &RACE_STRUCT_DESC;
+EINA_API const Eina_Value_Struct_Desc *EINA_PROMISE_RACE_STRUCT_DESC = &RACE_STRUCT_DESC;
 /** @endcond */
 
 static inline void
@@ -574,7 +574,7 @@ eina_promise_init(void)
    return EINA_FALSE;
 }
 
-EAPI void
+EINA_API void
 __eina_promise_cancel_all(void)
 {
    eina_lock_take(&_pending_futures_lock);
@@ -583,7 +583,7 @@ __eina_promise_cancel_all(void)
    eina_lock_release(&_pending_futures_lock);
 }
 
-EAPI void
+EINA_API void
 __eina_promise_cancel_data(void *data)
 {
    Eina_List *del = NULL, *l;
@@ -618,7 +618,7 @@ eina_promise_shutdown(void)
    return EINA_TRUE;
 }
 
-EAPI Eina_Value
+EINA_API Eina_Value
 eina_promise_as_value(Eina_Promise *p)
 {
    Eina_Value v = EINA_VALUE_EMPTY;
@@ -698,7 +698,7 @@ _scheduler_get(Eina_Future *f)
    return NULL;
 }
 
-EAPI Eina_Value
+EINA_API Eina_Value
 eina_future_as_value(Eina_Future *f)
 {
    Eina_Value v = EINA_VALUE_EMPTY;
@@ -739,7 +739,7 @@ eina_future_as_value(Eina_Future *f)
    return v;
 }
 
-EAPI Eina_Promise *
+EINA_API Eina_Promise *
 eina_promise_new(Eina_Future_Scheduler *scheduler,
                  Eina_Promise_Cancel_Cb cancel_cb, const void *data)
 {
@@ -758,7 +758,7 @@ eina_promise_new(Eina_Future_Scheduler *scheduler,
    return p;
 }
 
-EAPI Eina_Promise *
+EINA_API Eina_Promise *
 eina_promise_continue_new(const Eina_Future *dead_future,
                           Eina_Promise_Cancel_Cb cancel_cb, const void *data)
 {
@@ -777,14 +777,14 @@ eina_promise_continue_new(const Eina_Future *dead_future,
    return p;
 }
 
-EAPI void
+EINA_API void
 eina_future_cancel(Eina_Future *f)
 {
    EINA_FUTURE_CHECK_RETURN(f);
    _eina_future_cancel(f, ECANCELED);
 }
 
-EAPI void
+EINA_API void
 eina_promise_resolve(Eina_Promise *p, Eina_Value value)
 {
    EINA_PROMISE_CHECK_GOTO(p, err);
@@ -795,7 +795,7 @@ eina_promise_resolve(Eina_Promise *p, Eina_Value value)
    eina_value_flush(&value);
 }
 
-EAPI void
+EINA_API void
 eina_promise_reject(Eina_Promise *p, Eina_Error err)
 {
    Eina_Value value;
@@ -863,7 +863,7 @@ _eina_future_new(Eina_Promise *p, const Eina_Future_Desc desc)
    return NULL;
 }
 
-EAPI Eina_Future *
+EINA_API Eina_Future *
 eina_future_new(Eina_Promise *p)
 {
    static const Eina_Future_Desc desc = {
@@ -898,7 +898,7 @@ _eina_future_then(Eina_Future *prev, const Eina_Future_Desc desc)
    return NULL;
 }
 
-EAPI Eina_Future *
+EINA_API Eina_Future *
 eina_future_resolved(Eina_Future_Scheduler *scheduler, Eina_Value value)
 {
    Eina_Promise *p;
@@ -920,7 +920,7 @@ eina_future_resolved(Eina_Future_Scheduler *scheduler, Eina_Value value)
    return NULL;
 }
 
-EAPI Eina_Future *
+EINA_API Eina_Future *
 eina_future_rejected(Eina_Future_Scheduler *scheduler, Eina_Error err)
 {
    Eina_Promise *p;
@@ -941,7 +941,7 @@ eina_future_rejected(Eina_Future_Scheduler *scheduler, Eina_Error err)
    return NULL;
 }
 
-EAPI Eina_Future *
+EINA_API Eina_Future *
 eina_future_then_from_desc(Eina_Future *prev, const Eina_Future_Desc desc)
 {
    EINA_FUTURE_CHECK_GOTO(prev, err_future);
@@ -955,7 +955,7 @@ eina_future_then_from_desc(Eina_Future *prev, const Eina_Future_Desc desc)
    return NULL;
 }
 
-EAPI Eina_Future *
+EINA_API Eina_Future *
 eina_future_chain_array(Eina_Future *prev, const Eina_Future_Desc descs[])
 {
    Eina_Future *f = prev;
@@ -991,7 +991,7 @@ eina_future_chain_array(Eina_Future *prev, const Eina_Future_Desc descs[])
    return NULL;
 }
 
-EAPI Eina_Future *
+EINA_API Eina_Future *
 eina_future_chain_easy_array(Eina_Future *prev, const Eina_Future_Cb_Easy_Desc descs[])
 {
    size_t i = -1;
@@ -1060,7 +1060,7 @@ _eina_future_cb_console(void *data,
    return value;
 }
 
-EAPI Eina_Future_Desc
+EINA_API Eina_Future_Desc
 eina_future_cb_console_from_desc(const Eina_Future_Cb_Console_Desc desc)
 {
    Eina_Future_Cb_Console_Desc *c;
@@ -1112,7 +1112,7 @@ _eina_future_cb_convert_to(void *data, const Eina_Value src,
     return dst;
 }
 
-EAPI Eina_Future_Desc
+EINA_API Eina_Future_Desc
 eina_future_cb_convert_to(const Eina_Value_Type *type)
 {
    return (Eina_Future_Desc){.cb = _eina_future_cb_convert_to, .data = type};
@@ -1134,7 +1134,7 @@ _eina_future_cb_easy(void *data, const Eina_Value value,
     return ret;
 }
 
-EAPI Eina_Future_Desc
+EINA_API Eina_Future_Desc
 eina_future_cb_easy_from_desc(const Eina_Future_Cb_Easy_Desc desc)
 {
    Eina_Future_Cb_Easy_Desc *d = calloc(1, sizeof(Eina_Future_Cb_Easy_Desc));
@@ -1329,7 +1329,7 @@ promise_proxy_of_future_array_create(Eina_Future *array[],
    return EINA_FALSE;
 }
 
-EAPI Eina_Promise *
+EINA_API Eina_Promise *
 eina_promise_all_iterator(Eina_Iterator *it)
 {
    All_Promise_Ctx *ctx;
@@ -1393,7 +1393,7 @@ eina_promise_all_iterator(Eina_Iterator *it)
    return NULL;
 }
 
-EAPI Eina_Promise *
+EINA_API Eina_Promise *
 eina_promise_all_array(Eina_Future *array[])
 {
    All_Promise_Ctx *ctx;
@@ -1436,7 +1436,7 @@ eina_promise_all_array(Eina_Future *array[])
    return NULL;
 }
 
-EAPI Eina_Promise *
+EINA_API Eina_Promise *
 eina_promise_race_array(Eina_Future *array[])
 {
    Race_Promise_Ctx *ctx;
@@ -1478,13 +1478,13 @@ _eina_future_cb_ignore_error(void *data, const Eina_Value value,
    return value;
 }
 
-EAPI Eina_Future_Desc
+EINA_API Eina_Future_Desc
 eina_future_cb_ignore_error(Eina_Error err)
 {
    return (Eina_Future_Desc){ _eina_future_cb_ignore_error, (void*)(uintptr_t)err, NULL };
 }
 
-EAPI void
+EINA_API void
 eina_future_desc_flush(Eina_Future_Desc *desc)
 {
    if (!desc) return;
@@ -1492,7 +1492,7 @@ eina_future_desc_flush(Eina_Future_Desc *desc)
    memset(desc, 0, sizeof(Eina_Future_Desc));
 }
 
-EAPI void
+EINA_API void
 eina_future_cb_easy_desc_flush(Eina_Future_Cb_Easy_Desc *desc)
 {
    if (!desc) return;
@@ -1541,7 +1541,7 @@ _future_cb_log(void *data, const Eina_Value value,
    return value;
 }
 
-EAPI Eina_Future_Desc
+EINA_API Eina_Future_Desc
 eina_future_cb_log_from_desc(const Eina_Future_Cb_Log_Desc desc)
 {
    Eina_Future_Cb_Log_Desc *ctx = calloc(1, sizeof(Eina_Future_Cb_Log_Desc));

--- a/src/lib/eina/eina_promise.h
+++ b/src/lib/eina/eina_promise.h
@@ -548,7 +548,7 @@ struct _Eina_Future_Desc {
 /**
  * Value type for #Eina_Value's containing an #Eina_Promise
  */
-EAPI extern const Eina_Value_Type EINA_VALUE_TYPE_PROMISE;
+EINA_API extern const Eina_Value_Type EINA_VALUE_TYPE_PROMISE;
 
 /**
  * Creates a new promise.
@@ -598,7 +598,7 @@ EAPI extern const Eina_Value_Type EINA_VALUE_TYPE_PROMISE;
  * @see Eina_Future_Schedule_Entry
  * @see Eina_Future_Scheduler_Cb
  */
-EAPI Eina_Promise *eina_promise_new(Eina_Future_Scheduler *scheduler, Eina_Promise_Cancel_Cb cancel_cb, const void *data) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Promise *eina_promise_new(Eina_Future_Scheduler *scheduler, Eina_Promise_Cancel_Cb cancel_cb, const void *data) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Creates a new promise from a dead_future.
@@ -664,7 +664,7 @@ EAPI Eina_Promise *eina_promise_new(Eina_Future_Scheduler *scheduler, Eina_Promi
  * @see Eina_Future_Schedule_Entry
  * @see Eina_Future_Scheduler_Cb
  */
-EAPI Eina_Promise *eina_promise_continue_new(const Eina_Future *dead_future, Eina_Promise_Cancel_Cb cancel_cb, const void *data) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Promise *eina_promise_continue_new(const Eina_Future *dead_future, Eina_Promise_Cancel_Cb cancel_cb, const void *data) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Resolves a promise.
@@ -686,7 +686,7 @@ EAPI Eina_Promise *eina_promise_continue_new(const Eina_Future *dead_future, Ein
  * @see eina_promise_reject()
  * @see eina_promise_as_value()
  */
-EAPI void eina_promise_resolve(Eina_Promise *p, Eina_Value value) EINA_ARG_NONNULL(1);
+EINA_API void eina_promise_resolve(Eina_Promise *p, Eina_Value value) EINA_ARG_NONNULL(1);
 
 /**
  * Rejects a promise.
@@ -703,7 +703,7 @@ EAPI void eina_promise_resolve(Eina_Promise *p, Eina_Value value) EINA_ARG_NONNU
  * @see eina_promise_resolve()
  * @see eina_promise_as_value()
  */
-EAPI void eina_promise_reject(Eina_Promise *p, Eina_Error err) EINA_ARG_NONNULL(1);
+EINA_API void eina_promise_reject(Eina_Promise *p, Eina_Error err) EINA_ARG_NONNULL(1);
 
 
 /**
@@ -725,7 +725,7 @@ EAPI void eina_promise_reject(Eina_Promise *p, Eina_Error err) EINA_ARG_NONNULL(
  * with an #Eina_Value typed as #EINA_VALUE_TYPE_ERROR, with its value set to @c ECANCELED
  * @param[in,out] f The future to cancel.
  */
-EAPI void eina_future_cancel(Eina_Future *f) EINA_ARG_NONNULL(1);
+EINA_API void eina_future_cancel(Eina_Future *f) EINA_ARG_NONNULL(1);
 
 /**
  * Flushes an #Eina_Future_Desc
@@ -735,7 +735,7 @@ EAPI void eina_future_cancel(Eina_Future *f) EINA_ARG_NONNULL(1);
  *
  * @param[in,out] desc The #Eina_Future_Desc to flush, if @c NULL this is a noop.
  */
-EAPI void eina_future_desc_flush(Eina_Future_Desc *desc);
+EINA_API void eina_future_desc_flush(Eina_Future_Desc *desc);
 
 /**
  * Flushes an #Eina_Future_Cb_Easy_Desc
@@ -746,7 +746,7 @@ EAPI void eina_future_desc_flush(Eina_Future_Desc *desc);
  *
  * @param[in,out] desc The #Eina_Future_Cb_Easy_Desc to flush, if @c NULL this is a noop.
  */
-EAPI void eina_future_cb_easy_desc_flush(Eina_Future_Cb_Easy_Desc *desc);
+EINA_API void eina_future_cb_easy_desc_flush(Eina_Future_Cb_Easy_Desc *desc);
 
 /**
  * Creates a new #Eina_Value from a promise.
@@ -826,7 +826,7 @@ EAPI void eina_future_cb_easy_desc_flush(Eina_Future_Cb_Easy_Desc *desc);
  * @see eina_promise_reject()
  * @see eina_promise_resolve()
  */
-EAPI Eina_Value eina_promise_as_value(Eina_Promise *p) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Value eina_promise_as_value(Eina_Promise *p) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Creates an #Eina_Value from a future.
@@ -839,7 +839,7 @@ EAPI Eina_Value eina_promise_as_value(Eina_Promise *p) EINA_ARG_NONNULL(1) EINA_
  * @note If an error happens the future @p f will be CANCELED
  * @see eina_promise_as_value()
  */
-EAPI Eina_Value eina_future_as_value(Eina_Future *f)EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Value eina_future_as_value(Eina_Future *f)EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Creates a new future.
@@ -864,7 +864,7 @@ EAPI Eina_Value eina_future_as_value(Eina_Future *f)EINA_ARG_NONNULL(1) EINA_WAR
  * @see eina_promise_resolve()
  * @see eina_future_cancel()
  */
-EAPI Eina_Future *eina_future_new(Eina_Promise *p) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Future *eina_future_new(Eina_Promise *p) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Creates a new future that is already resolved to a value.
@@ -896,7 +896,7 @@ EAPI Eina_Future *eina_future_new(Eina_Promise *p) EINA_ARG_NONNULL(1) EINA_WARN
  * @see eina_promise_resolve()
  * @see eina_future_cancel()
  */
-EAPI Eina_Future *eina_future_resolved(Eina_Future_Scheduler *scheduler, Eina_Value value) EINA_ARG_NONNULL(1);
+EINA_API Eina_Future *eina_future_resolved(Eina_Future_Scheduler *scheduler, Eina_Value value) EINA_ARG_NONNULL(1);
 
 /**
  * Creates a new future that is already rejected to a specified error.
@@ -923,7 +923,7 @@ EAPI Eina_Future *eina_future_resolved(Eina_Future_Scheduler *scheduler, Eina_Va
  * @see eina_promise_resolve()
  * @see eina_future_cancel()
  */
-EAPI Eina_Future *eina_future_rejected(Eina_Future_Scheduler *scheduler, Eina_Error err);
+EINA_API Eina_Future *eina_future_rejected(Eina_Future_Scheduler *scheduler, Eina_Error err);
 
 /**
  * Register an #Eina_Future_Desc to be used when the future is resolved/rejected.
@@ -1078,7 +1078,7 @@ EAPI Eina_Future *eina_future_rejected(Eina_Future_Scheduler *scheduler, Eina_Er
  * @see eina_future_then_easy()
  * @see eina_future_cb_log_from_desc()
  */
-EAPI Eina_Future *eina_future_then_from_desc(Eina_Future *prev, const Eina_Future_Desc desc) EINA_ARG_NONNULL(1);
+EINA_API Eina_Future *eina_future_then_from_desc(Eina_Future *prev, const Eina_Future_Desc desc) EINA_ARG_NONNULL(1);
 
 /**
  * Creates an Eina_Future_Desc that will log the previous future resolved value.
@@ -1109,7 +1109,7 @@ EAPI Eina_Future *eina_future_then_from_desc(Eina_Future *prev, const Eina_Futur
  * @see eina_future_cb_log_warn()
  * @see eina_future_cb_console_from_desc()
  */
-EAPI Eina_Future_Desc eina_future_cb_log_from_desc(const Eina_Future_Cb_Log_Desc desc) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Future_Desc eina_future_cb_log_from_desc(const Eina_Future_Cb_Log_Desc desc) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Creates a future chain.
@@ -1160,7 +1160,7 @@ EAPI Eina_Future_Desc eina_future_cb_log_from_desc(const Eina_Future_Cb_Log_Desc
  * @see eina_future_then_easy()
  * @see eina_future_cb_convert_to()
  */
-EAPI Eina_Future *eina_future_chain_array(Eina_Future *prev, const Eina_Future_Desc descs[]) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Future *eina_future_chain_array(Eina_Future *prev, const Eina_Future_Desc descs[]) EINA_ARG_NONNULL(1, 2);
 
 
 /**
@@ -1181,7 +1181,7 @@ EAPI Eina_Future *eina_future_chain_array(Eina_Future *prev, const Eina_Future_D
  * @see eina_future_chain_array()
  * @see eina_future_cb_easy_from_desc()
  */
-EAPI Eina_Future *eina_future_chain_easy_array(Eina_Future *prev, const Eina_Future_Cb_Easy_Desc descs[]) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Future *eina_future_chain_easy_array(Eina_Future *prev, const Eina_Future_Cb_Easy_Desc descs[]) EINA_ARG_NONNULL(1, 2);
 
 /**
  * Creates an #Eina_Future_Desc that will print the previous future's resolved value.
@@ -1224,7 +1224,7 @@ EAPI Eina_Future *eina_future_chain_easy_array(Eina_Future *prev, const Eina_Fut
  * @see eina_future_cb_ignore_error()
  * @see eina_future_cb_log_from_desc()
  */
-EAPI Eina_Future_Desc eina_future_cb_console_from_desc(const Eina_Future_Cb_Console_Desc desc) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Future_Desc eina_future_cb_console_from_desc(const Eina_Future_Cb_Console_Desc desc) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Returns an #Eina_Future_Desc that ignores an error.
@@ -1236,7 +1236,7 @@ EAPI Eina_Future_Desc eina_future_cb_console_from_desc(const Eina_Future_Cb_Cons
  * @param[in] err The error to be ignored.
  * @return A future descriptor to be used with eina_future_then() or eina_future_chain()
  */
-EAPI Eina_Future_Desc eina_future_cb_ignore_error(Eina_Error err);
+EINA_API Eina_Future_Desc eina_future_cb_ignore_error(Eina_Error err);
 
 /**
  * Creates an #Eina_Future_Desc which will convert the received eina value to a given type.
@@ -1251,7 +1251,7 @@ EAPI Eina_Future_Desc eina_future_cb_ignore_error(Eina_Error err);
  * @see eina_future_then_from_desc()
  * @see eina_future_then_easy()
  */
-EAPI Eina_Future_Desc eina_future_cb_convert_to(const Eina_Value_Type *type);
+EINA_API Eina_Future_Desc eina_future_cb_convert_to(const Eina_Value_Type *type);
 
 /**
  * Creates an #Eina_Future_Desc based on an #Eina_Future_Cb_Easy_Desc.
@@ -1326,7 +1326,7 @@ EAPI Eina_Future_Desc eina_future_cb_convert_to(const Eina_Value_Type *type);
  * @see eina_future_then()
  * @see eina_future_cb_easy()
  */
-EAPI Eina_Future_Desc eina_future_cb_easy_from_desc(const Eina_Future_Cb_Easy_Desc desc) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Future_Desc eina_future_cb_easy_from_desc(const Eina_Future_Cb_Easy_Desc desc) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Creates an all promise.
@@ -1427,7 +1427,7 @@ EAPI Eina_Future_Desc eina_future_cb_easy_from_desc(const Eina_Future_Cb_Easy_De
  * @note On error all the futures will be CANCELED.
  * @see eina_future_all_array()
  */
-EAPI Eina_Promise *eina_promise_all_array(Eina_Future *array[]) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Promise *eina_promise_all_array(Eina_Future *array[]) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Creates an all promise from an iterator.
@@ -1443,7 +1443,7 @@ EAPI Eina_Promise *eina_promise_all_array(Eina_Future *array[]) EINA_ARG_NONNULL
  * @note On error all the futures will be CANCELED.
  * @see eina_future_all_iterator()
  */
-EAPI Eina_Promise *eina_promise_all_iterator(Eina_Iterator *iterator) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Promise *eina_promise_all_iterator(Eina_Iterator *iterator) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * Creates a race promise.
@@ -1555,7 +1555,7 @@ EAPI Eina_Promise *eina_promise_all_iterator(Eina_Iterator *iterator) EINA_ARG_N
  * @see eina_future_race_array()
  * @see _Eina_Future_Race_Result
  */
-EAPI Eina_Promise *eina_promise_race_array(Eina_Future *array[]) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Promise *eina_promise_race_array(Eina_Future *array[]) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @struct _Eina_Future_Race_Result
@@ -1611,7 +1611,7 @@ struct _Eina_Future_Race_Result {
  * @see eina_promise_race_array()
  * @see _Eina_Future_Race_Result
  */
-EAPI extern const Eina_Value_Struct_Desc *EINA_PROMISE_RACE_STRUCT_DESC;
+EINA_API extern const Eina_Value_Struct_Desc *EINA_PROMISE_RACE_STRUCT_DESC;
 
 /**
  * Creates a future that will be resolved once all futures from @p array is resolved.

--- a/src/lib/eina/eina_quad.c
+++ b/src/lib/eina/eina_quad.c
@@ -53,7 +53,7 @@ static inline void _quad_dump(Eina_Quad *q)
 /*============================================================================*
  *                                   API                                      *
  *============================================================================*/
-EAPI void
+EINA_API void
 eina_quad_rectangle_to(const Eina_Quad *q,
                        Eina_Rectangle *r)
 {
@@ -82,7 +82,7 @@ eina_quad_rectangle_to(const Eina_Quad *q,
    r->h = lround(ymax) - r->y;
 }
 
-EAPI void
+EINA_API void
 eina_quad_rectangle_from(Eina_Quad *q,
                          const Eina_Rectangle *r)
 {
@@ -96,7 +96,7 @@ eina_quad_rectangle_from(Eina_Quad *q,
    QUAD_Y3(q) = r->y + r->h;
 }
 
-EAPI void eina_quad_coords_get(const Eina_Quad *q,
+EINA_API void eina_quad_coords_get(const Eina_Quad *q,
                                double *qx0, double *qy0,
                                double *qx1, double *qy1,
                                double *qx2, double *qy2,
@@ -112,7 +112,7 @@ EAPI void eina_quad_coords_get(const Eina_Quad *q,
    if (qy3) *qy3 = q->y3;
 }
 
-EAPI void eina_quad_coords_set(Eina_Quad *q,
+EINA_API void eina_quad_coords_set(Eina_Quad *q,
                                double qx0, double qy0,
                                double qx1, double qy1,
                                double qx2, double qy2,

--- a/src/lib/eina/eina_quad.h
+++ b/src/lib/eina/eina_quad.h
@@ -61,7 +61,7 @@ typedef struct _Eina_Quad
  *
  * @since 1.14
  * */
-EAPI void eina_quad_rectangle_to(const Eina_Quad *q,
+EINA_API void eina_quad_rectangle_to(const Eina_Quad *q,
                                  Eina_Rectangle *r);
 /**
  * @brief Transform the given rectangle to the given quadrangle.
@@ -71,7 +71,7 @@ EAPI void eina_quad_rectangle_to(const Eina_Quad *q,
  *
  * @since 1.14
  * */
-EAPI void eina_quad_rectangle_from(Eina_Quad *q,
+EINA_API void eina_quad_rectangle_from(Eina_Quad *q,
                                    const Eina_Rectangle *r);
 /**
  * @brief Sets the values of the coordinates of the given quadrangle.
@@ -88,7 +88,7 @@ EAPI void eina_quad_rectangle_from(Eina_Quad *q,
  *
  * @since 1.14
  * */
-EAPI void eina_quad_coords_set(Eina_Quad *q,
+EINA_API void eina_quad_coords_set(Eina_Quad *q,
                                double x0, double y0,
                                double x1, double y1,
                                double x2, double y2,
@@ -109,7 +109,7 @@ EAPI void eina_quad_coords_set(Eina_Quad *q,
  *
  * @since 1.14
  * */
-EAPI void eina_quad_coords_get(const Eina_Quad *q,
+EINA_API void eina_quad_coords_get(const Eina_Quad *q,
                                double *x0, double *y0,
                                double *x1, double *y1,
                                double *x2, double *y2,

--- a/src/lib/eina/eina_quadtree.c
+++ b/src/lib/eina/eina_quadtree.c
@@ -584,7 +584,7 @@ end:
    object->root = NULL;
 }
 
-EAPI Eina_QuadTree *
+EINA_API Eina_QuadTree *
 eina_quadtree_new(size_t w, size_t h,
                   Eina_Quad_Callback vertical, Eina_Quad_Callback horizontal)
 {
@@ -612,7 +612,7 @@ eina_quadtree_new(size_t w, size_t h,
    return result;
 }
 
-EAPI void
+EINA_API void
 eina_quadtree_free(Eina_QuadTree *q)
 {
    Eina_QuadTree_Item *item;
@@ -653,7 +653,7 @@ eina_quadtree_free(Eina_QuadTree *q)
    free(q);
 }
 
-EAPI Eina_QuadTree_Item *
+EINA_API Eina_QuadTree_Item *
 eina_quadtree_add(Eina_QuadTree *q, const void *object)
 {
    Eina_QuadTree_Item *result;
@@ -691,7 +691,7 @@ eina_quadtree_add(Eina_QuadTree *q, const void *object)
    return result;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_quadtree_del(Eina_QuadTree_Item *object)
 {
    if (!object)
@@ -728,7 +728,7 @@ eina_quadtree_del(Eina_QuadTree_Item *object)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_quadtree_change(Eina_QuadTree_Item *object)
 {
    EINA_MAGIC_CHECK_QUADTREE_ITEM(object, EINA_FALSE);
@@ -751,7 +751,7 @@ eina_quadtree_change(Eina_QuadTree_Item *object)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_quadtree_hide(Eina_QuadTree_Item *object)
 {
    EINA_MAGIC_CHECK_QUADTREE_ITEM(object, EINA_FALSE);
@@ -761,7 +761,7 @@ eina_quadtree_hide(Eina_QuadTree_Item *object)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_quadtree_show(Eina_QuadTree_Item *object)
 {
    EINA_MAGIC_CHECK_QUADTREE_ITEM(object, EINA_FALSE);
@@ -778,7 +778,7 @@ eina_quadtree_show(Eina_QuadTree_Item *object)
    return EINA_TRUE;
 }
 
-EAPI Eina_Inlist *
+EINA_API Eina_Inlist *
 eina_quadtree_collide(Eina_QuadTree *q, int x, int y, int w, int h)
 {
    Eina_Rectangle canvas;
@@ -826,7 +826,7 @@ eina_quadtree_collide(Eina_QuadTree *q, int x, int y, int w, int h)
    return q->cached;
 }
 
-EAPI void *
+EINA_API void *
 eina_quadtree_object(Eina_Inlist *item)
 {
    Eina_QuadTree_Item *qi;
@@ -846,7 +846,7 @@ eina_quadtree_object(Eina_Inlist *item)
    return (void *)qi->object;
 }
 
-EAPI void
+EINA_API void
 eina_quadtree_resize(Eina_QuadTree *q, size_t w, size_t h)
 {
    EINA_MAGIC_CHECK_QUADTREE(q);
@@ -860,7 +860,7 @@ eina_quadtree_resize(Eina_QuadTree *q, size_t w, size_t h)
    q->geom.h = h;
 }
 
-EAPI void
+EINA_API void
 eina_quadtree_cycle(Eina_QuadTree *q)
 {
    EINA_MAGIC_CHECK_QUADTREE(q);
@@ -868,7 +868,7 @@ eina_quadtree_cycle(Eina_QuadTree *q)
    q->index = 0;
 }
 
-EAPI void
+EINA_API void
 eina_quadtree_increase(Eina_QuadTree_Item *object)
 {
    size_t tmp;

--- a/src/lib/eina/eina_quadtree.h
+++ b/src/lib/eina/eina_quadtree.h
@@ -86,7 +86,7 @@ typedef Eina_Quad_Direction (*Eina_Quad_Callback)(const void *object, size_t mid
  * The vertical and horizontal callbacks are used to assist in
  * determining which quadrant a given data item belongs to.
  */
-EAPI Eina_QuadTree *eina_quadtree_new(size_t w, size_t h, Eina_Quad_Callback vertical, Eina_Quad_Callback horizontal);
+EINA_API Eina_QuadTree *eina_quadtree_new(size_t w, size_t h, Eina_Quad_Callback vertical, Eina_Quad_Callback horizontal);
 
 /**
  * @brief Destructs quadtree and its data.
@@ -96,7 +96,7 @@ EAPI Eina_QuadTree *eina_quadtree_new(size_t w, size_t h, Eina_Quad_Callback ver
  * Frees the memory for the Eina_QuadTree object, and any memory used by
  * its change tracking and garbage collection internals.
  */
-EAPI void eina_quadtree_free(Eina_QuadTree *q);
+EINA_API void eina_quadtree_free(Eina_QuadTree *q);
 
 /**
  * @brief Changes the width and height of the quadtree.
@@ -108,14 +108,14 @@ EAPI void eina_quadtree_free(Eina_QuadTree *q);
  * Sets the width and height of the quadtree, but the actual update is
  * done lazily.
  */
-EAPI void eina_quadtree_resize(Eina_QuadTree *q, size_t w, size_t h);
+EINA_API void eina_quadtree_resize(Eina_QuadTree *q, size_t w, size_t h);
 
 /**
  * @brief Sets the quadtree's index to 0.
  *
  * @param[in,out] q The quadtree to cycle.
  */
-EAPI void eina_quadtree_cycle(Eina_QuadTree *q);
+EINA_API void eina_quadtree_cycle(Eina_QuadTree *q);
 
 /**
  * @brief Increases the index of the quadtree item by one.
@@ -124,7 +124,7 @@ EAPI void eina_quadtree_cycle(Eina_QuadTree *q);
  *
  * If necessary, records that the root is no longer sorted.
  */
-EAPI void eina_quadtree_increase(Eina_QuadTree_Item *object);
+EINA_API void eina_quadtree_increase(Eina_QuadTree_Item *object);
 
 /**
  * @brief Inserts a data object into the quadtree.
@@ -138,7 +138,7 @@ EAPI void eina_quadtree_increase(Eina_QuadTree_Item *object);
  * insert the item into the quadtree (i.e. insertion is delayed until
  * it needs to be used.)
  */
-EAPI Eina_QuadTree_Item *eina_quadtree_add(Eina_QuadTree *q, const void *object);
+EINA_API Eina_QuadTree_Item *eina_quadtree_add(Eina_QuadTree *q, const void *object);
 
 /**
  * @brief Deletes a given quadtree item from the quadtree.
@@ -149,7 +149,7 @@ EAPI Eina_QuadTree_Item *eina_quadtree_add(Eina_QuadTree *q, const void *object)
  * Moves the item to the quadtree's internal garbage heap for later
  * reclamation.
  */
-EAPI Eina_Bool eina_quadtree_del(Eina_QuadTree_Item *object);
+EINA_API Eina_Bool eina_quadtree_del(Eina_QuadTree_Item *object);
 
 /**
  * @brief Marks an object within the quadtree as needing changed.
@@ -157,7 +157,7 @@ EAPI Eina_Bool eina_quadtree_del(Eina_QuadTree_Item *object);
  * @param[in,out] object The object that has changed.
  * @return #EINA_TRUE if change successfully noted, or #EINA_FALSE otherwise.
  */
-EAPI Eina_Bool eina_quadtree_change(Eina_QuadTree_Item *object);
+EINA_API Eina_Bool eina_quadtree_change(Eina_QuadTree_Item *object);
 
 /**
  * @brief Sets @p object invisible.
@@ -166,7 +166,7 @@ EAPI Eina_Bool eina_quadtree_change(Eina_QuadTree_Item *object);
  * @return #EINA_TRUE if @p object was successfully hidden, or
  *         #EINA_FALSE if it wasn't in the quadtree.
  */
-EAPI Eina_Bool eina_quadtree_hide(Eina_QuadTree_Item *object);
+EINA_API Eina_Bool eina_quadtree_hide(Eina_QuadTree_Item *object);
 
 /**
  * @brief Sets @p object to visible.
@@ -175,7 +175,7 @@ EAPI Eina_Bool eina_quadtree_hide(Eina_QuadTree_Item *object);
  * @return #EINA_TRUE if @p object was successfully shown, or
  *         #EINA_FALSE if it wasn't in the quadtree.
  */
-EAPI Eina_Bool eina_quadtree_show(Eina_QuadTree_Item *object);
+EINA_API Eina_Bool eina_quadtree_show(Eina_QuadTree_Item *object);
 
 /**
  * @brief Retrieves items in quadtree inside the target geometry.
@@ -191,7 +191,7 @@ EAPI Eina_Bool eina_quadtree_show(Eina_QuadTree_Item *object);
  * changes, then performs a collision detection to find items whose
  * geometry is contained within or intersects the given target geometry.
  */
-EAPI Eina_Inlist *eina_quadtree_collide(Eina_QuadTree *q, int x, int y, int w, int h);
+EINA_API Eina_Inlist *eina_quadtree_collide(Eina_QuadTree *q, int x, int y, int w, int h);
 
 /**
  * @brief Retrieves the quadtree item's data for the given inline list.
@@ -200,7 +200,7 @@ EAPI Eina_Inlist *eina_quadtree_collide(Eina_QuadTree *q, int x, int y, int w, i
  * @return The contained data object in the Eina_QuadTree_Item, or @c
  *         NULL if none could be found.
  */
-EAPI void *eina_quadtree_object(Eina_Inlist *list);
+EINA_API void *eina_quadtree_object(Eina_Inlist *list);
 
 /**
  * @}

--- a/src/lib/eina/eina_quaternion.c
+++ b/src/lib/eina/eina_quaternion.c
@@ -30,7 +30,7 @@
 #include "eina_quaternion.h"
 #include "eina_util.h"
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_set(Eina_Quaternion *out,
                            Eina_F16p16 x, Eina_F16p16 y,
                            Eina_F16p16 z, Eina_F16p16 w)
@@ -41,7 +41,7 @@ eina_quaternion_f16p16_set(Eina_Quaternion *out,
    out->z = z;
 }
 
-EAPI Eina_F16p16
+EINA_API Eina_F16p16
 eina_quaternion_f16p16_norm(const Eina_Quaternion_F16p16 *q)
 {
    Eina_F16p16 s;
@@ -54,7 +54,7 @@ eina_quaternion_f16p16_norm(const Eina_Quaternion_F16p16 *q)
    return eina_f16p16_sqrt(s);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_negative(Eina_Quaternion_F16p16 *out,
                                 const Eina_Quaternion_F16p16 *in)
 {
@@ -64,7 +64,7 @@ eina_quaternion_f16p16_negative(Eina_Quaternion_F16p16 *out,
    out->z = eina_f16p16_sub(0, in->z);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_add(Eina_Quaternion_F16p16 *out,
                            const Eina_Quaternion_F16p16 *a,
                            const Eina_Quaternion_F16p16 *b)
@@ -75,7 +75,7 @@ eina_quaternion_f16p16_add(Eina_Quaternion_F16p16 *out,
    out->z = eina_f16p16_add(a->z, b->z);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_mul(Eina_Quaternion_F16p16 *out,
                            const Eina_Quaternion_F16p16 *a,
                            const Eina_Quaternion_F16p16 *b)
@@ -98,7 +98,7 @@ eina_quaternion_f16p16_mul(Eina_Quaternion_F16p16 *out,
                                             eina_f16p16_mul(a->y, b->x)));
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_scale(Eina_Quaternion_F16p16 *out,
                              const Eina_Quaternion_F16p16 *a,
                              Eina_F16p16 b)
@@ -109,7 +109,7 @@ eina_quaternion_f16p16_scale(Eina_Quaternion_F16p16 *out,
    out->z = eina_f16p16_scale(a->z, b);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_conjugate(Eina_Quaternion_F16p16 *out,
                                  const Eina_Quaternion_F16p16 *in)
 {
@@ -119,7 +119,7 @@ eina_quaternion_f16p16_conjugate(Eina_Quaternion_F16p16 *out,
    out->z = eina_f16p16_sub(0, in->z);
 }
 
-EAPI Eina_F16p16
+EINA_API Eina_F16p16
 eina_quaternion_f16p16_dot(const Eina_Quaternion_F16p16 *a,
                            const Eina_Quaternion_F16p16 *b)
 {
@@ -129,7 +129,7 @@ eina_quaternion_f16p16_dot(const Eina_Quaternion_F16p16 *a,
                                           eina_f16p16_mul(a->z, b->z)));
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_normalized(Eina_Quaternion_F16p16 *out,
                                   const Eina_Quaternion_F16p16 *in)
 {
@@ -141,7 +141,7 @@ eina_quaternion_f16p16_normalized(Eina_Quaternion_F16p16 *out,
                                                 norm));
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_lerp(Eina_Quaternion_F16p16 *out,
                             const Eina_Quaternion_F16p16 *a,
                             const Eina_Quaternion_F16p16 *b,
@@ -172,7 +172,7 @@ eina_quaternion_f16p16_lerp(Eina_Quaternion_F16p16 *out,
                                             pos));
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_slerp(Eina_Quaternion_F16p16 *out,
                              const Eina_Quaternion_F16p16 *a,
                              const Eina_Quaternion_F16p16 *b,
@@ -228,7 +228,7 @@ eina_quaternion_f16p16_slerp(Eina_Quaternion_F16p16 *out,
    eina_quaternion_f16p16_add(out, &left, &right);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_nlerp(Eina_Quaternion_F16p16 *out,
                              const Eina_Quaternion_F16p16 *a,
                              const Eina_Quaternion_F16p16 *b,
@@ -267,7 +267,7 @@ eina_quaternion_f16p16_nlerp(Eina_Quaternion_F16p16 *out,
    eina_quaternion_f16p16_normalized(out, &not_normalize);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_rotate(Eina_Point_3D_F16p16 *p,
                               const Eina_Point_3D_F16p16 *center,
                               const Eina_Quaternion_F16p16 *q)
@@ -313,7 +313,7 @@ eina_quaternion_f16p16_rotate(Eina_Point_3D_F16p16 *p,
                           eina_f16p16_add(uvz, uuvz));
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_f16p16_rotation_matrix3_get(Eina_Matrix3_F16p16 *m,
                                             const Eina_Quaternion_F16p16 *q)
 {
@@ -351,7 +351,7 @@ eina_quaternion_f16p16_rotation_matrix3_get(Eina_Matrix3_F16p16 *m,
                            eina_f16p16_add(xx, yy));
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_set(Eina_Quaternion *out, double x,
                     double y, double z, double w)
 {
@@ -361,7 +361,7 @@ eina_quaternion_set(Eina_Quaternion *out, double x,
    out->z = z;
 }
 
-EAPI double
+EINA_API double
 eina_quaternion_norm(const Eina_Quaternion *q)
 {
    double s;
@@ -371,7 +371,7 @@ eina_quaternion_norm(const Eina_Quaternion *q)
    return sqrt(s);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_negative(Eina_Quaternion *out,
                          const Eina_Quaternion *in)
 {
@@ -381,7 +381,7 @@ eina_quaternion_negative(Eina_Quaternion *out,
    out->z = - in->z;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_add(Eina_Quaternion *out,
                     const Eina_Quaternion *a,
                     const Eina_Quaternion *b)
@@ -392,7 +392,7 @@ eina_quaternion_add(Eina_Quaternion *out,
    out->z = a->z + b->z;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_mul(Eina_Quaternion *out,
                     const Eina_Quaternion *a,
                     const Eina_Quaternion *b)
@@ -403,7 +403,7 @@ eina_quaternion_mul(Eina_Quaternion *out,
    out->z = a->w * b->z + a->x * b->y - a->y * b->x + a->z * b->w;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_scale(Eina_Quaternion *out,
                       const Eina_Quaternion *a,
                       double b)
@@ -414,7 +414,7 @@ eina_quaternion_scale(Eina_Quaternion *out,
    out->z = a->z * b;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_conjugate(Eina_Quaternion *out,
                           const Eina_Quaternion *in)
 {
@@ -424,14 +424,14 @@ eina_quaternion_conjugate(Eina_Quaternion *out,
    out->z = - in->z;
 }
 
-EAPI double
+EINA_API double
 eina_quaternion_dot(const Eina_Quaternion *a,
                     const Eina_Quaternion *b)
 {
    return a->w * b->w + a->x * b->x + a->y * b->y + a->z * b->z;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_normalized(Eina_Quaternion *out,
                            const Eina_Quaternion *in)
 {
@@ -441,7 +441,7 @@ eina_quaternion_normalized(Eina_Quaternion *out,
    eina_quaternion_scale(out, in, 1.0 / norm);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_lerp(Eina_Quaternion *out,
                      const Eina_Quaternion *a,
                      const Eina_Quaternion *b,
@@ -464,7 +464,7 @@ eina_quaternion_lerp(Eina_Quaternion *out,
    out->z = a->z + pos * (b->z - a->z);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_slerp(Eina_Quaternion *out,
                       const Eina_Quaternion *a,
                       const Eina_Quaternion *b,
@@ -518,7 +518,7 @@ eina_quaternion_slerp(Eina_Quaternion *out,
    eina_quaternion_add(out, &left, &right);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_nlerp(Eina_Quaternion *out,
                       const Eina_Quaternion *a,
                       const Eina_Quaternion *b,
@@ -556,7 +556,7 @@ eina_quaternion_nlerp(Eina_Quaternion *out,
    eina_quaternion_normalized(out, &not_normalize);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_rotate(Eina_Point_3D *p,
                        const Eina_Point_3D *center,
                        const Eina_Quaternion *q)
@@ -590,7 +590,7 @@ eina_quaternion_rotate(Eina_Point_3D *p,
    p->z = center->z + z + uvz + uuvz;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_rotation_matrix3_get(Eina_Matrix3 *m,
                                      const Eina_Quaternion *q)
 {
@@ -681,7 +681,7 @@ eina_point3d_neg(Eina_Point_3D *out, const Eina_Point_3D *in)
 }
 
 /* http://www.w3.org/TR/css3-transforms/#decomposing-a-3d-matrix */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_matrix4_quaternion_to(Eina_Quaternion *rotation,
                            Eina_Quaternion *perspective,
                            Eina_Point_3D *translation,
@@ -832,7 +832,7 @@ eina_matrix4_quaternion_to(Eina_Quaternion *rotation,
    return EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 eina_matrix3_quaternion_get(Eina_Quaternion *q,
                             const Eina_Matrix3 *m)
 {
@@ -884,7 +884,7 @@ eina_matrix3_quaternion_get(Eina_Quaternion *q,
    q->z = z;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_matrix4_to(Eina_Matrix4 *m,
                            const Eina_Quaternion *rotation,
                            const Eina_Quaternion *perspective,
@@ -986,7 +986,7 @@ eina_quaternion_matrix4_to(Eina_Matrix4 *m,
    m->ww = tmp.ww;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_inverse(Eina_Quaternion *out, const Eina_Quaternion *q)
 {
    double norm = (q->x * q->x) + (q->y * q->y) + (q->z * q->z) + (q->w * q->w);
@@ -1008,7 +1008,7 @@ eina_quaternion_inverse(Eina_Quaternion *out, const Eina_Quaternion *q)
      }
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_array_set(Eina_Quaternion *dst, const double *v)
 {
    dst->x = v[0];
@@ -1017,7 +1017,7 @@ eina_quaternion_array_set(Eina_Quaternion *dst, const double *v)
    dst->w = v[3];
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_copy(Eina_Quaternion *dst, const Eina_Quaternion *src)
 {
    dst->x = src->x;
@@ -1026,7 +1026,7 @@ eina_quaternion_copy(Eina_Quaternion *dst, const Eina_Quaternion *src)
    dst->w = src->w;
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_homogeneous_regulate(Eina_Quaternion *out, const Eina_Quaternion *v)
 {
    if (!EINA_DBL_EQ(v->w, 0.0))
@@ -1040,7 +1040,7 @@ eina_quaternion_homogeneous_regulate(Eina_Quaternion *out, const Eina_Quaternion
      }
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_subtract(Eina_Quaternion *out, const Eina_Quaternion *a, const Eina_Quaternion *b)
 {
    out->x = a->x - b->x;
@@ -1049,20 +1049,20 @@ eina_quaternion_subtract(Eina_Quaternion *out, const Eina_Quaternion *a, const E
    out->w = a->w - b->w;
 }
 
-EAPI double
+EINA_API double
 eina_quaternion_length_get(const Eina_Quaternion *v)
 {
    return (double)sqrt((double)((v->x * v->x) + (v->y * v->y) +
                                 (v->z * v->z) + (v->w * v->w)));
 }
 
-EAPI double
+EINA_API double
 eina_quaternion_length_square_get(const Eina_Quaternion *v)
 {
    return (v->x * v->x) + (v->y * v->y) + (v->z * v->z) + (v->w * v->w);
 }
 
-EAPI double
+EINA_API double
 eina_quaternion_distance_get(const Eina_Quaternion *a, const Eina_Quaternion *b)
 {
    Eina_Quaternion v;
@@ -1071,7 +1071,7 @@ eina_quaternion_distance_get(const Eina_Quaternion *a, const Eina_Quaternion *b)
    return eina_quaternion_length_get(&v);
 }
 
-EAPI double
+EINA_API double
 eina_quaternion_distance_square_get(const Eina_Quaternion *a, const Eina_Quaternion *b)
 {
    Eina_Quaternion v;
@@ -1080,7 +1080,7 @@ eina_quaternion_distance_square_get(const Eina_Quaternion *a, const Eina_Quatern
    return eina_quaternion_length_square_get(&v);
 }
 
-EAPI void
+EINA_API void
 eina_quaternion_transform(Eina_Quaternion *out, const Eina_Quaternion *v, const Eina_Matrix4 *m)
 {
    Eina_Quaternion tmp;
@@ -1099,7 +1099,7 @@ eina_quaternion_transform(Eina_Quaternion *out, const Eina_Quaternion *v, const 
    eina_quaternion_copy(out, &tmp);
 }
 
-EAPI double
+EINA_API double
 eina_quaternion_angle_plains(Eina_Quaternion *a, Eina_Quaternion *b)
 {
    return (double) ((a->x * b->x) + (a->y * b->y) + (a->z * b->z)) / ((sqrt((a->x * a->x) +

--- a/src/lib/eina/eina_quaternion.h
+++ b/src/lib/eina/eina_quaternion.h
@@ -53,89 +53,89 @@ struct _Eina_Point_3D_F16p16
    Eina_F16p16 z;
 };
 
-EAPI void eina_quaternion_f16p16_set(Eina_Quaternion *out,
+EINA_API void eina_quaternion_f16p16_set(Eina_Quaternion *out,
                                      Eina_F16p16 x, Eina_F16p16 y,
                                      Eina_F16p16 z, Eina_F16p16 w); /**< @since 1.15 */
-EAPI Eina_F16p16 eina_quaternion_f16p16_norm(const Eina_Quaternion_F16p16 *q); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_negative(Eina_Quaternion_F16p16 *out,
+EINA_API Eina_F16p16 eina_quaternion_f16p16_norm(const Eina_Quaternion_F16p16 *q); /**< @since 1.15 */
+EINA_API void eina_quaternion_f16p16_negative(Eina_Quaternion_F16p16 *out,
                                           const Eina_Quaternion_F16p16 *in); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_add(Eina_Quaternion_F16p16 *out,
+EINA_API void eina_quaternion_f16p16_add(Eina_Quaternion_F16p16 *out,
                                      const Eina_Quaternion_F16p16 *a,
                                      const Eina_Quaternion_F16p16 *b); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_mul(Eina_Quaternion_F16p16 *out,
+EINA_API void eina_quaternion_f16p16_mul(Eina_Quaternion_F16p16 *out,
                                      const Eina_Quaternion_F16p16 *a,
                                      const Eina_Quaternion_F16p16 *b); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_scale(Eina_Quaternion_F16p16 *out,
+EINA_API void eina_quaternion_f16p16_scale(Eina_Quaternion_F16p16 *out,
                                        const Eina_Quaternion_F16p16 *a,
                                        Eina_F16p16 b); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_conjugate(Eina_Quaternion_F16p16 *out,
+EINA_API void eina_quaternion_f16p16_conjugate(Eina_Quaternion_F16p16 *out,
                                            const Eina_Quaternion_F16p16 *in); /**< @since 1.15 */
-EAPI Eina_F16p16 eina_quaternion_f16p16_dot(const Eina_Quaternion_F16p16 *a,
+EINA_API Eina_F16p16 eina_quaternion_f16p16_dot(const Eina_Quaternion_F16p16 *a,
                                             const Eina_Quaternion_F16p16 *b); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_lerp(Eina_Quaternion_F16p16 *out,
+EINA_API void eina_quaternion_f16p16_lerp(Eina_Quaternion_F16p16 *out,
                                       const Eina_Quaternion_F16p16 *a,
                                       const Eina_Quaternion_F16p16 *b,
                                       Eina_F16p16 pos); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_slerp(Eina_Quaternion_F16p16 *out,
+EINA_API void eina_quaternion_f16p16_slerp(Eina_Quaternion_F16p16 *out,
                                        const Eina_Quaternion_F16p16 *a,
                                        const Eina_Quaternion_F16p16 *b,
                                        Eina_F16p16 pos); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_nlerp(Eina_Quaternion_F16p16 *out,
+EINA_API void eina_quaternion_f16p16_nlerp(Eina_Quaternion_F16p16 *out,
                                        const Eina_Quaternion_F16p16 *a,
                                        const Eina_Quaternion_F16p16 *b,
                                        Eina_F16p16 pos); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_rotate(Eina_Point_3D_F16p16 *p,
+EINA_API void eina_quaternion_f16p16_rotate(Eina_Point_3D_F16p16 *p,
                                         const Eina_Point_3D_F16p16 *center,
                                         const Eina_Quaternion_F16p16 *q); /**< @since 1.15 */
-EAPI void eina_quaternion_f16p16_rotation_matrix3_get(Eina_Matrix3_F16p16 *m,
+EINA_API void eina_quaternion_f16p16_rotation_matrix3_get(Eina_Matrix3_F16p16 *m,
                                                      const Eina_Quaternion_F16p16 *q); /**< @since 1.15 */
 
-EAPI void eina_quaternion_set(Eina_Quaternion *q, double x,
+EINA_API void eina_quaternion_set(Eina_Quaternion *q, double x,
                               double y, double z, double w);
-EAPI double eina_quaternion_norm(const Eina_Quaternion *q); /**< @since 1.15 */
-EAPI void eina_quaternion_negative(Eina_Quaternion *out,
+EINA_API double eina_quaternion_norm(const Eina_Quaternion *q); /**< @since 1.15 */
+EINA_API void eina_quaternion_negative(Eina_Quaternion *out,
                                    const Eina_Quaternion *in); /**< @since 1.15 */
-EAPI void eina_quaternion_add(Eina_Quaternion *out,
+EINA_API void eina_quaternion_add(Eina_Quaternion *out,
                               const Eina_Quaternion *a,
                               const Eina_Quaternion *b); /**< @since 1.15 */
-EAPI void eina_quaternion_mul(Eina_Quaternion *out,
+EINA_API void eina_quaternion_mul(Eina_Quaternion *out,
                               const Eina_Quaternion *a,
                               const Eina_Quaternion *b); /**< @since 1.15 */
-EAPI void eina_quaternion_scale(Eina_Quaternion *out,
+EINA_API void eina_quaternion_scale(Eina_Quaternion *out,
                                 const Eina_Quaternion *a,
                                 double b); /**< @since 1.15 */
-EAPI void eina_quaternion_conjugate(Eina_Quaternion *out,
+EINA_API void eina_quaternion_conjugate(Eina_Quaternion *out,
                                     const Eina_Quaternion *in); /**< @since 1.15 */
-EAPI double eina_quaternion_dot(const Eina_Quaternion *a,
+EINA_API double eina_quaternion_dot(const Eina_Quaternion *a,
                                 const Eina_Quaternion *b); /**< @since 1.15 */
-EAPI void eina_quaternion_normalized(Eina_Quaternion *out,
+EINA_API void eina_quaternion_normalized(Eina_Quaternion *out,
                                      const Eina_Quaternion *in); /**< @since 1.15 */
-EAPI void eina_quaternion_lerp(Eina_Quaternion *out,
+EINA_API void eina_quaternion_lerp(Eina_Quaternion *out,
                                const Eina_Quaternion *a,
                                const Eina_Quaternion *b,
                                double pos); /**< @since 1.15 */
-EAPI void eina_quaternion_slerp(Eina_Quaternion *out,
+EINA_API void eina_quaternion_slerp(Eina_Quaternion *out,
                                 const Eina_Quaternion *a,
                                 const Eina_Quaternion *b,
                                 double pos); /**< @since 1.15 */
-EAPI void eina_quaternion_nlerp(Eina_Quaternion *out,
+EINA_API void eina_quaternion_nlerp(Eina_Quaternion *out,
                                 const Eina_Quaternion *a,
                                 const Eina_Quaternion *b,
                                 double pos); /**< @since 1.15 */
-EAPI void eina_quaternion_rotate(Eina_Point_3D *p,
+EINA_API void eina_quaternion_rotate(Eina_Point_3D *p,
                                  const Eina_Point_3D *center,
                                  const Eina_Quaternion *q); /**< @since 1.15 */
-EAPI void eina_quaternion_rotation_matrix3_get(Eina_Matrix3 *m,
+EINA_API void eina_quaternion_rotation_matrix3_get(Eina_Matrix3 *m,
                                                const Eina_Quaternion *q); /**< @since 1.15 */
-EAPI void eina_matrix3_quaternion_get(Eina_Quaternion *q,
+EINA_API void eina_matrix3_quaternion_get(Eina_Quaternion *q,
                                       const Eina_Matrix3 *m); /**< @since 1.15 */
-EAPI Eina_Bool eina_matrix4_quaternion_to(Eina_Quaternion *rotation,
+EINA_API Eina_Bool eina_matrix4_quaternion_to(Eina_Quaternion *rotation,
                                           Eina_Quaternion *perspective,
                                           Eina_Point_3D *translation,
                                           Eina_Point_3D *scale,
                                           Eina_Point_3D *skew,
                                           const Eina_Matrix4 *m); /**< @since 1.16 */
-EAPI void eina_quaternion_matrix4_to(Eina_Matrix4 *m,
+EINA_API void eina_quaternion_matrix4_to(Eina_Matrix4 *m,
                                      const Eina_Quaternion *rotation,
                                      const Eina_Quaternion *perspective,
                                      const Eina_Point_3D *translation,
@@ -152,7 +152,7 @@ EAPI void eina_quaternion_matrix4_to(Eina_Matrix4 *m,
  *
  * @since 1.17
  */
-EAPI void eina_quaternion_inverse(Eina_Quaternion *out, const Eina_Quaternion *q);
+EINA_API void eina_quaternion_inverse(Eina_Quaternion *out, const Eina_Quaternion *q);
 
 /**
  * @brief Set array to quaternion.
@@ -164,7 +164,7 @@ EAPI void eina_quaternion_inverse(Eina_Quaternion *out, const Eina_Quaternion *q
  *
  * @since 1.17
  */
-EAPI void eina_quaternion_array_set(Eina_Quaternion *dst, const double *v);
+EINA_API void eina_quaternion_array_set(Eina_Quaternion *dst, const double *v);
 
 /**
  * @brief Copy quaternion.
@@ -174,7 +174,7 @@ EAPI void eina_quaternion_array_set(Eina_Quaternion *dst, const double *v);
  *
  * @since 1.17
  */
-EAPI void eina_quaternion_copy(Eina_Quaternion *dst,
+EINA_API void eina_quaternion_copy(Eina_Quaternion *dst,
                                const Eina_Quaternion *src);
 
 /**
@@ -185,7 +185,7 @@ EAPI void eina_quaternion_copy(Eina_Quaternion *dst,
  *
  * @since 1.17
  */
-EAPI void eina_quaternion_homogeneous_regulate(Eina_Quaternion *out,
+EINA_API void eina_quaternion_homogeneous_regulate(Eina_Quaternion *out,
                                                const Eina_Quaternion *v);
 
 /**
@@ -197,7 +197,7 @@ EAPI void eina_quaternion_homogeneous_regulate(Eina_Quaternion *out,
  *
  * @since 1.17
  */
-EAPI void eina_quaternion_subtract(Eina_Quaternion *out, const Eina_Quaternion *a,
+EINA_API void eina_quaternion_subtract(Eina_Quaternion *out, const Eina_Quaternion *a,
                                    const Eina_Quaternion *b);
 
 /**
@@ -208,7 +208,7 @@ EAPI void eina_quaternion_subtract(Eina_Quaternion *out, const Eina_Quaternion *
  *
  * @since 1.17
  */
-EAPI double eina_quaternion_length_get(const Eina_Quaternion *v);
+EINA_API double eina_quaternion_length_get(const Eina_Quaternion *v);
 
 /**
  * @brief Return the length in square of the given quaternion.
@@ -218,7 +218,7 @@ EAPI double eina_quaternion_length_get(const Eina_Quaternion *v);
  *
  * @since 1.17
  */
-EAPI double eina_quaternion_length_square_get(const Eina_Quaternion *v);
+EINA_API double eina_quaternion_length_square_get(const Eina_Quaternion *v);
 
 /**
  * @brief Return the distance between of two quaternions.
@@ -229,7 +229,7 @@ EAPI double eina_quaternion_length_square_get(const Eina_Quaternion *v);
  *
  * @since 1.17
  */
-EAPI double eina_quaternion_distance_get(const Eina_Quaternion *a,
+EINA_API double eina_quaternion_distance_get(const Eina_Quaternion *a,
                                          const Eina_Quaternion *b);
 /**
  * @brief Return the distance in square between of two quaternions.
@@ -240,7 +240,7 @@ EAPI double eina_quaternion_distance_get(const Eina_Quaternion *a,
  *
  * @since 1.17
  */
-EAPI double eina_quaternion_distance_square_get(const Eina_Quaternion *a,
+EINA_API double eina_quaternion_distance_square_get(const Eina_Quaternion *a,
                                                 const Eina_Quaternion *b);
 
 /**
@@ -252,7 +252,7 @@ EAPI double eina_quaternion_distance_square_get(const Eina_Quaternion *a,
  *
  * @since 1.17
  */
-EAPI void eina_quaternion_transform(Eina_Quaternion *out, const Eina_Quaternion *v,
+EINA_API void eina_quaternion_transform(Eina_Quaternion *out, const Eina_Quaternion *v,
                                     const Eina_Matrix4 *m);
 
 /**
@@ -264,6 +264,6 @@ EAPI void eina_quaternion_transform(Eina_Quaternion *out, const Eina_Quaternion 
  *
  * @since 1.17
  */
-EAPI double eina_quaternion_angle_plains(Eina_Quaternion *a, Eina_Quaternion *b);
+EINA_API double eina_quaternion_angle_plains(Eina_Quaternion *a, Eina_Quaternion *b);
 
 #endif

--- a/src/lib/eina/eina_rbtree.c
+++ b/src/lib/eina/eina_rbtree.c
@@ -303,7 +303,7 @@ _eina_rbtree_inline_double_rotation(Eina_Rbtree *node,
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Rbtree *
+EINA_API Eina_Rbtree *
 eina_rbtree_inline_insert(Eina_Rbtree *root,
                           Eina_Rbtree *node,
                           Eina_Rbtree_Cmp_Node_Cb cmp,
@@ -370,7 +370,7 @@ eina_rbtree_inline_insert(Eina_Rbtree *root,
    return root;
 }
 
-EAPI Eina_Rbtree *
+EINA_API Eina_Rbtree *
 eina_rbtree_inline_remove(Eina_Rbtree *root,
                           Eina_Rbtree *node,
                           Eina_Rbtree_Cmp_Node_Cb cmp,
@@ -517,25 +517,25 @@ eina_rbtree_inline_remove(Eina_Rbtree *root,
    return root;
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_rbtree_iterator_prefix(const Eina_Rbtree *root)
 {
    return _eina_rbtree_iterator_build(root, EINA_RBTREE_ITERATOR_PREFIX_MASK);
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_rbtree_iterator_infix(const Eina_Rbtree *root)
 {
    return _eina_rbtree_iterator_build(root, EINA_RBTREE_ITERATOR_INFIX_MASK);
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_rbtree_iterator_postfix(const Eina_Rbtree *root)
 {
    return _eina_rbtree_iterator_build(root, EINA_RBTREE_ITERATOR_POSTFIX_MASK);
 }
 
-EAPI void
+EINA_API void
 eina_rbtree_delete(Eina_Rbtree *root, Eina_Rbtree_Free_Cb func, void *data)
 {
    if (!root)

--- a/src/lib/eina/eina_rbtree.h
+++ b/src/lib/eina/eina_rbtree.h
@@ -162,7 +162,7 @@ typedef void (*Eina_Rbtree_Free_Cb)(Eina_Rbtree *node, void *data);
  * an empty valid red black tree. The resulting new tree is a valid red
  * black tree. This function doesn't allocate any data.
  */
-EAPI Eina_Rbtree          *eina_rbtree_inline_insert(Eina_Rbtree *root, Eina_Rbtree *node, Eina_Rbtree_Cmp_Node_Cb cmp, const void *data) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Rbtree          *eina_rbtree_inline_insert(Eina_Rbtree *root, Eina_Rbtree *node, Eina_Rbtree_Cmp_Node_Cb cmp, const void *data) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Removes a node from an existing red black tree.
@@ -177,7 +177,7 @@ EAPI Eina_Rbtree          *eina_rbtree_inline_insert(Eina_Rbtree *root, Eina_Rbt
  * contain the node that you are removing. This function will return @c NULL
  * when the red black tree got empty. This function doesn't free any data.
  */
-EAPI Eina_Rbtree          *eina_rbtree_inline_remove(Eina_Rbtree *root, Eina_Rbtree *node, Eina_Rbtree_Cmp_Node_Cb cmp, const void *data) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Rbtree          *eina_rbtree_inline_remove(Eina_Rbtree *root, Eina_Rbtree *node, Eina_Rbtree_Cmp_Node_Cb cmp, const void *data) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Deletes all nodes from a valid red black tree.
@@ -186,7 +186,7 @@ EAPI Eina_Rbtree          *eina_rbtree_inline_remove(Eina_Rbtree *root, Eina_Rbt
  * @param[in] func The callback that will free each node.
  * @param[in] data Private data to help the compare function.
  */
-EAPI void                  eina_rbtree_delete(Eina_Rbtree *root, Eina_Rbtree_Free_Cb func, void *data) EINA_ARG_NONNULL(2);
+EINA_API void                  eina_rbtree_delete(Eina_Rbtree *root, Eina_Rbtree_Free_Cb func, void *data) EINA_ARG_NONNULL(2);
 
 /**
  * @brief Searches tree for a key using a comparison function.
@@ -221,7 +221,7 @@ static inline Eina_Rbtree *eina_rbtree_inline_lookup(const Eina_Rbtree *root, co
  *    invalid! That is, if you add or remove nodes this iterator
  *    behavior is undefined and your program may crash!
  */
-EAPI Eina_Iterator        *eina_rbtree_iterator_prefix(const Eina_Rbtree *root) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator        *eina_rbtree_iterator_prefix(const Eina_Rbtree *root) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Returns a new prefix iterator associated with a rbtree.
@@ -241,7 +241,7 @@ EAPI Eina_Iterator        *eina_rbtree_iterator_prefix(const Eina_Rbtree *root) 
  *    invalid! That is, if you add or remove nodes this iterator
  *    behavior is undefined and your program may crash!
  */
-EAPI Eina_Iterator        *eina_rbtree_iterator_infix(const Eina_Rbtree *root) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator        *eina_rbtree_iterator_infix(const Eina_Rbtree *root) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Returns a new prefix iterator associated with a rbtree.
@@ -261,7 +261,7 @@ EAPI Eina_Iterator        *eina_rbtree_iterator_infix(const Eina_Rbtree *root) E
  *    invalid! That is, if you add or remove nodes this iterator
  *    behavior is undefined and your program may crash!
  */
-EAPI Eina_Iterator        *eina_rbtree_iterator_postfix(const Eina_Rbtree *root) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator        *eina_rbtree_iterator_postfix(const Eina_Rbtree *root) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 #include "eina_inline_rbtree.x"
 

--- a/src/lib/eina/eina_rectangle.c
+++ b/src/lib/eina/eina_rectangle.c
@@ -591,7 +591,7 @@ eina_rectangle_shutdown(void)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Rectangle *
+EINA_API Eina_Rectangle *
 eina_rectangle_new(int x, int y, int w, int h)
 {
    Eina_Rectangle *rect = NULL;
@@ -615,7 +615,7 @@ eina_rectangle_new(int x, int y, int w, int h)
    return rect;
 }
 
-EAPI void
+EINA_API void
 eina_rectangle_free(Eina_Rectangle *rect)
 {
    EINA_SAFETY_ON_NULL_RETURN(rect);
@@ -631,7 +631,7 @@ eina_rectangle_free(Eina_Rectangle *rect)
      }
 }
 
-EAPI Eina_Rectangle_Pool *
+EINA_API Eina_Rectangle_Pool *
 eina_rectangle_pool_new(int w, int h)
 {
    Eina_Rectangle_Pool *new;
@@ -660,7 +660,7 @@ eina_rectangle_pool_new(int w, int h)
    return new;
 }
 
-EAPI void
+EINA_API void
 eina_rectangle_pool_free(Eina_Rectangle_Pool *pool)
 {
    Eina_Rectangle_Alloc *del;
@@ -690,14 +690,14 @@ eina_rectangle_pool_free(Eina_Rectangle_Pool *pool)
    MAGIC_FREE(pool);
 }
 
-EAPI int
+EINA_API int
 eina_rectangle_pool_count(Eina_Rectangle_Pool *pool)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(pool, 0);
    return pool->references;
 }
 
-EAPI Eina_Rectangle *
+EINA_API Eina_Rectangle *
 eina_rectangle_pool_request(Eina_Rectangle_Pool *pool, int w, int h)
 {
    Eina_Rectangle_Alloc *new;
@@ -763,7 +763,7 @@ eina_rectangle_pool_request(Eina_Rectangle_Pool *pool, int w, int h)
    return rect;
 }
 
-EAPI void
+EINA_API void
 eina_rectangle_pool_release(Eina_Rectangle *rect)
 {
    Eina_Rectangle_Alloc *era = ((Eina_Rectangle_Alloc *)rect) - 1;
@@ -817,7 +817,7 @@ eina_rectangle_pool_release(Eina_Rectangle *rect)
      }
 }
 
-EAPI Eina_Rectangle_Pool *
+EINA_API Eina_Rectangle_Pool *
 eina_rectangle_pool_get(Eina_Rectangle *rect)
 {
    Eina_Rectangle_Alloc *era = ((Eina_Rectangle_Alloc *)rect) - 1;
@@ -830,7 +830,7 @@ eina_rectangle_pool_get(Eina_Rectangle *rect)
    return era->pool;
 }
 
-EAPI void
+EINA_API void
 eina_rectangle_pool_packing_set(Eina_Rectangle_Pool *pool, Eina_Rectangle_Packing type)
 {
    EINA_MAGIC_CHECK_RECTANGLE_POOL(pool);
@@ -853,7 +853,7 @@ eina_rectangle_pool_packing_set(Eina_Rectangle_Pool *pool, Eina_Rectangle_Packin
      }
 }
 
-EAPI void
+EINA_API void
 eina_rectangle_pool_data_set(Eina_Rectangle_Pool *pool, const void *data)
 {
    EINA_MAGIC_CHECK_RECTANGLE_POOL(pool);
@@ -865,7 +865,7 @@ eina_rectangle_pool_data_set(Eina_Rectangle_Pool *pool, const void *data)
    pool->data = (void *)data;
 }
 
-EAPI void *
+EINA_API void *
 eina_rectangle_pool_data_get(Eina_Rectangle_Pool *pool)
 {
    EINA_MAGIC_CHECK_RECTANGLE_POOL(pool);
@@ -874,7 +874,7 @@ eina_rectangle_pool_data_get(Eina_Rectangle_Pool *pool)
    return pool->data;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_rectangle_pool_geometry_get(Eina_Rectangle_Pool *pool, int *w, int *h)
 {
    if (!pool)
@@ -892,7 +892,7 @@ eina_rectangle_pool_geometry_get(Eina_Rectangle_Pool *pool, int *w, int *h)
    return EINA_TRUE;
 }
 
-EAPI Eina_Rectangle_Outside
+EINA_API Eina_Rectangle_Outside
 eina_rectangle_outside_position(Eina_Rectangle *rect1, Eina_Rectangle *rect2)
 {
    Eina_Rectangle_Outside ret = 0;

--- a/src/lib/eina/eina_rectangle.h
+++ b/src/lib/eina/eina_rectangle.h
@@ -422,7 +422,7 @@ static inline Eina_Bool   eina_rectangle_subtract(Eina_Rectangle *rect, Eina_Rec
  * new pool. If the pool can not be created, @c NULL is
  * returned. Otherwise the newly allocated pool is returned.
  */
-EAPI Eina_Rectangle_Pool *eina_rectangle_pool_new(int w, int h) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Rectangle_Pool *eina_rectangle_pool_new(int w, int h) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Returns the pool of the given rectangle.
@@ -433,7 +433,7 @@ EAPI Eina_Rectangle_Pool *eina_rectangle_pool_new(int w, int h) EINA_MALLOC EINA
  * This function returns the pool in which @p rect is. If  @p rect is
  * @c NULL, @c NULL is returned.
  */
-EAPI Eina_Rectangle_Pool *eina_rectangle_pool_get(Eina_Rectangle *rect) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Rectangle_Pool *eina_rectangle_pool_get(Eina_Rectangle *rect) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Returns the width and height of the given pool.
@@ -448,7 +448,7 @@ EAPI Eina_Rectangle_Pool *eina_rectangle_pool_get(Eina_Rectangle *rect) EINA_WAR
  * @p pool is @c NULL, #EINA_FALSE is returned. Otherwise #EINA_TRUE is
  * returned.
  */
-EAPI Eina_Bool            eina_rectangle_pool_geometry_get(Eina_Rectangle_Pool *pool, int *w, int *h) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool            eina_rectangle_pool_geometry_get(Eina_Rectangle_Pool *pool, int *w, int *h) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets the data from the given pool.
@@ -460,7 +460,7 @@ EAPI Eina_Bool            eina_rectangle_pool_geometry_get(Eina_Rectangle_Pool *
  * eina_rectangle_pool_data_set(). If @p pool is @c NULL, this
  * function returns @c NULL.
  */
-EAPI void                *eina_rectangle_pool_data_get(Eina_Rectangle_Pool *pool) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API void                *eina_rectangle_pool_data_get(Eina_Rectangle_Pool *pool) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Sets the data to the given pool.
@@ -471,7 +471,7 @@ EAPI void                *eina_rectangle_pool_data_get(Eina_Rectangle_Pool *pool
  * This function sets @p data to @p pool. If @p pool is @c NULL, this
  * function does nothing.
  */
-EAPI void                 eina_rectangle_pool_data_set(Eina_Rectangle_Pool *pool, const void *data) EINA_ARG_NONNULL(1);
+EINA_API void                 eina_rectangle_pool_data_set(Eina_Rectangle_Pool *pool, const void *data) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Frees the given pool.
@@ -481,7 +481,7 @@ EAPI void                 eina_rectangle_pool_data_set(Eina_Rectangle_Pool *pool
  * This function frees the allocated data of @p pool. If @p pool is
  * @c NULL, this function returned immediately.
  */
-EAPI void                 eina_rectangle_pool_free(Eina_Rectangle_Pool *pool) EINA_ARG_NONNULL(1);
+EINA_API void                 eina_rectangle_pool_free(Eina_Rectangle_Pool *pool) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Returns the number of rectangles in the given pool.
@@ -491,7 +491,7 @@ EAPI void                 eina_rectangle_pool_free(Eina_Rectangle_Pool *pool) EI
  *
  * This function returns the number of rectangles in @p pool.
  */
-EAPI int                  eina_rectangle_pool_count(Eina_Rectangle_Pool *pool) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API int                  eina_rectangle_pool_count(Eina_Rectangle_Pool *pool) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Requests a rectangle of given size in the given pool.
@@ -508,7 +508,7 @@ EAPI int                  eina_rectangle_pool_count(Eina_Rectangle_Pool *pool) E
  * returns the rectangle which matches the size (@p w, @p h).
  * Otherwise it returns @c NULL.
  */
-EAPI Eina_Rectangle      *eina_rectangle_pool_request(Eina_Rectangle_Pool *pool, int w, int h) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Rectangle      *eina_rectangle_pool_request(Eina_Rectangle_Pool *pool, int w, int h) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Removes the given rectangle from the pool.
@@ -519,7 +519,7 @@ EAPI Eina_Rectangle      *eina_rectangle_pool_request(Eina_Rectangle_Pool *pool,
  * @c NULL, the function returns immediately. Otherwise it removes @p
  * rect from the pool.
  */
-EAPI void                 eina_rectangle_pool_release(Eina_Rectangle *rect) EINA_ARG_NONNULL(1);
+EINA_API void                 eina_rectangle_pool_release(Eina_Rectangle *rect) EINA_ARG_NONNULL(1);
 
 /**
  * @def EINA_RECTANGLE_SET
@@ -565,7 +565,7 @@ EAPI void                 eina_rectangle_pool_release(Eina_Rectangle *rect) EINA
  *
  * No check is done on @p w and @p h.
  */
-EAPI Eina_Rectangle *eina_rectangle_new(int x, int y, int w, int h) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Rectangle *eina_rectangle_new(int x, int y, int w, int h) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Frees the given rectangle.
@@ -574,7 +574,7 @@ EAPI Eina_Rectangle *eina_rectangle_new(int x, int y, int w, int h) EINA_MALLOC 
  *
  * This function removes @p rect from the rectangles pool.
  */
-EAPI void            eina_rectangle_free(Eina_Rectangle *rect) EINA_ARG_NONNULL(1);
+EINA_API void            eina_rectangle_free(Eina_Rectangle *rect) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Sets the type of given rectangle pool.
@@ -586,7 +586,7 @@ EAPI void            eina_rectangle_free(Eina_Rectangle *rect) EINA_ARG_NONNULL(
  * @see Eina_Rectangle_Packing
  * @since 1.11
  */
-EAPI void            eina_rectangle_pool_packing_set(Eina_Rectangle_Pool *pool,Eina_Rectangle_Packing type) EINA_ARG_NONNULL(1);
+EINA_API void            eina_rectangle_pool_packing_set(Eina_Rectangle_Pool *pool,Eina_Rectangle_Packing type) EINA_ARG_NONNULL(1);
 
 /**
  * @brief calculates where rect2 is outside of rect1.
@@ -597,7 +597,7 @@ EAPI void            eina_rectangle_pool_packing_set(Eina_Rectangle_Pool *pool,E
  * @return An OR'd map of Eina_Rectangle_Outside values
  * @since 1.19
  */
-EAPI Eina_Rectangle_Outside eina_rectangle_outside_position(Eina_Rectangle *rect1, Eina_Rectangle *rect2);
+EINA_API Eina_Rectangle_Outside eina_rectangle_outside_position(Eina_Rectangle *rect1, Eina_Rectangle *rect2);
 
 /**
  * @brief Compares two rectangles for equality

--- a/src/lib/eina/eina_safepointer.c
+++ b/src/lib/eina/eina_safepointer.c
@@ -59,8 +59,8 @@ struct _Eina_Memory_Header
    size_t size;
 };
 
-EAPI Eina_Memory_Table **_eina_sp_ids_tables[EINA_MAX_MID_TABLE_ID] = { NULL };
-EAPI int _eina_sp_log_dom = -1;
+EINA_API Eina_Memory_Table **_eina_sp_ids_tables[EINA_MAX_MID_TABLE_ID] = { NULL };
+EINA_API int _eina_sp_log_dom = -1;
 
 /* Spare empty table */
 static Eina_Memory_Table *empty_table = NULL;
@@ -261,7 +261,7 @@ _eina_safepointer_entry_find(Eina_Memory_Table *table)
    return entry;
 }
 
-EAPI const Eina_Safepointer *
+EINA_API const Eina_Safepointer *
 eina_safepointer_register(const void *target)
 {
    Eina_Memory_Table *table;
@@ -298,7 +298,7 @@ eina_safepointer_register(const void *target)
    return (void*) id;
 }
 
-EAPI void
+EINA_API void
 eina_safepointer_unregister(const Eina_Safepointer *safe)
 {
    Eina_Memory_Table *table;

--- a/src/lib/eina/eina_safepointer.h
+++ b/src/lib/eina/eina_safepointer.h
@@ -77,7 +77,7 @@ typedef struct _Eina_Safepointer Eina_Safepointer;
  *
  * @since 1.18
  */
-EAPI const Eina_Safepointer *eina_safepointer_register(const void *target);
+EINA_API const Eina_Safepointer *eina_safepointer_register(const void *target);
 
 /**
  * @brief Unregister an Eina_Safepointer and the pointer that maps to it.
@@ -88,7 +88,7 @@ EAPI const Eina_Safepointer *eina_safepointer_register(const void *target);
  *
  * @since 1.18
  */
-EAPI void  eina_safepointer_unregister(const Eina_Safepointer *safe);
+EINA_API void  eina_safepointer_unregister(const Eina_Safepointer *safe);
 
 /**
  * @brief Get the associated pointer from an Eina_Safepointer mapping.

--- a/src/lib/eina/eina_safety_checks.c
+++ b/src/lib/eina/eina_safety_checks.c
@@ -25,7 +25,7 @@
 #include "eina_log.h"
 #include "eina_safety_checks.h"
 
-EAPI Eina_Error EINA_ERROR_SAFETY_FAILED = 0;
+EINA_API Eina_Error EINA_ERROR_SAFETY_FAILED = 0;
 
 static int EINA_SAFETY_LOG_DOMAIN = 0;
 static int initcnt = 0;
@@ -74,7 +74,7 @@ eina_safety_checks_init(void)
    return EINA_TRUE;
 }
 
-EAPI void
+EINA_API void
 _eina_safety_error(const char *file, const char *func, int line, const char *str)
 {
    eina_error_set(EINA_ERROR_SAFETY_FAILED);

--- a/src/lib/eina/eina_safety_checks.h
+++ b/src/lib/eina/eina_safety_checks.h
@@ -87,7 +87,7 @@
 #include "eina_config.h"
 #include "eina_error.h"
 
-EAPI extern Eina_Error EINA_ERROR_SAFETY_FAILED;
+EINA_API extern Eina_Error EINA_ERROR_SAFETY_FAILED;
 
 #ifdef EINA_SAFETY_CHECKS
 
@@ -104,7 +104,7 @@ EAPI extern Eina_Error EINA_ERROR_SAFETY_FAILED;
  * @since 1.17
  * @internal
  */
-EAPI void _eina_safety_error(const char *file, const char *func, int line, const char *str);
+EINA_API void _eina_safety_error(const char *file, const char *func, int line, const char *str);
 #  define EINA_SAFETY_ERROR(msg) _eina_safety_error(__FILE__, __func__, __LINE__, msg)
 # else
 #  define EINA_SAFETY_ERROR(msg) EINA_LOG_ERR("%s", msg)

--- a/src/lib/eina/eina_sched.h
+++ b/src/lib/eina/eina_sched.h
@@ -49,9 +49,9 @@
  *          only one that is implemented as of now. In this case, the nice level is
  *          incremented on this thread by @c NICENESS.
  */
-EAPI void eina_sched_prio_drop(void);
+EINA_API void eina_sched_prio_drop(void);
 
-EAPI void eina_sched_prio_init(Eina_Thread_Call*);
+EINA_API void eina_sched_prio_init(Eina_Thread_Call*);
 
 /**
  * @}

--- a/src/lib/eina/eina_sched_posix.c
+++ b/src/lib/eina/eina_sched_posix.c
@@ -23,7 +23,7 @@
 #include <errno.h>
 #include <pthread.h>
 
-EAPI void
+EINA_API void
 eina_sched_prio_drop(void)
 {
    struct sched_param param;
@@ -69,7 +69,7 @@ eina_sched_prio_drop(void)
      }
 }
 
-EAPI void
+EINA_API void
 eina_sched_prio_init(Eina_Thread_Call* c)
 {
    Eina_Thread self = eina_thread_self();

--- a/src/lib/eina/eina_sched_win32.c
+++ b/src/lib/eina/eina_sched_win32.c
@@ -23,7 +23,7 @@
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
 
-EAPI void
+EINA_API void
 eina_sched_prio_drop(void)
 {
    Eina_Thread thread;
@@ -65,7 +65,7 @@ eina_sched_prio_drop(void)
      }
 }
 
-EAPI void
+EINA_API void
 eina_sched_prio_init(Eina_Thread_Call* c)
 {
     // TODO

--- a/src/lib/eina/eina_simple_xml_parser.c
+++ b/src/lib/eina/eina_simple_xml_parser.c
@@ -282,7 +282,7 @@ eina_simple_xml_shutdown(void)
  *============================================================================*/
 
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_simple_xml_parse(const char *buf, unsigned buflen, Eina_Bool strip, Eina_Simple_XML_Cb func, const void *data)
 {
    const char *itr = buf, *itr_end = buf + buflen;
@@ -474,7 +474,7 @@ eina_simple_xml_parse(const char *buf, unsigned buflen, Eina_Bool strip, Eina_Si
    return EINA_TRUE;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_simple_xml_tag_attributes_find(const char *buf, unsigned buflen)
 {
    const char *itr = buf, *itr_end = buf + buflen;
@@ -499,7 +499,7 @@ eina_simple_xml_tag_attributes_find(const char *buf, unsigned buflen)
    return NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_simple_xml_attributes_parse(const char *buf, unsigned buflen, Eina_Simple_XML_Attribute_Cb func, const void *data)
 {
    const char *itr = buf, *itr_end = buf + buflen;
@@ -559,7 +559,7 @@ eina_simple_xml_attributes_parse(const char *buf, unsigned buflen, Eina_Simple_X
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_simple_xml_attribute_w3c_parse(const char *buf, Eina_Simple_XML_Attribute_Cb func, const void *data)
 {
    const char *end;
@@ -618,7 +618,7 @@ eina_simple_xml_attribute_w3c_parse(const char *buf, Eina_Simple_XML_Attribute_C
 
 /* Node loader *************************************************************/
 
-EAPI Eina_Simple_XML_Attribute *
+EINA_API Eina_Simple_XML_Attribute *
 eina_simple_xml_attribute_new(Eina_Simple_XML_Node_Tag *parent, const char *key, const char *value)
 {
    Eina_Simple_XML_Attribute *attr;
@@ -644,7 +644,7 @@ eina_simple_xml_attribute_new(Eina_Simple_XML_Node_Tag *parent, const char *key,
    return attr;
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_attribute_free(Eina_Simple_XML_Attribute *attr)
 {
    if (!attr)
@@ -673,7 +673,7 @@ _eina_simple_xml_node_data_free(Eina_Simple_XML_Node_Data *node)
    free(node);
 }
 
-EAPI Eina_Simple_XML_Node_Tag *
+EINA_API Eina_Simple_XML_Node_Tag *
 eina_simple_xml_node_tag_new(Eina_Simple_XML_Node_Tag *parent, const char *name)
 {
    Eina_Simple_XML_Node_Tag *n;
@@ -731,7 +731,7 @@ _eina_simple_xml_node_tag_free(Eina_Simple_XML_Node_Tag *tag)
    eina_mempool_free(_eina_simple_xml_tag_mp, tag);
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_node_tag_free(Eina_Simple_XML_Node_Tag *tag)
 {
    if (!tag)
@@ -776,14 +776,14 @@ _eina_simple_xml_node_data_new(Eina_Simple_XML_Node_Tag *parent, Eina_Simple_XML
    return n;
 }
 
-EAPI Eina_Simple_XML_Node_Data *
+EINA_API Eina_Simple_XML_Node_Data *
 eina_simple_xml_node_data_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length)
 {
    return _eina_simple_xml_node_data_new
      (parent, EINA_SIMPLE_XML_NODE_DATA, contents, length);
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_node_data_free(Eina_Simple_XML_Node_Data *node)
 {
    if (!node)
@@ -798,14 +798,14 @@ eina_simple_xml_node_data_free(Eina_Simple_XML_Node_Data *node)
    _eina_simple_xml_node_data_free(node);
 }
 
-EAPI Eina_Simple_XML_Node_CData *
+EINA_API Eina_Simple_XML_Node_CData *
 eina_simple_xml_node_cdata_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length)
 {
    return _eina_simple_xml_node_data_new
      (parent, EINA_SIMPLE_XML_NODE_CDATA, contents, length);
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_node_cdata_free(Eina_Simple_XML_Node_Data *node)
 {
    if (!node)
@@ -820,14 +820,14 @@ eina_simple_xml_node_cdata_free(Eina_Simple_XML_Node_Data *node)
    _eina_simple_xml_node_data_free(node);
 }
 
-EAPI Eina_Simple_XML_Node_Doctype_Child *
+EINA_API Eina_Simple_XML_Node_Doctype_Child *
 eina_simple_xml_node_doctype_child_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length)
 {
    return _eina_simple_xml_node_data_new
      (parent, EINA_SIMPLE_XML_NODE_DOCTYPE_CHILD, contents, length);
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_node_doctype_child_free(Eina_Simple_XML_Node_Data *node)
 {
    if (!node)
@@ -842,14 +842,14 @@ eina_simple_xml_node_doctype_child_free(Eina_Simple_XML_Node_Data *node)
    _eina_simple_xml_node_data_free(node);
 }
 
-EAPI Eina_Simple_XML_Node_Processing *
+EINA_API Eina_Simple_XML_Node_Processing *
 eina_simple_xml_node_processing_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length)
 {
    return _eina_simple_xml_node_data_new
      (parent, EINA_SIMPLE_XML_NODE_PROCESSING, contents, length);
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_node_processing_free(Eina_Simple_XML_Node_Data *node)
 {
    if (!node)
@@ -864,14 +864,14 @@ eina_simple_xml_node_processing_free(Eina_Simple_XML_Node_Data *node)
    _eina_simple_xml_node_data_free(node);
 }
 
-EAPI Eina_Simple_XML_Node_Doctype *
+EINA_API Eina_Simple_XML_Node_Doctype *
 eina_simple_xml_node_doctype_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length)
 {
    return _eina_simple_xml_node_data_new
      (parent, EINA_SIMPLE_XML_NODE_DOCTYPE, contents, length);
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_node_doctype_free(Eina_Simple_XML_Node_Data *node)
 {
    if (!node)
@@ -886,14 +886,14 @@ eina_simple_xml_node_doctype_free(Eina_Simple_XML_Node_Data *node)
    _eina_simple_xml_node_data_free(node);
 }
 
-EAPI Eina_Simple_XML_Node_Comment *
+EINA_API Eina_Simple_XML_Node_Comment *
 eina_simple_xml_node_comment_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length)
 {
    return _eina_simple_xml_node_data_new
      (parent, EINA_SIMPLE_XML_NODE_COMMENT, contents, length);
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_node_comment_free(Eina_Simple_XML_Node_Data *node)
 {
    if (!node)
@@ -1012,7 +1012,7 @@ _eina_simple_xml_node_parse(void *data, Eina_Simple_XML_Type type, const char *c
    return EINA_TRUE;
 }
 
-EAPI Eina_Simple_XML_Node_Root *
+EINA_API Eina_Simple_XML_Node_Root *
 eina_simple_xml_node_load(const char *buf, unsigned buflen, Eina_Bool strip)
 {
    Eina_Simple_XML_Node_Root *root;
@@ -1034,7 +1034,7 @@ eina_simple_xml_node_load(const char *buf, unsigned buflen, Eina_Bool strip)
    return root;
 }
 
-EAPI void
+EINA_API void
 eina_simple_xml_node_root_free(Eina_Simple_XML_Node_Root *root)
 {
    if (!root) return;
@@ -1194,7 +1194,7 @@ _eina_simple_xml_node_dump(Eina_Strbuf *buf, Eina_Simple_XML_Node *node, const c
      }
 }
 
-EAPI char *
+EINA_API char *
 eina_simple_xml_node_dump(Eina_Simple_XML_Node *node, const char *indent)
 {
    Eina_Strbuf *buf;

--- a/src/lib/eina/eina_simple_xml_parser.h
+++ b/src/lib/eina/eina_simple_xml_parser.h
@@ -229,7 +229,7 @@ typedef Eina_Bool (*Eina_Simple_XML_Attribute_Cb)(void *data, const char *key, c
  * @return #EINA_TRUE on success, or #EINA_FALSE if it was aborted by user or
  * parsing error.
  */
-EAPI Eina_Bool eina_simple_xml_parse(const char *buf, unsigned buflen,
+EINA_API Eina_Bool eina_simple_xml_parse(const char *buf, unsigned buflen,
                                      Eina_Bool strip,
                                      Eina_Simple_XML_Cb func, const void *data);
 
@@ -247,7 +247,7 @@ EAPI Eina_Bool eina_simple_xml_parse(const char *buf, unsigned buflen,
  * type is #EINA_SIMPLE_XML_OPEN or #EINA_SIMPLE_XML_OPEN_EMPTY.
  *
  */
-EAPI const char * eina_simple_xml_tag_attributes_find(const char *buf, unsigned buflen);
+EINA_API const char * eina_simple_xml_tag_attributes_find(const char *buf, unsigned buflen);
 
 /**
  * @brief Given a buffer with xml attributes, parse them to key=value pairs.
@@ -264,7 +264,7 @@ EAPI const char * eina_simple_xml_tag_attributes_find(const char *buf, unsigned 
  * @return #EINA_TRUE on success, or #EINA_FALSE if it was aborted by user or
  *         parsing error.
  */
-EAPI Eina_Bool eina_simple_xml_attributes_parse(const char *buf, unsigned buflen,
+EINA_API Eina_Bool eina_simple_xml_attributes_parse(const char *buf, unsigned buflen,
 						Eina_Simple_XML_Attribute_Cb func, const void *data);
 
 /**
@@ -283,7 +283,7 @@ EAPI Eina_Bool eina_simple_xml_attributes_parse(const char *buf, unsigned buflen
  *
  * @since 1.14
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_simple_xml_attribute_w3c_parse(const char *buf, Eina_Simple_XML_Attribute_Cb func, const void *data);
 
 /**
@@ -299,14 +299,14 @@ eina_simple_xml_attribute_w3c_parse(const char *buf, Eina_Simple_XML_Attribute_C
  *         released with eina_simple_xml_attribute_free() or indirectly
  *         with eina_simple_xml_node_tag_free().
  */
-EAPI Eina_Simple_XML_Attribute * eina_simple_xml_attribute_new(Eina_Simple_XML_Node_Tag *parent, const char *key, const char *value);
+EINA_API Eina_Simple_XML_Attribute * eina_simple_xml_attribute_new(Eina_Simple_XML_Node_Tag *parent, const char *key, const char *value);
 
 /**
  * @brief Removes attribute from parent and deletes it.
  *
  * @param[in] attr attribute to release memory.
  */
-EAPI void eina_simple_xml_attribute_free(Eina_Simple_XML_Attribute *attr);
+EINA_API void eina_simple_xml_attribute_free(Eina_Simple_XML_Attribute *attr);
 
 /**
  * @brief Creates new tag. If parent is provided, it is automatically appended.
@@ -319,14 +319,14 @@ EAPI void eina_simple_xml_attribute_free(Eina_Simple_XML_Attribute *attr);
  *         released with eina_simple_xml_node_tag_free() or indirectly
  *         with eina_simple_xml_node_tag_free() of the parent.
  */
-EAPI Eina_Simple_XML_Node_Tag * eina_simple_xml_node_tag_new(Eina_Simple_XML_Node_Tag *parent, const char *name);
+EINA_API Eina_Simple_XML_Node_Tag * eina_simple_xml_node_tag_new(Eina_Simple_XML_Node_Tag *parent, const char *name);
 
 /**
  * @brief Removes tag from parent and deletes it.
  *
  * @param[in] tag to release memory.
  */
-EAPI void eina_simple_xml_node_tag_free(Eina_Simple_XML_Node_Tag *tag);
+EINA_API void eina_simple_xml_node_tag_free(Eina_Simple_XML_Node_Tag *tag);
 
 
 /**
@@ -341,14 +341,14 @@ EAPI void eina_simple_xml_node_tag_free(Eina_Simple_XML_Node_Tag *tag);
  *         released with eina_simple_xml_node_data_free() or indirectly
  *         with eina_simple_xml_node_tag_free() of the parent.
  */
-EAPI Eina_Simple_XML_Node_Data * eina_simple_xml_node_data_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
+EINA_API Eina_Simple_XML_Node_Data * eina_simple_xml_node_data_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
 
 /**
  * @brief Removes data from parent and deletes it.
  *
  * @param[in] node to release memory.
  */
-EAPI void eina_simple_xml_node_data_free(Eina_Simple_XML_Node_Data *node);
+EINA_API void eina_simple_xml_node_data_free(Eina_Simple_XML_Node_Data *node);
 
 
 /**
@@ -363,14 +363,14 @@ EAPI void eina_simple_xml_node_data_free(Eina_Simple_XML_Node_Data *node);
  *         released with eina_simple_xml_node_cdata_free() or indirectly
  *         with eina_simple_xml_node_tag_free() of the parent.
  */
-EAPI Eina_Simple_XML_Node_CData * eina_simple_xml_node_cdata_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
+EINA_API Eina_Simple_XML_Node_CData * eina_simple_xml_node_cdata_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
 
 /**
  * @brief Removes cdata from parent and deletes it.
  *
  * @param[in] node to release memory.
  */
-EAPI void eina_simple_xml_node_cdata_free(Eina_Simple_XML_Node_Data *node);
+EINA_API void eina_simple_xml_node_cdata_free(Eina_Simple_XML_Node_Data *node);
 
 
 /**
@@ -387,7 +387,7 @@ EAPI void eina_simple_xml_node_cdata_free(Eina_Simple_XML_Node_Data *node);
  *
  * @since 1.8
  */
-EAPI Eina_Simple_XML_Node_Doctype_Child * eina_simple_xml_node_doctype_child_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
+EINA_API Eina_Simple_XML_Node_Doctype_Child * eina_simple_xml_node_doctype_child_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
 
 /**
  * @brief Removes doctype child from parent and deletes it.
@@ -396,7 +396,7 @@ EAPI Eina_Simple_XML_Node_Doctype_Child * eina_simple_xml_node_doctype_child_new
  *
  * @since 1.8
  */
-EAPI void eina_simple_xml_node_doctype_child_free(Eina_Simple_XML_Node_Data *node);
+EINA_API void eina_simple_xml_node_doctype_child_free(Eina_Simple_XML_Node_Data *node);
 
 
 /**
@@ -411,14 +411,14 @@ EAPI void eina_simple_xml_node_doctype_child_free(Eina_Simple_XML_Node_Data *nod
  *         released with eina_simple_xml_node_processing_free() or indirectly
  *         with eina_simple_xml_node_tag_free() of the parent.
  */
-EAPI Eina_Simple_XML_Node_Processing * eina_simple_xml_node_processing_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
+EINA_API Eina_Simple_XML_Node_Processing * eina_simple_xml_node_processing_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
 
 /**
  * @brief Removes processing from parent and deletes it.
  *
  * @param[in] node processing to release memory.
  */
-EAPI void eina_simple_xml_node_processing_free(Eina_Simple_XML_Node_Data *node);
+EINA_API void eina_simple_xml_node_processing_free(Eina_Simple_XML_Node_Data *node);
 
 
 /**
@@ -433,14 +433,14 @@ EAPI void eina_simple_xml_node_processing_free(Eina_Simple_XML_Node_Data *node);
  *         released with eina_simple_xml_node_doctype_free() or indirectly
  *         with eina_simple_xml_node_tag_free() of the parent.
  */
-EAPI Eina_Simple_XML_Node_Doctype * eina_simple_xml_node_doctype_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
+EINA_API Eina_Simple_XML_Node_Doctype * eina_simple_xml_node_doctype_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
 
 /**
  * @brief Removes doctype from parent and deletes it.
  *
  * @param[in] node doctype to release memory.
  */
-EAPI void eina_simple_xml_node_doctype_free(Eina_Simple_XML_Node_Data *node);
+EINA_API void eina_simple_xml_node_doctype_free(Eina_Simple_XML_Node_Data *node);
 
 
 /**
@@ -455,14 +455,14 @@ EAPI void eina_simple_xml_node_doctype_free(Eina_Simple_XML_Node_Data *node);
  *         released with eina_simple_xml_node_comment_free() or indirectly
  *         with eina_simple_xml_node_tag_free() of the parent.
  */
-EAPI Eina_Simple_XML_Node_Comment * eina_simple_xml_node_comment_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
+EINA_API Eina_Simple_XML_Node_Comment * eina_simple_xml_node_comment_new(Eina_Simple_XML_Node_Tag *parent, const char *contents, size_t length);
 
 /**
  * @brief Removes comment from parent and deletes it.
  *
  * @param[in] node comment to release memory.
  */
-EAPI void eina_simple_xml_node_comment_free(Eina_Simple_XML_Node_Data *node);
+EINA_API void eina_simple_xml_node_comment_free(Eina_Simple_XML_Node_Data *node);
 
 
 /**
@@ -477,14 +477,14 @@ EAPI void eina_simple_xml_node_comment_free(Eina_Simple_XML_Node_Data *node);
  *         Document with errors may return partial tree instead of @c NULL,
  *         we'll do our best to avoid returning nothing.
  */
-EAPI Eina_Simple_XML_Node_Root * eina_simple_xml_node_load(const char *buf, unsigned buflen, Eina_Bool strip);
+EINA_API Eina_Simple_XML_Node_Root * eina_simple_xml_node_load(const char *buf, unsigned buflen, Eina_Bool strip);
 
 /**
  * @brief Frees node tree build with eina_simple_xml_node_load()
  *
  * @param[in] root Memory returned by eina_simple_xml_node_load()
  */
-EAPI void eina_simple_xml_node_root_free(Eina_Simple_XML_Node_Root *root);
+EINA_API void eina_simple_xml_node_root_free(Eina_Simple_XML_Node_Root *root);
 
 /**
  * @brief Converts the node tree under the given element to a XML string.
@@ -494,7 +494,7 @@ EAPI void eina_simple_xml_node_root_free(Eina_Simple_XML_Node_Root *root);
  *
  * @return @c NULL on errors, or a newly allocated string on success.
  */
-EAPI char * eina_simple_xml_node_dump(Eina_Simple_XML_Node *node, const char *indent);
+EINA_API char * eina_simple_xml_node_dump(Eina_Simple_XML_Node *node, const char *indent);
 
 
 /**

--- a/src/lib/eina/eina_slstr.c
+++ b/src/lib/eina/eina_slstr.c
@@ -24,9 +24,9 @@ static Eina_TLS _slstr_tls = 0;
 
 #if 0
 // 2 extension ideas here: slices for short-lived raw data buffers
-EAPI Eina_Rw_Slice eina_slslice_new(size_t length); // alloc
-EAPI Eina_Rw_Slice eina_slslice_copy(Eina_Slice slice); // copies
-EAPI Eina_Rw_Slice eina_slslice_free(Eina_Rw_Slice slice); // steals
+EINA_API Eina_Rw_Slice eina_slslice_new(size_t length); // alloc
+EINA_API Eina_Rw_Slice eina_slslice_copy(Eina_Slice slice); // copies
+EINA_API Eina_Rw_Slice eina_slslice_free(Eina_Rw_Slice slice); // steals
 #endif
 
 static void
@@ -90,7 +90,7 @@ _slstr_freeq_get(Eina_Bool nocreate)
      }
 }
 
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_copy_new(const char *string)
 {
    Eina_FreeQ *fq;
@@ -111,7 +111,7 @@ eina_slstr_copy_new(const char *string)
    return copy;
 }
 
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_copy_new_length(const char *string, size_t len)
 {
    Eina_FreeQ *fq;
@@ -128,7 +128,7 @@ eina_slstr_copy_new_length(const char *string, size_t len)
    return copy;
 }
 
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_steal_new(char *string)
 {
    Eina_FreeQ *fq;
@@ -146,7 +146,7 @@ eina_slstr_steal_new(char *string)
    return string;
 }
 
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_stringshare_new(Eina_Stringshare *string)
 {
    Eina_FreeQ *fq;
@@ -164,7 +164,7 @@ eina_slstr_stringshare_new(Eina_Stringshare *string)
    return string;
 }
 
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_tmpstr_new(Eina_Tmpstr *string)
 {
    Eina_FreeQ *fq;
@@ -182,7 +182,7 @@ eina_slstr_tmpstr_new(Eina_Tmpstr *string)
    return string;
 }
 
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_strbuf_new(Eina_Strbuf *string)
 {
    Eina_FreeQ *fq;
@@ -206,7 +206,7 @@ error:
    return NULL;
 }
 
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_vasprintf_new(const char *fmt, va_list args)
 {
    Eina_FreeQ *fq;
@@ -227,7 +227,7 @@ eina_slstr_vasprintf_new(const char *fmt, va_list args)
    return str;
 }
 
-EAPI void
+EINA_API void
 eina_slstr_local_clear(void)
 {
    Eina_FreeQ *fq;

--- a/src/lib/eina/eina_slstr.h
+++ b/src/lib/eina/eina_slstr.h
@@ -48,7 +48,7 @@ typedef const char Eina_Slstr;
  *
  * @since 1.19
  */
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_copy_new(const char *string);
 
 /**
@@ -67,7 +67,7 @@ eina_slstr_copy_new(const char *string);
  *
  * @since 1.19
  */
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_copy_new_length(const char *string, size_t len);
 
 /**
@@ -84,7 +84,7 @@ eina_slstr_copy_new_length(const char *string, size_t len);
  *
  * @since 1.19
  */
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_steal_new(char *string);
 
 /**
@@ -101,7 +101,7 @@ eina_slstr_steal_new(char *string);
  *
  * @since 1.19
  */
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_stringshare_new(Eina_Stringshare *string);
 
 /**
@@ -118,7 +118,7 @@ eina_slstr_stringshare_new(Eina_Stringshare *string);
  *
  * @since 1.19
  */
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_tmpstr_new(Eina_Tmpstr *string);
 
 /**
@@ -139,7 +139,7 @@ eina_slstr_tmpstr_new(Eina_Tmpstr *string);
  *
  * @since 1.19
  */
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_strbuf_new(Eina_Strbuf *string);
 
 /**
@@ -151,7 +151,7 @@ eina_slstr_strbuf_new(Eina_Strbuf *string);
  *
  * @since 1.19
  */
-EAPI Eina_Slstr *
+EINA_API Eina_Slstr *
 eina_slstr_vasprintf_new(const char *fmt, va_list args);
 
 /**
@@ -191,7 +191,7 @@ eina_slstr_printf(const char *fmt, ...)
  *
  * @since 1.19
  */
-EAPI void
+EINA_API void
 eina_slstr_local_clear(void);
 #endif
 

--- a/src/lib/eina/eina_str.c
+++ b/src/lib/eina/eina_str.c
@@ -317,7 +317,7 @@ eina_str_split_full_helper(const char *str,
 *                                   API                                      *
 *============================================================================*/
 
-EAPI size_t
+EINA_API size_t
 eina_strlcpy(char *dst, const char *src, size_t siz)
 {
 #ifdef HAVE_STRLCPY
@@ -349,7 +349,7 @@ eina_strlcpy(char *dst, const char *src, size_t siz)
 #endif
 }
 
-EAPI size_t
+EINA_API size_t
 eina_strlcat(char *dst, const char *src, size_t siz)
 {
    char *d = dst;
@@ -383,7 +383,7 @@ eina_strlcat(char *dst, const char *src, size_t siz)
    return(dlen + (s - src)); /* count does not include NUL */
 }
 
-EAPI char *
+EINA_API char *
 eina_strftime(const char *format, const struct tm *tm)
 {
    const size_t flen = strlen(format);
@@ -416,7 +416,7 @@ eina_strftime(const char *format, const struct tm *tm)
    return NULL;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_str_has_prefix(const char *str, const char *prefix)
 {
    size_t str_len;
@@ -430,19 +430,19 @@ eina_str_has_prefix(const char *str, const char *prefix)
    return (strncmp(str, prefix, prefix_len) == 0);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_str_has_suffix(const char *str, const char *suffix)
 {
    return eina_str_has_suffix_helper(str, suffix, strcmp);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_str_has_extension(const char *str, const char *ext)
 {
    return eina_str_has_suffix_helper(str, ext, strcasecmp);
 }
 
-EAPI char **
+EINA_API char **
 eina_str_split_full(const char *str,
                     const char *delim,
                     int max_tokens,
@@ -452,13 +452,13 @@ eina_str_split_full(const char *str,
 }
 
 
-EAPI char **
+EINA_API char **
 eina_str_split(const char *str, const char *delim, int max_tokens)
 {
    return eina_str_split_full_helper(str, delim, max_tokens, NULL);
 }
 
-EAPI size_t
+EINA_API size_t
 eina_str_join_len(char *dst,
                   size_t size,
                   char sep,
@@ -505,7 +505,7 @@ eina_str_join_len(char *dst,
 }
 
 #ifdef HAVE_ICONV
-EAPI char *
+EINA_API char *
 eina_str_convert(const char *enc_from, const char *enc_to, const char *text)
 {
    iconv_t ic;
@@ -567,7 +567,7 @@ eina_str_convert(const char *enc_from, const char *enc_to, const char *text)
    return new_txt;
 }
 #else
-EAPI char *
+EINA_API char *
 eina_str_convert(const char *enc_from EINA_UNUSED,
                  const char *enc_to EINA_UNUSED,
                  const char *text EINA_UNUSED)
@@ -577,7 +577,7 @@ eina_str_convert(const char *enc_from EINA_UNUSED,
 #endif
 
 #ifdef HAVE_ICONV
-EAPI char *
+EINA_API char *
 eina_str_convert_len(const char *enc_from, const char *enc_to, const char *text, size_t len, size_t *retlen)
 {
    iconv_t ic;
@@ -640,7 +640,7 @@ eina_str_convert_len(const char *enc_from, const char *enc_to, const char *text,
    return new_txt;
 }
 #else
-EAPI char *
+EINA_API char *
 eina_str_convert_len(const char *enc_from EINA_UNUSED, const char *enc_to EINA_UNUSED, const char *text EINA_UNUSED, size_t len EINA_UNUSED, size_t *retlen)
 {
    if (retlen) *retlen = 0;
@@ -648,7 +648,7 @@ eina_str_convert_len(const char *enc_from EINA_UNUSED, const char *enc_to EINA_U
 }
 #endif
 
-EAPI char *
+EINA_API char *
 eina_str_escape(const char *str)
 {
    char *s2, *d;
@@ -698,7 +698,7 @@ eina_str_escape(const char *str)
    return s2;
 }
 
-EAPI void
+EINA_API void
 eina_str_tolower(char **str)
 {
    char *p;
@@ -709,7 +709,7 @@ eina_str_tolower(char **str)
       *p = tolower((unsigned char )(*p));
 }
 
-EAPI void
+EINA_API void
 eina_str_toupper(char **str)
 {
    char *p;
@@ -720,7 +720,7 @@ eina_str_toupper(char **str)
       *p = toupper((unsigned char)(*p));
 }
 
-EAPI unsigned char *
+EINA_API unsigned char *
 eina_memdup(unsigned char *mem, size_t size, Eina_Bool terminate)
 {
    unsigned char *ret;

--- a/src/lib/eina/eina_str.h
+++ b/src/lib/eina/eina_str.h
@@ -105,7 +105,7 @@
  * ensures @p dst is NULL-terminated even if no @c NULL byte is found in the first
  * @p siz bytes of src.
  */
-EAPI size_t          eina_strlcpy(char *dst, const char *src, size_t siz) EINA_ARG_NONNULL(1, 2);
+EINA_API size_t          eina_strlcpy(char *dst, const char *src, size_t siz) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a c-string.
@@ -122,7 +122,7 @@ EAPI size_t          eina_strlcpy(char *dst, const char *src, size_t siz) EINA_A
  * MIN(siz, strlen(initial dst)). If the returned value is greater or
  * equal than @p siz, truncation occurred.
  */
-EAPI size_t          eina_strlcat(char *dst, const char *src, size_t siz) EINA_ARG_NONNULL(1, 2);
+EINA_API size_t          eina_strlcat(char *dst, const char *src, size_t siz) EINA_ARG_NONNULL(1, 2);
 
 
 /**
@@ -136,7 +136,7 @@ EAPI size_t          eina_strlcat(char *dst, const char *src, size_t siz) EINA_A
  * @p prefix, #EINA_FALSE otherwise. If the length of @p prefix is
  * greater than @p str, #EINA_FALSE is returned.
  */
-EAPI Eina_Bool       eina_str_has_prefix(const char *str, const char *prefix) EINA_PURE EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool       eina_str_has_prefix(const char *str, const char *prefix) EINA_PURE EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Checks if the given string has the given suffix.
@@ -149,7 +149,7 @@ EAPI Eina_Bool       eina_str_has_prefix(const char *str, const char *prefix) EI
  * @p suffix, #EINA_FALSE otherwise. If the length of @p suffix is
  * greater than @p str, #EINA_FALSE is returned.
  */
-EAPI Eina_Bool       eina_str_has_suffix(const char *str, const char *suffix) EINA_PURE EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool       eina_str_has_suffix(const char *str, const char *suffix) EINA_PURE EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Checks if the given string has the given extension.
@@ -161,7 +161,7 @@ EAPI Eina_Bool       eina_str_has_suffix(const char *str, const char *suffix) EI
  * This function does the same as eina_str_has_suffix(), except it's case
  * insensitive.
  */
-EAPI Eina_Bool       eina_str_has_extension(const char *str, const char *ext) EINA_PURE EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool       eina_str_has_extension(const char *str, const char *ext) EINA_PURE EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Splits a string using a delimiter.
@@ -187,7 +187,7 @@ EAPI Eina_Bool       eina_str_has_extension(const char *str, const char *ext) EI
  * @note If you need the number of elements in the returned array see
  * eina_str_split_full().
  */
-EAPI char          **eina_str_split(const char *string, const char *delimiter, int max_tokens) EINA_ARG_NONNULL(1, 2) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API char          **eina_str_split(const char *string, const char *delimiter, int max_tokens) EINA_ARG_NONNULL(1, 2) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Splits a string using a delimiter and returns number of elements.
@@ -220,7 +220,7 @@ EAPI char          **eina_str_split(const char *string, const char *delimiter, i
  *
  * @see eina_str_split()
  */
-EAPI char          **eina_str_split_full(const char *string, const char *delimiter, int max_tokens, unsigned int *elements) EINA_ARG_NONNULL(1, 2, 4) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API char          **eina_str_split_full(const char *string, const char *delimiter, int max_tokens, unsigned int *elements) EINA_ARG_NONNULL(1, 2, 4) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 
 /**
@@ -249,7 +249,7 @@ EAPI char          **eina_str_split_full(const char *string, const char *delimit
  * @see eina_str_join()
  * @see eina_str_join_static()
  */
-EAPI size_t          eina_str_join_len(char *dst, size_t size, char sep, const char *a, size_t a_len, const char *b, size_t b_len) EINA_ARG_NONNULL(1, 4, 6);
+EINA_API size_t          eina_str_join_len(char *dst, size_t size, char sep, const char *a, size_t a_len, const char *b, size_t b_len) EINA_ARG_NONNULL(1, 4, 6);
 
 
 /**
@@ -269,7 +269,7 @@ EAPI size_t          eina_str_join_len(char *dst, size_t size, char sep, const c
  * @warning This function is guaranteed to break when '\0' characters are in @p text.
  * DO NOT USE THIS FUNCTION IF YOUR TEXT CONTAINS NON-TERMINATING '\0' CHARACTERS.
  */
-EAPI char           *eina_str_convert(const char *enc_from, const char *enc_to, const char *text) EINA_WARN_UNUSED_RESULT EINA_MALLOC EINA_ARG_NONNULL(1, 2, 3);
+EINA_API char           *eina_str_convert(const char *enc_from, const char *enc_to, const char *text) EINA_WARN_UNUSED_RESULT EINA_MALLOC EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief Uses Iconv to convert a text string from one encoding to another.
@@ -289,7 +289,7 @@ EAPI char           *eina_str_convert(const char *enc_from, const char *enc_to, 
  *
  * @since 1.8
  */
-EAPI char           *eina_str_convert_len(const char *enc_from, const char *enc_to, const char *text, size_t len, size_t *retlen) EINA_WARN_UNUSED_RESULT EINA_MALLOC EINA_ARG_NONNULL(1, 2, 3);
+EINA_API char           *eina_str_convert_len(const char *enc_from, const char *enc_to, const char *text, size_t len, size_t *retlen) EINA_WARN_UNUSED_RESULT EINA_MALLOC EINA_ARG_NONNULL(1, 2, 3);
 
 
 /**
@@ -304,7 +304,7 @@ EAPI char           *eina_str_convert_len(const char *enc_from, const char *enc_
  * failure. When not used anymore, the
  * returned value must be freed.
  */
-EAPI char           *eina_str_escape(const char *str) EINA_WARN_UNUSED_RESULT EINA_MALLOC EINA_ARG_NONNULL(1);
+EINA_API char           *eina_str_escape(const char *str) EINA_WARN_UNUSED_RESULT EINA_MALLOC EINA_ARG_NONNULL(1);
 
 
 /**
@@ -316,7 +316,7 @@ EAPI char           *eina_str_escape(const char *str) EINA_WARN_UNUSED_RESULT EI
  * in [A-Z] to lowercase. If @p str is @c NULL or is an empty string,
  * this function does nothing.
  */
-EAPI void            eina_str_tolower(char **str);
+EINA_API void            eina_str_tolower(char **str);
 
 /**
  * @brief Uppercases all the characters in range [a-z] in the given string.
@@ -327,7 +327,7 @@ EAPI void            eina_str_tolower(char **str);
  * in [a-z] to uppercase. If @p str is @c NULL or is an empty string,
  * this function does nothing.
  */
-EAPI void            eina_str_toupper(char **str);
+EINA_API void            eina_str_toupper(char **str);
 
 static inline size_t eina_str_join(char *dst, size_t size, char sep, const char *a, const char *b) EINA_ARG_NONNULL(1, 4, 5);
 
@@ -359,7 +359,7 @@ static inline size_t eina_strlen_bounded(const char *str, size_t maxlen) EINA_PU
  * @return The copied memory, must be freed
  * @since 1.13
  */
-EAPI unsigned char *eina_memdup(unsigned char *mem, size_t size, Eina_Bool terminate);
+EINA_API unsigned char *eina_memdup(unsigned char *mem, size_t size, Eina_Bool terminate);
 
 /**
  * @brief Creates and update the buffer based on strftime output.
@@ -385,7 +385,7 @@ EAPI unsigned char *eina_memdup(unsigned char *mem, size_t size, Eina_Bool termi
  *
  * @since 1.17.0
  */
-EAPI char *eina_strftime(const char *format, const struct tm *tm);
+EINA_API char *eina_strftime(const char *format, const struct tm *tm);
 
 static inline size_t eina_strlen_bounded(const char *str, size_t maxlen);
 

--- a/src/lib/eina/eina_strbuf.c
+++ b/src/lib/eina/eina_strbuf.c
@@ -82,7 +82,7 @@ static const char __STRBUF_MAGIC_STR[] = "Eina Strbuf";
  *============================================================================*/
 
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_strbuf_append_printf(Eina_Strbuf *buf, const char *fmt, ...)
 {
    va_list args;
@@ -102,7 +102,7 @@ eina_strbuf_append_printf(Eina_Strbuf *buf, const char *fmt, ...)
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_strbuf_append_vprintf(Eina_Strbuf *buf, const char *fmt, va_list args)
 {
    char *str;
@@ -119,7 +119,7 @@ eina_strbuf_append_vprintf(Eina_Strbuf *buf, const char *fmt, va_list args)
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_strbuf_insert_printf(Eina_Strbuf *buf, const char *fmt, size_t pos, ...)
 {
    va_list args;
@@ -139,7 +139,7 @@ eina_strbuf_insert_printf(Eina_Strbuf *buf, const char *fmt, size_t pos, ...)
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_strbuf_insert_vprintf(Eina_Strbuf *buf,
                            const char *fmt,
                            size_t pos,
@@ -159,7 +159,7 @@ eina_strbuf_insert_vprintf(Eina_Strbuf *buf,
    return ret;
 }
 
-EAPI void
+EINA_API void
 eina_strbuf_trim(Eina_Strbuf *buf)
 {
    unsigned char *c = buf->buf;
@@ -175,7 +175,7 @@ eina_strbuf_trim(Eina_Strbuf *buf)
    ((unsigned char *)buf->buf)[buf->len] = '\0';
 }
 
-EAPI void
+EINA_API void
 eina_strbuf_ltrim(Eina_Strbuf *buf)
 {
    unsigned char *c = buf->buf;
@@ -189,7 +189,7 @@ eina_strbuf_ltrim(Eina_Strbuf *buf)
    ((unsigned char *)buf->buf)[buf->len] = '\0';
 }
 
-EAPI void
+EINA_API void
 eina_strbuf_rtrim(Eina_Strbuf *buf)
 {
    while (buf->len > 0 && isspace(((unsigned char*)(buf->buf))[buf->len - 1]))
@@ -197,7 +197,7 @@ eina_strbuf_rtrim(Eina_Strbuf *buf)
    ((unsigned char *)buf->buf)[buf->len] = '\0';
 }
 
-EAPI void
+EINA_API void
 eina_strbuf_tolower(Eina_Strbuf *buf)
 {
    if (!buf || !(buf->buf)) return;
@@ -205,7 +205,7 @@ eina_strbuf_tolower(Eina_Strbuf *buf)
    eina_str_tolower((char **)&(buf->buf));
 }
 
-EAPI Eina_Strbuf *
+EINA_API Eina_Strbuf *
 eina_strbuf_substr_get(Eina_Strbuf *buf, size_t pos, size_t len)
 {
    char *str;
@@ -220,7 +220,7 @@ eina_strbuf_substr_get(Eina_Strbuf *buf, size_t pos, size_t len)
    return eina_strbuf_manage_new(str);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_strbuf_append_strftime(Eina_Strbuf *buf, const char *format, const struct tm *tm)
 {
    char *outputbuf;
@@ -234,7 +234,7 @@ eina_strbuf_append_strftime(Eina_Strbuf *buf, const char *format, const struct t
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_strbuf_insert_strftime(Eina_Strbuf *buf, const char *format, const struct tm *tm, size_t pos)
 {
    char *outputbuf;

--- a/src/lib/eina/eina_strbuf.h
+++ b/src/lib/eina/eina_strbuf.h
@@ -79,7 +79,7 @@ typedef struct _Eina_Strbuf Eina_Strbuf;
  * @see eina_strbuf_append()
  * @see eina_strbuf_string_get()
  */
-EAPI Eina_Strbuf *eina_strbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Strbuf *eina_strbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates a new string buffer using the passed string.
@@ -98,7 +98,7 @@ EAPI Eina_Strbuf *eina_strbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
  *
  * @since 1.1.0
  */
-EAPI Eina_Strbuf *eina_strbuf_manage_new(char *str) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Strbuf *eina_strbuf_manage_new(char *str) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates a new string buffer using the passed string.
@@ -116,7 +116,7 @@ EAPI Eina_Strbuf *eina_strbuf_manage_new(char *str) EINA_MALLOC EINA_WARN_UNUSED
  *
  * @since 1.2.0
  */
-EAPI Eina_Strbuf *eina_strbuf_manage_new_length(char *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Strbuf *eina_strbuf_manage_new_length(char *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates a new string buffer using the passed string.
@@ -137,7 +137,7 @@ EAPI Eina_Strbuf *eina_strbuf_manage_new_length(char *str, size_t length) EINA_M
  *
  * @since 1.9.0
  */
-EAPI Eina_Strbuf *eina_strbuf_manage_read_only_new_length(const char *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Strbuf *eina_strbuf_manage_read_only_new_length(const char *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Frees a string buffer.
@@ -147,7 +147,7 @@ EAPI Eina_Strbuf *eina_strbuf_manage_read_only_new_length(const char *str, size_
  * This function frees the memory of @p buf. @p buf must have been
  * created by eina_strbuf_new().
  */
-EAPI void eina_strbuf_free(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_strbuf_free(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Resets a string buffer.
@@ -157,7 +157,7 @@ EAPI void eina_strbuf_free(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
  * This function resets @p buf: the buffer len is set to 0, and the
  * string data is set to '\\0'. No memory is freed.
  */
-EAPI void eina_strbuf_reset(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_strbuf_reset(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Appends a string to a buffer, reallocating as necessary.
@@ -174,7 +174,7 @@ EAPI void eina_strbuf_reset(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
  * @see eina_strbuf_append()
  * @see eina_strbuf_append_length()
  */
-EAPI Eina_Bool eina_strbuf_append(Eina_Strbuf *buf, const char *str) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_append(Eina_Strbuf *buf, const char *str) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends an escaped string to a buffer, reallocating as necessary.
@@ -185,7 +185,7 @@ EAPI Eina_Bool eina_strbuf_append(Eina_Strbuf *buf, const char *str) EINA_ARG_NO
  *
  * This function escapes and then appends the string @p str to @p buf.
  */
-EAPI Eina_Bool eina_strbuf_append_escaped(Eina_Strbuf *buf, const char *str) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_append_escaped(Eina_Strbuf *buf, const char *str) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a string to a buffer, reallocating as necessary,
@@ -206,7 +206,7 @@ EAPI Eina_Bool eina_strbuf_append_escaped(Eina_Strbuf *buf, const char *str) EIN
  * @see eina_strbuf_append()
  * @see eina_strbuf_append_length()
  */
-EAPI Eina_Bool eina_strbuf_append_n(Eina_Strbuf *buf, const char *str, size_t maxlen) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_append_n(Eina_Strbuf *buf, const char *str, size_t maxlen) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a string of exact length to a buffer, reallocating as
@@ -226,7 +226,7 @@ EAPI Eina_Bool eina_strbuf_append_n(Eina_Strbuf *buf, const char *str, size_t ma
  * @see eina_strbuf_append()
  * @see eina_strbuf_append_n()
  */
-EAPI Eina_Bool eina_strbuf_append_length(Eina_Strbuf *buf, const char *str, size_t length) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_append_length(Eina_Strbuf *buf, const char *str, size_t length) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Append a slice to a buffer, reallocating as necessary.
@@ -239,7 +239,7 @@ EAPI Eina_Bool eina_strbuf_append_length(Eina_Strbuf *buf, const char *str, size
  *
  * @since 1.19.0
  */
-EAPI Eina_Bool eina_strbuf_append_slice(Eina_Strbuf *buf, const Eina_Slice slice) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_strbuf_append_slice(Eina_Strbuf *buf, const Eina_Slice slice) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Appends an Eina_Strbuf to a buffer, reallocating as necessary.
@@ -258,7 +258,7 @@ EAPI Eina_Bool eina_strbuf_append_slice(Eina_Strbuf *buf, const Eina_Slice slice
  *
  * @since 1.9.0
  */
-EAPI Eina_Bool eina_strbuf_append_buffer(Eina_Strbuf *buf, const Eina_Strbuf *data) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_append_buffer(Eina_Strbuf *buf, const Eina_Strbuf *data) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a character to a string buffer, reallocating as
@@ -270,7 +270,7 @@ EAPI Eina_Bool eina_strbuf_append_buffer(Eina_Strbuf *buf, const Eina_Strbuf *da
  *
  * This function appends @p c to @p buf.
  */
-EAPI Eina_Bool eina_strbuf_append_char(Eina_Strbuf *buf, char c) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_strbuf_append_char(Eina_Strbuf *buf, char c) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Appends data elements to a buffer using printf-style formatting.
@@ -287,7 +287,7 @@ EAPI Eina_Bool eina_strbuf_append_char(Eina_Strbuf *buf, char c) EINA_ARG_NONNUL
  *
  * @see eina_strbuf_append()
  */
-EAPI Eina_Bool eina_strbuf_append_printf(Eina_Strbuf *buf, const char *fmt, ...) EINA_ARG_NONNULL(1, 2) EINA_PRINTF(2, 3);
+EINA_API Eina_Bool eina_strbuf_append_printf(Eina_Strbuf *buf, const char *fmt, ...) EINA_ARG_NONNULL(1, 2) EINA_PRINTF(2, 3);
 
 /**
  * @brief Appends data elements to a string buffer using a va_list.
@@ -299,7 +299,7 @@ EAPI Eina_Bool eina_strbuf_append_printf(Eina_Strbuf *buf, const char *fmt, ...)
  *
  * @see eina_strbuf_append_printf()
  */
-EAPI Eina_Bool eina_strbuf_append_vprintf(Eina_Strbuf *buf, const char *fmt, va_list args) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_append_vprintf(Eina_Strbuf *buf, const char *fmt, va_list args) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts a string into a buffer, reallocating as necessary.
@@ -314,7 +314,7 @@ EAPI Eina_Bool eina_strbuf_append_vprintf(Eina_Strbuf *buf, const char *fmt, va_
  * eina_strbuf_insert_length(). If the length is known beforehand,
  * consider using that variant.
  */
-EAPI Eina_Bool eina_strbuf_insert(Eina_Strbuf *buf, const char *str, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_insert(Eina_Strbuf *buf, const char *str, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts an escaped string into a buffer, reallocating as
@@ -328,7 +328,7 @@ EAPI Eina_Bool eina_strbuf_insert(Eina_Strbuf *buf, const char *str, size_t pos)
  * This function escapes and inserts the string @p str into @p buf at
  * position @p pos.
  */
-EAPI Eina_Bool eina_strbuf_insert_escaped(Eina_Strbuf *buf, const char *str, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_insert_escaped(Eina_Strbuf *buf, const char *str, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts a string of a maximum length into a buffer, reallocating as necessary.
@@ -347,7 +347,7 @@ EAPI Eina_Bool eina_strbuf_insert_escaped(Eina_Strbuf *buf, const char *str, siz
  * should then be checked so that it is greater than the size of
  * @p str).
  */
-EAPI Eina_Bool eina_strbuf_insert_n(Eina_Strbuf *buf, const char *str, size_t maxlen, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_insert_n(Eina_Strbuf *buf, const char *str, size_t maxlen, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts a string of an exact length into a buffer, reallocating as necessary.
@@ -367,7 +367,7 @@ EAPI Eina_Bool eina_strbuf_insert_n(Eina_Strbuf *buf, const char *str, size_t ma
  * @see eina_strbuf_insert()
  * @see eina_strbuf_insert_n()
  */
-EAPI Eina_Bool eina_strbuf_insert_length(Eina_Strbuf *buf, const char *str, size_t length, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_insert_length(Eina_Strbuf *buf, const char *str, size_t length, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Insert a slice into a buffer, reallocating as necessary.
@@ -381,7 +381,7 @@ EAPI Eina_Bool eina_strbuf_insert_length(Eina_Strbuf *buf, const char *str, size
  *
  * @since 1.19.0
  */
-EAPI Eina_Bool eina_strbuf_insert_slice(Eina_Strbuf *buf, const Eina_Slice slice, size_t pos) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_strbuf_insert_slice(Eina_Strbuf *buf, const Eina_Slice slice, size_t pos) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Inserts a character into a string buffer, reallocating as
@@ -394,7 +394,7 @@ EAPI Eina_Bool eina_strbuf_insert_slice(Eina_Strbuf *buf, const Eina_Slice slice
  *
  * This function inserts @p c into @p buf at position @p pos.
  */
-EAPI Eina_Bool eina_strbuf_insert_char(Eina_Strbuf *buf, char c, size_t pos) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_strbuf_insert_char(Eina_Strbuf *buf, char c, size_t pos) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Inserts data elements into a buffer using printf-style formatting.
@@ -409,7 +409,7 @@ EAPI Eina_Bool eina_strbuf_insert_char(Eina_Strbuf *buf, char c, size_t pos) EIN
  * the position @p pos. @p fmt must be of a valid format for printf family of
  * functions.
  */
-EAPI Eina_Bool eina_strbuf_insert_printf(Eina_Strbuf *buf, const char *fmt, size_t pos, ...) EINA_ARG_NONNULL(1, 2) EINA_PRINTF(2, 4);
+EINA_API Eina_Bool eina_strbuf_insert_printf(Eina_Strbuf *buf, const char *fmt, size_t pos, ...) EINA_ARG_NONNULL(1, 2) EINA_PRINTF(2, 4);
 
 /**
  * @brief Inserts data elements into a buffer using a va_list.
@@ -422,7 +422,7 @@ EAPI Eina_Bool eina_strbuf_insert_printf(Eina_Strbuf *buf, const char *fmt, size
  *
  * @see eina_strbuf_insert_printf
  */
-EAPI Eina_Bool eina_strbuf_insert_vprintf(Eina_Strbuf *buf, const char *fmt, size_t pos, va_list args) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_strbuf_insert_vprintf(Eina_Strbuf *buf, const char *fmt, size_t pos, va_list args) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @def eina_strbuf_prepend(buf, str)
@@ -525,7 +525,7 @@ EAPI Eina_Bool eina_strbuf_insert_vprintf(Eina_Strbuf *buf, const char *fmt, siz
  * in bytes.
  */
 
-EAPI Eina_Bool eina_strbuf_remove(Eina_Strbuf *buf, size_t start, size_t end) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_strbuf_remove(Eina_Strbuf *buf, size_t start, size_t end) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Retrieves a pointer to the contents of a string buffer.
@@ -541,7 +541,7 @@ EAPI Eina_Bool eina_strbuf_remove(Eina_Strbuf *buf, size_t start, size_t end) EI
  *
  * @see eina_strbuf_string_steal()
  */
-EAPI const char *eina_strbuf_string_get(const Eina_Strbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API const char *eina_strbuf_string_get(const Eina_Strbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Steals the contents of a string buffer.
@@ -556,7 +556,7 @@ EAPI const char *eina_strbuf_string_get(const Eina_Strbuf *buf) EINA_ARG_NONNULL
  *
  * @see eina_strbuf_string_get()
  */
-EAPI char *eina_strbuf_string_steal(Eina_Strbuf *buf) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API char *eina_strbuf_string_steal(Eina_Strbuf *buf) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Frees the contents of a string buffer but not the buffer.
@@ -566,7 +566,7 @@ EAPI char *eina_strbuf_string_steal(Eina_Strbuf *buf) EINA_MALLOC EINA_WARN_UNUS
  * This function frees the string contained in @p buf without freeing
  * @p buf.
  */
-EAPI void eina_strbuf_string_free(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_strbuf_string_free(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Retrieves the length of the string buffer's content.
@@ -576,7 +576,7 @@ EAPI void eina_strbuf_string_free(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
  *
  * This function returns the length of @p buf.
  */
-EAPI size_t eina_strbuf_length_get(const Eina_Strbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API size_t eina_strbuf_length_get(const Eina_Strbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Replaces a substring in the buffer with another string.
@@ -590,7 +590,7 @@ EAPI size_t eina_strbuf_length_get(const Eina_Strbuf *buf) EINA_ARG_NONNULL(1) E
  * This function replaces the n-th occurrence of @p str in @p buf with
  * @p with.
  */
-EAPI Eina_Bool eina_strbuf_replace(Eina_Strbuf *buf, const char *str, const char *with, unsigned int n) EINA_ARG_NONNULL(1, 2, 3);
+EINA_API Eina_Bool eina_strbuf_replace(Eina_Strbuf *buf, const char *str, const char *with, unsigned int n) EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @def eina_strbuf_replace_first(buf, str, with)
@@ -618,7 +618,7 @@ EAPI Eina_Bool eina_strbuf_replace(Eina_Strbuf *buf, const char *str, const char
  * This function replaces all the occurrences of @p str in @p buf with
  * the string @p with.
  */
-EAPI int eina_strbuf_replace_all(Eina_Strbuf *buf, const char *str, const char *with) EINA_ARG_NONNULL(1, 2, 3);
+EINA_API int eina_strbuf_replace_all(Eina_Strbuf *buf, const char *str, const char *with) EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief Trims the string buffer.
@@ -628,7 +628,7 @@ EAPI int eina_strbuf_replace_all(Eina_Strbuf *buf, const char *str, const char *
  * This function removes whitespace at the beginning and end of the
  * buffer's string.
  */
-EAPI void eina_strbuf_trim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_strbuf_trim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Left trims the string buffer.
@@ -638,7 +638,7 @@ EAPI void eina_strbuf_trim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
  * This function removes whitespace at the beginning of the buffer's
  * string.
  */
-EAPI void eina_strbuf_ltrim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_strbuf_ltrim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Right trims the string buffer.
@@ -647,7 +647,7 @@ EAPI void eina_strbuf_ltrim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
  *
  * This function removes whitespace at the end of the buffer's string.
  */
-EAPI void eina_strbuf_rtrim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_strbuf_rtrim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Converts the string to lower case.
@@ -659,7 +659,7 @@ EAPI void eina_strbuf_rtrim(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
  *
  * @since 1.17
  */
-EAPI void eina_strbuf_tolower(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_strbuf_tolower(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Obtains substring from a source string buffer.
@@ -676,7 +676,7 @@ EAPI void eina_strbuf_tolower(Eina_Strbuf *buf) EINA_ARG_NONNULL(1);
  *
  * @since 1.17
  */
-EAPI Eina_Strbuf * eina_strbuf_substr_get(Eina_Strbuf *buf, size_t pos, size_t len) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Strbuf * eina_strbuf_substr_get(Eina_Strbuf *buf, size_t pos, size_t len) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets a read-only slice of the buffer contents.
@@ -687,7 +687,7 @@ EAPI Eina_Strbuf * eina_strbuf_substr_get(Eina_Strbuf *buf, size_t pos, size_t l
  *
  * @since 1.19
  */
-EAPI Eina_Slice eina_strbuf_slice_get(const Eina_Strbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Slice eina_strbuf_slice_get(const Eina_Strbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets a read-write slice of the buffer contents.
@@ -699,7 +699,7 @@ EAPI Eina_Slice eina_strbuf_slice_get(const Eina_Strbuf *buf) EINA_WARN_UNUSED_R
  *
  * @since 1.19.0
  */
-EAPI Eina_Rw_Slice eina_strbuf_rw_slice_get(const Eina_Strbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Rw_Slice eina_strbuf_rw_slice_get(const Eina_Strbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Frees the buffer, returning its old contents.
@@ -710,7 +710,7 @@ EAPI Eina_Rw_Slice eina_strbuf_rw_slice_get(const Eina_Strbuf *buf) EINA_WARN_UN
  *
  * @since 1.19
  */
-EAPI char* eina_strbuf_release(Eina_Strbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API char* eina_strbuf_release(Eina_Strbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Appends a strftime-style timestamp to the buffer.
@@ -738,7 +738,7 @@ EAPI char* eina_strbuf_release(Eina_Strbuf *buf) EINA_WARN_UNUSED_RESULT EINA_AR
  *
  * @since 1.21
  */
-EAPI Eina_Bool eina_strbuf_append_strftime(Eina_Strbuf *buf, const char *fmt, const struct tm *tm);
+EINA_API Eina_Bool eina_strbuf_append_strftime(Eina_Strbuf *buf, const char *fmt, const struct tm *tm);
 
 /**
  * @brief Inserts a strftime-style timestamp into the buffer.
@@ -767,7 +767,7 @@ EAPI Eina_Bool eina_strbuf_append_strftime(Eina_Strbuf *buf, const char *fmt, co
  *
  * @since 1.21
  */
-EAPI Eina_Bool eina_strbuf_insert_strftime(Eina_Strbuf *buf, const char *fmt, const struct tm *tm, size_t pos);
+EINA_API Eina_Bool eina_strbuf_insert_strftime(Eina_Strbuf *buf, const char *fmt, const struct tm *tm, size_t pos);
 
 /**
  * @def eina_strbuf_prepend_strftime(buf, fmt, tm)

--- a/src/lib/eina/eina_strbuf_common.c
+++ b/src/lib/eina/eina_strbuf_common.c
@@ -922,7 +922,7 @@ eina_strbuf_common_rw_slice_get(const Eina_Strbuf *buf)
  */
 
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_strbuf_replace(Eina_Strbuf *buf,
                     const char *str,
                     const char *with,
@@ -976,7 +976,7 @@ eina_strbuf_replace(Eina_Strbuf *buf,
    return EINA_TRUE;
 }
 
-EAPI int
+EINA_API int
 eina_strbuf_replace_all(Eina_Strbuf *buf, const char *str, const char *with)
 {
    size_t len1, len2, len;

--- a/src/lib/eina/eina_strbuf_template_c.x
+++ b/src/lib/eina/eina_strbuf_template_c.x
@@ -22,7 +22,7 @@
  *                                   API                                      *
  *============================================================================*/
 
-EAPI _STRBUF_STRUCT_NAME *
+EINA_API _STRBUF_STRUCT_NAME *
 _FUNC_EXPAND(manage_new)(_STRBUF_DATA_TYPE *str)
 {
    _STRBUF_STRUCT_NAME *buf = eina_strbuf_common_manage_new(_STRBUF_CSIZE,
@@ -31,14 +31,14 @@ _FUNC_EXPAND(manage_new)(_STRBUF_DATA_TYPE *str)
    return buf;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(append)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *str)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_append(_STRBUF_CSIZE, buf, (const void *) str, _STRBUF_STRLEN_FUNC(str));
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(append_escaped)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *str)
 {
    _STRBUF_DATA_TYPE *esc;
@@ -56,21 +56,21 @@ _FUNC_EXPAND(append_escaped)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(append_n)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *str, size_t maxlen)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_append_n(_STRBUF_CSIZE, buf, (const void *) str, _STRBUF_STRLEN_FUNC(str), maxlen);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(insert)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *str, size_t pos)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);
    return eina_strbuf_common_insert(_STRBUF_CSIZE, buf, (const void *) str, _STRBUF_STRLEN_FUNC(str), pos);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(insert_escaped)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *str, size_t pos)
 {
    _STRBUF_DATA_TYPE *esc;
@@ -88,7 +88,7 @@ _FUNC_EXPAND(insert_escaped)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 _FUNC_EXPAND(insert_n)(_STRBUF_STRUCT_NAME *buf, const _STRBUF_DATA_TYPE *str, size_t maxlen, size_t pos)
 {
    EINA_MAGIC_CHECK_STRBUF(buf, EINA_FALSE);

--- a/src/lib/eina/eina_stringshare.c
+++ b/src/lib/eina/eina_stringshare.c
@@ -532,7 +532,7 @@ eina_stringshare_shutdown(void)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI void
+EINA_API void
 eina_stringshare_del(Eina_Stringshare *str)
 {
    int slen;
@@ -572,7 +572,7 @@ eina_stringshare_del(Eina_Stringshare *str)
      CRI("EEEK trying to del non-shared stringshare \"%s\"", str);
 }
 
-EAPI Eina_Stringshare *
+EINA_API Eina_Stringshare *
 eina_stringshare_add_length(const char *str, unsigned int slen)
 {
    if (!str)
@@ -605,14 +605,14 @@ eina_stringshare_add_length(const char *str, unsigned int slen)
                                        sizeof(char), sizeof(char));
 }
 
-EAPI Eina_Stringshare *
+EINA_API Eina_Stringshare *
 eina_stringshare_add(const char *str)
 {
    if (!str) return NULL;
    return eina_stringshare_add_length(str, strlen(str));
 }
 
-EAPI Eina_Stringshare *
+EINA_API Eina_Stringshare *
 eina_stringshare_printf(const char *fmt, ...)
 {
    va_list args;
@@ -636,7 +636,7 @@ eina_stringshare_printf(const char *fmt, ...)
    return ret;
 }
 
-EAPI Eina_Stringshare *
+EINA_API Eina_Stringshare *
 eina_stringshare_vprintf(const char *fmt, va_list args)
 {
    char *tmp = NULL;
@@ -657,7 +657,7 @@ eina_stringshare_vprintf(const char *fmt, va_list args)
    return ret;
 }
 
-EAPI Eina_Stringshare *
+EINA_API Eina_Stringshare *
 eina_stringshare_nprintf(unsigned int len, const char *fmt, ...)
 {
    va_list args;
@@ -684,7 +684,7 @@ eina_stringshare_nprintf(unsigned int len, const char *fmt, ...)
    return eina_stringshare_add_length(tmp, size);
 }
 
-EAPI Eina_Stringshare *
+EINA_API Eina_Stringshare *
 eina_stringshare_ref(Eina_Stringshare *str)
 {
    int slen;
@@ -725,7 +725,7 @@ eina_stringshare_ref(Eina_Stringshare *str)
    return eina_share_common_ref(stringshare_share, str);
 }
 
-EAPI int
+EINA_API int
 eina_stringshare_strlen(Eina_Stringshare *str)
 {
    int len;
@@ -750,7 +750,7 @@ eina_stringshare_strlen(Eina_Stringshare *str)
    return len;
 }
 
-EAPI void
+EINA_API void
 eina_stringshare_dump(void)
 {
    eina_share_common_dump(stringshare_share,

--- a/src/lib/eina/eina_stringshare.h
+++ b/src/lib/eina/eina_stringshare.h
@@ -194,7 +194,7 @@ typedef const char Eina_Stringshare;
  *
  * @see eina_share_common_add()
  */
-EAPI Eina_Stringshare  *eina_stringshare_add_length(const char *str, unsigned int slen) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Stringshare  *eina_stringshare_add_length(const char *str, unsigned int slen) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Retrieves an instance of a string for use in a program.
@@ -214,7 +214,7 @@ EAPI Eina_Stringshare  *eina_stringshare_add_length(const char *str, unsigned in
  *
  * @see eina_stringshare_add_length()
  */
-EAPI Eina_Stringshare  *eina_stringshare_add(const char *str) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Stringshare  *eina_stringshare_add(const char *str) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Retrieves an instance of a string for use in a program
@@ -235,7 +235,7 @@ EAPI Eina_Stringshare  *eina_stringshare_add(const char *str) EINA_WARN_UNUSED_R
  *
  * @see eina_stringshare_nprintf()
  */
-EAPI Eina_Stringshare  *eina_stringshare_printf(const char *fmt, ...) EINA_WARN_UNUSED_RESULT EINA_PRINTF(1, 2);
+EINA_API Eina_Stringshare  *eina_stringshare_printf(const char *fmt, ...) EINA_WARN_UNUSED_RESULT EINA_PRINTF(1, 2);
 
 /**
  * @brief Retrieves an instance of a string for use in a program
@@ -257,7 +257,7 @@ EAPI Eina_Stringshare  *eina_stringshare_printf(const char *fmt, ...) EINA_WARN_
  *
  * @see eina_stringshare_nprintf()
  */
-EAPI Eina_Stringshare  *eina_stringshare_vprintf(const char *fmt, va_list args) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Stringshare  *eina_stringshare_vprintf(const char *fmt, va_list args) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Retrieves an instance of a string for use in a program
@@ -278,7 +278,7 @@ EAPI Eina_Stringshare  *eina_stringshare_vprintf(const char *fmt, va_list args) 
  *
  * @see eina_stringshare_printf()
  */
-EAPI Eina_Stringshare  *eina_stringshare_nprintf(unsigned int len, const char *fmt, ...) EINA_WARN_UNUSED_RESULT EINA_PRINTF(2, 3);
+EINA_API Eina_Stringshare  *eina_stringshare_nprintf(unsigned int len, const char *fmt, ...) EINA_WARN_UNUSED_RESULT EINA_PRINTF(2, 3);
 
 /**
  * Increment references of the given shared string.
@@ -294,7 +294,7 @@ EAPI Eina_Stringshare  *eina_stringshare_nprintf(unsigned int len, const char *f
  *
  * There is no unref since this is the work of eina_share_common_del().
  */
-EAPI Eina_Stringshare  *eina_stringshare_ref(Eina_Stringshare *str);
+EINA_API Eina_Stringshare  *eina_stringshare_ref(Eina_Stringshare *str);
 
 /**
  * @brief Notes that the given string has lost an instance.
@@ -309,7 +309,7 @@ EAPI Eina_Stringshare  *eina_stringshare_ref(Eina_Stringshare *str);
  * @note If the given pointer is not shared, bad things will happen, likely a
  * segmentation fault.
  */
-EAPI void               eina_stringshare_del(Eina_Stringshare *str);
+EINA_API void               eina_stringshare_del(Eina_Stringshare *str);
 
 /**
  * @brief Notes that the given string @b must be shared.
@@ -324,7 +324,7 @@ EAPI void               eina_stringshare_del(Eina_Stringshare *str);
  * @note If the given pointer is not shared, bad things will happen, likely a
  * segmentation fault. If in doubt, try strlen().
  */
-EAPI int                eina_stringshare_strlen(Eina_Stringshare *str) EINA_PURE EINA_WARN_UNUSED_RESULT;
+EINA_API int                eina_stringshare_strlen(Eina_Stringshare *str) EINA_PURE EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Dumps the contents of the share_common.
@@ -332,7 +332,7 @@ EAPI int                eina_stringshare_strlen(Eina_Stringshare *str) EINA_PURE
  * This function dumps all strings in the share_common to stdout with a
  * DDD: prefix per line and a memory usage summary.
  */
-EAPI void               eina_stringshare_dump(void);
+EINA_API void               eina_stringshare_dump(void);
 
 static inline Eina_Bool eina_stringshare_replace(Eina_Stringshare **p_str, const char *news) EINA_ARG_NONNULL(1);
 static inline Eina_Bool eina_stringshare_replace_length(Eina_Stringshare **p_str, const char *news, unsigned int slen) EINA_ARG_NONNULL(1);

--- a/src/lib/eina/eina_thread.c
+++ b/src/lib/eina/eina_thread.c
@@ -40,21 +40,21 @@
 #endif
 # include <string.h>
 
-EAPI const void *EINA_THREAD_JOIN_CANCELED = EINA_THREAD_CANCELED;
+EINA_API const void *EINA_THREAD_JOIN_CANCELED = EINA_THREAD_CANCELED;
 
-EAPI Eina_Thread
+EINA_API Eina_Thread
 eina_thread_self(void)
 {
    return _eina_thread_self();
 }
 
-EAPI Eina_ThreadId
+EINA_API Eina_ThreadId
 eina_thread_self_id(void)
 {
    return _eina_thread_self_id();
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_thread_equal(Eina_Thread t1, Eina_Thread t2)
 {
    return _eina_thread_equal(t1, t2);
@@ -82,7 +82,7 @@ _eina_internal_call(void *context)
 
    return r;
 }
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_thread_create(Eina_Thread *t,
                    Eina_Thread_Priority prio, int affinity,
                    Eina_Thread_Cb func, const void *data)
@@ -109,13 +109,13 @@ eina_thread_create(Eina_Thread *t,
    return EINA_FALSE;
 }
 
-EAPI void *
+EINA_API void *
 eina_thread_join(Eina_Thread t)
 {
    return _eina_thread_join(t);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_thread_name_set(Eina_Thread t, const char *name)
 {
 #if defined(EINA_HAVE_PTHREAD_SETNAME) || defined(EINA_HAVE_WIN32_THREAD_SETNAME)
@@ -134,25 +134,25 @@ eina_thread_name_set(Eina_Thread t, const char *name)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_thread_cancel(Eina_Thread t)
 {
    return _eina_thread_cancel(t) == 0;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_thread_cancellable_set(Eina_Bool cancellable, Eina_Bool *was_cancellable)
 {
    return _eina_thread_cancellable_set(cancellable,was_cancellable);
 }
 
-EAPI void
+EINA_API void
 eina_thread_cancel_checkpoint(void)
 {
    _eina_thread_cancel_checkpoint();
 }
 
-EAPI void *
+EINA_API void *
 eina_thread_cancellable_run(Eina_Thread_Cancellable_Run_Cb cb, Eina_Free_Cb cleanup_cb, void *data)
 {
    Eina_Bool old = EINA_FALSE;

--- a/src/lib/eina/eina_thread.h
+++ b/src/lib/eina/eina_thread.h
@@ -71,7 +71,7 @@ typedef enum _Eina_Thread_Priority
  * @return identifier of current thread.
  * @since 1.8
  */
-EAPI Eina_Thread eina_thread_self(void) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Thread eina_thread_self(void) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Returns an integral compatible identifier of the current thread.
@@ -83,7 +83,7 @@ EAPI Eina_Thread eina_thread_self(void) EINA_WARN_UNUSED_RESULT;
  * @return integral identifier of current thread.
  * @since 1.25
  */
-EAPI Eina_ThreadId eina_thread_self_id(void) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_ThreadId eina_thread_self_id(void) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Checks if two thread identifiers are the same.
@@ -92,7 +92,7 @@ EAPI Eina_ThreadId eina_thread_self_id(void) EINA_WARN_UNUSED_RESULT;
  * @return #EINA_TRUE if they are equal, #EINA_FALSE otherwise.
  * @since 1.8
  */
-EAPI Eina_Bool eina_thread_equal(Eina_Thread t1, Eina_Thread t2) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool eina_thread_equal(Eina_Thread t1, Eina_Thread t2) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates a new thread, setting its priority and affinity.
@@ -105,7 +105,7 @@ EAPI Eina_Bool eina_thread_equal(Eina_Thread t1, Eina_Thread t2) EINA_WARN_UNUSE
  * @return #EINA_TRUE if thread was created, #EINA_FALSE on errors.
  * @since 1.8
  */
-EAPI Eina_Bool eina_thread_create(Eina_Thread *t,
+EINA_API Eina_Bool eina_thread_create(Eina_Thread *t,
                                   Eina_Thread_Priority prio, int affinity,
                                   Eina_Thread_Cb func, const void *data) EINA_ARG_NONNULL(1, 4) EINA_WARN_UNUSED_RESULT;
 
@@ -121,7 +121,7 @@ EAPI Eina_Bool eina_thread_create(Eina_Thread *t,
  *
  * @since 1.19
  */
-EAPI extern const void *EINA_THREAD_JOIN_CANCELED;
+EINA_API extern const void *EINA_THREAD_JOIN_CANCELED;
 
 /**
  * @brief Joins a currently running thread, waiting until it finishes.
@@ -138,7 +138,7 @@ EAPI extern const void *EINA_THREAD_JOIN_CANCELED;
  *         EINA_THREAD_JOIN_CANCELED.
  * @since 1.8
  */
-EAPI void *eina_thread_join(Eina_Thread t);
+EINA_API void *eina_thread_join(Eina_Thread t);
 
 /**
  * @brief Sets the name of a given thread for debugging purposes.
@@ -155,7 +155,7 @@ EAPI void *eina_thread_join(Eina_Thread t);
  *         otherwise.
  * @since 1.16
  */
-EAPI Eina_Bool eina_thread_name_set(Eina_Thread t, const char *name);
+EINA_API Eina_Bool eina_thread_name_set(Eina_Thread t, const char *name);
 
 /**
  * @brief Attempts to cancel a running thread.
@@ -178,7 +178,7 @@ EAPI Eina_Bool eina_thread_name_set(Eina_Thread t, const char *name);
  *
  * @since 1.19
  */
-EAPI Eina_Bool eina_thread_cancel(Eina_Thread t);
+EINA_API Eina_Bool eina_thread_cancel(Eina_Thread t);
 
 /**
  * @brief Enables or disables if the current thread can be canceled.
@@ -216,7 +216,7 @@ EAPI Eina_Bool eina_thread_cancel(Eina_Thread t);
  *
  * @since 1.19
  */
-EAPI Eina_Bool eina_thread_cancellable_set(Eina_Bool cancellable, Eina_Bool *was_cancellable);
+EINA_API Eina_Bool eina_thread_cancellable_set(Eina_Bool cancellable, Eina_Bool *was_cancellable);
 
 /**
  * If the current thread is cancellable, this introduces a
@@ -232,7 +232,7 @@ EAPI Eina_Bool eina_thread_cancellable_set(Eina_Bool cancellable, Eina_Bool *was
  *
  * @since 1.19
  */
-EAPI void eina_thread_cancel_checkpoint(void);
+EINA_API void eina_thread_cancel_checkpoint(void);
 
 /**
  * @typedef Eina_Thread_Cancellable_Run_Cb
@@ -284,7 +284,7 @@ typedef void *(*Eina_Thread_Cancellable_Run_Cb)(void *data);
  *
  * @since 1.19
  */
-EAPI void *eina_thread_cancellable_run(Eina_Thread_Cancellable_Run_Cb cb, Eina_Free_Cb cleanup_cb, void *data);
+EINA_API void *eina_thread_cancellable_run(Eina_Thread_Cancellable_Run_Cb cb, Eina_Free_Cb cleanup_cb, void *data);
 
 typedef struct _Eina_Thread_Call Eina_Thread_Call;
 struct _Eina_Thread_Call

--- a/src/lib/eina/eina_thread_queue.c
+++ b/src/lib/eina/eina_thread_queue.c
@@ -399,7 +399,7 @@ eina_thread_queue_shutdown(void)
    return EINA_TRUE;
 }
 
-EAPI Eina_Thread_Queue *
+EINA_API Eina_Thread_Queue *
 eina_thread_queue_new(void)
 {
    Eina_Thread_Queue *thq;
@@ -425,7 +425,7 @@ eina_thread_queue_new(void)
    return thq;
 }
 
-EAPI void
+EINA_API void
 eina_thread_queue_free(Eina_Thread_Queue *thq)
 {
    if (!thq) return;
@@ -439,7 +439,7 @@ eina_thread_queue_free(Eina_Thread_Queue *thq)
    free(thq);
 }
 
-EAPI void *
+EINA_API void *
 eina_thread_queue_send(Eina_Thread_Queue *thq, int size, void **allocref)
 {
    Eina_Thread_Queue_Msg *msg;
@@ -459,7 +459,7 @@ eina_thread_queue_send(Eina_Thread_Queue *thq, int size, void **allocref)
    return msg;
 }
 
-EAPI void
+EINA_API void
 eina_thread_queue_send_done(Eina_Thread_Queue *thq, void *allocref)
 {
    _eina_thread_queue_msg_alloc_done(allocref);
@@ -485,7 +485,7 @@ eina_thread_queue_send_done(Eina_Thread_Queue *thq, void *allocref)
      }
 }
 
-EAPI void *
+EINA_API void *
 eina_thread_queue_wait(Eina_Thread_Queue *thq, void **allocref)
 {
    Eina_Thread_Queue_Msg *msg;
@@ -506,13 +506,13 @@ eina_thread_queue_wait(Eina_Thread_Queue *thq, void **allocref)
    return msg;
 }
 
-EAPI void
+EINA_API void
 eina_thread_queue_wait_done(Eina_Thread_Queue *thq EINA_UNUSED, void *allocref)
 {
    _eina_thread_queue_msg_fetch_done(allocref);
 }
 
-EAPI void *
+EINA_API void *
 eina_thread_queue_poll(Eina_Thread_Queue *thq, void **allocref)
 {
    Eina_Thread_Queue_Msg *msg;
@@ -536,7 +536,7 @@ eina_thread_queue_poll(Eina_Thread_Queue *thq, void **allocref)
    return msg;
 }
 
-EAPI int
+EINA_API int
 eina_thread_queue_pending_get(const Eina_Thread_Queue *thq)
 {
    int pending;
@@ -551,25 +551,25 @@ eina_thread_queue_pending_get(const Eina_Thread_Queue *thq)
    return pending;
 }
 
-EAPI void
+EINA_API void
 eina_thread_queue_parent_set(Eina_Thread_Queue *thq, Eina_Thread_Queue *thq_parent)
 {
    thq->parent = thq_parent;
 }
 
-EAPI Eina_Thread_Queue *
+EINA_API Eina_Thread_Queue *
 eina_thread_queue_parent_get(const Eina_Thread_Queue *thq)
 {
    return thq->parent;
 }
 
-EAPI void
+EINA_API void
 eina_thread_queue_fd_set(Eina_Thread_Queue *thq, int fd)
 {
    thq->fd = fd;
 }
 
-EAPI int
+EINA_API int
 eina_thread_queue_fd_get(const Eina_Thread_Queue *thq)
 {
    return thq->fd;

--- a/src/lib/eina/eina_thread_queue.h
+++ b/src/lib/eina/eina_thread_queue.h
@@ -73,7 +73,7 @@ struct _Eina_Thread_Queue_Msg_Sub
  *
  * @since 1.11
  */
-EAPI Eina_Thread_Queue *
+EINA_API Eina_Thread_Queue *
 eina_thread_queue_new(void);
 
 /**
@@ -87,7 +87,7 @@ eina_thread_queue_new(void);
  *
  * @since 1.11
  */
-EAPI void
+EINA_API void
 eina_thread_queue_free(Eina_Thread_Queue *thq) EINA_ARG_NONNULL(1);
 
 /**
@@ -106,7 +106,7 @@ eina_thread_queue_free(Eina_Thread_Queue *thq) EINA_ARG_NONNULL(1);
  *
  * @since 1.11
  */
-EAPI void *
+EINA_API void *
 eina_thread_queue_send(Eina_Thread_Queue *thq, int size, void **allocref) EINA_ARG_NONNULL(1, 3);
 
 /**
@@ -120,7 +120,7 @@ eina_thread_queue_send(Eina_Thread_Queue *thq, int size, void **allocref) EINA_A
  *
  * @since 1.11
  */
-EAPI void
+EINA_API void
 eina_thread_queue_send_done(Eina_Thread_Queue *thq, void *allocref) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -140,7 +140,7 @@ eina_thread_queue_send_done(Eina_Thread_Queue *thq, void *allocref) EINA_ARG_NON
  *
  * @since 1.11
  */
-EAPI void *
+EINA_API void *
 eina_thread_queue_wait(Eina_Thread_Queue *thq, void **allocref) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -154,7 +154,7 @@ eina_thread_queue_wait(Eina_Thread_Queue *thq, void **allocref) EINA_ARG_NONNULL
  *
  * @since 1.11
  */
-EAPI void
+EINA_API void
 eina_thread_queue_wait_done(Eina_Thread_Queue *thq, void *allocref) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -172,7 +172,7 @@ eina_thread_queue_wait_done(Eina_Thread_Queue *thq, void *allocref) EINA_ARG_NON
  *
  * @since 1.11
  */
-EAPI void *
+EINA_API void *
 eina_thread_queue_poll(Eina_Thread_Queue *thq, void **allocref) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -186,7 +186,7 @@ eina_thread_queue_poll(Eina_Thread_Queue *thq, void **allocref) EINA_ARG_NONNULL
  *
  * @since 1.11
  */
-EAPI int
+EINA_API int
 eina_thread_queue_pending_get(const Eina_Thread_Queue *thq) EINA_ARG_NONNULL(1);
 
 /**
@@ -203,7 +203,7 @@ eina_thread_queue_pending_get(const Eina_Thread_Queue *thq) EINA_ARG_NONNULL(1);
  *
  * @since 1.11
  */
-EAPI void
+EINA_API void
 eina_thread_queue_parent_set(Eina_Thread_Queue *thq, Eina_Thread_Queue *thq_parent) EINA_ARG_NONNULL(1);
 
 /**
@@ -219,7 +219,7 @@ eina_thread_queue_parent_set(Eina_Thread_Queue *thq, Eina_Thread_Queue *thq_pare
  *
  * @since 1.11
  */
-EAPI Eina_Thread_Queue *
+EINA_API Eina_Thread_Queue *
 eina_thread_queue_parent_get(const Eina_Thread_Queue *thq) EINA_ARG_NONNULL(1);
 
 /**
@@ -239,7 +239,7 @@ eina_thread_queue_parent_get(const Eina_Thread_Queue *thq) EINA_ARG_NONNULL(1);
  *
  * @since 1.11
  */
-EAPI void
+EINA_API void
 eina_thread_queue_fd_set(Eina_Thread_Queue *thq, int fd) EINA_ARG_NONNULL(1);
 
 /**
@@ -255,7 +255,7 @@ eina_thread_queue_fd_set(Eina_Thread_Queue *thq, int fd) EINA_ARG_NONNULL(1);
  *
  * @since 1.11
  */
-EAPI int
+EINA_API int
 eina_thread_queue_fd_get(const Eina_Thread_Queue *thq) EINA_ARG_NONNULL(1);
 
 /**

--- a/src/lib/eina/eina_tiler.c
+++ b/src/lib/eina/eina_tiler.c
@@ -1137,7 +1137,7 @@ static void _iterator_free(Eina_Iterator_Tiler *it)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Tiler *eina_tiler_new(int w, int h)
+EINA_API Eina_Tiler *eina_tiler_new(int w, int h)
 {
    Eina_Tiler *t;
 
@@ -1158,7 +1158,7 @@ EAPI Eina_Tiler *eina_tiler_new(int w, int h)
    return t;
 }
 
-EAPI void eina_tiler_free(Eina_Tiler *t)
+EINA_API void eina_tiler_free(Eina_Tiler *t)
 {
    if (!t)
      return;
@@ -1168,7 +1168,7 @@ EAPI void eina_tiler_free(Eina_Tiler *t)
    free(t);
 }
 
-EAPI void eina_tiler_area_size_set(Eina_Tiler *t, int w, int h)
+EINA_API void eina_tiler_area_size_set(Eina_Tiler *t, int w, int h)
 {
    EINA_MAGIC_CHECK_TILER(t);
    if ((w <= 0) || (h <= 0))
@@ -1178,14 +1178,14 @@ EAPI void eina_tiler_area_size_set(Eina_Tiler *t, int w, int h)
    t->area.h = h;
 }
 
-EAPI void eina_tiler_area_size_get(const Eina_Tiler *t, int *w, int *h)
+EINA_API void eina_tiler_area_size_get(const Eina_Tiler *t, int *w, int *h)
 {
    EINA_MAGIC_CHECK_TILER(t);
    if (w) *w = t->area.w;
    if (h) *h = t->area.h;
 }
 
-EAPI void eina_tiler_tile_size_set(Eina_Tiler *t, int w, int h)
+EINA_API void eina_tiler_tile_size_set(Eina_Tiler *t, int w, int h)
 {
    EINA_MAGIC_CHECK_TILER(t);
    if ((w <= 0) || (h <= 0))
@@ -1198,7 +1198,7 @@ EAPI void eina_tiler_tile_size_set(Eina_Tiler *t, int w, int h)
    _splitter_tile_size_set(t, w, h);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_tiler_empty(const Eina_Tiler *t)
 {
    EINA_MAGIC_CHECK_TILER(t, EINA_TRUE);
@@ -1219,7 +1219,7 @@ _rect_same(Eina_Rectangle *rec1, Eina_Rectangle *rec2)
    return ((same1->x == same2->x) && (same1->y == same2->y));
 }
 
-EAPI Eina_Bool eina_tiler_rect_add(Eina_Tiler *t, const Eina_Rectangle *r)
+EINA_API Eina_Bool eina_tiler_rect_add(Eina_Tiler *t, const Eina_Rectangle *r)
 {
    Eina_Rectangle tmp __attribute__ ((aligned (8)));
 
@@ -1245,7 +1245,7 @@ EAPI Eina_Bool eina_tiler_rect_add(Eina_Tiler *t, const Eina_Rectangle *r)
    return _splitter_rect_add(t, &tmp);
 }
 
-EAPI void eina_tiler_rect_del(Eina_Tiler *t, const Eina_Rectangle *r)
+EINA_API void eina_tiler_rect_del(Eina_Tiler *t, const Eina_Rectangle *r)
 {
    Eina_Rectangle tmp __attribute__ ((aligned (8)));
 
@@ -1271,7 +1271,7 @@ EAPI void eina_tiler_rect_del(Eina_Tiler *t, const Eina_Rectangle *r)
    _splitter_rect_del(t, &tmp);
 }
 
-EAPI void eina_tiler_clear(Eina_Tiler *t)
+EINA_API void eina_tiler_clear(Eina_Tiler *t)
 {
    EINA_MAGIC_CHECK_TILER(t);
    _splitter_clear(t);
@@ -1281,14 +1281,14 @@ EAPI void eina_tiler_clear(Eina_Tiler *t)
    t->last.del.h = -1;
 }
 
-EAPI void
+EINA_API void
 eina_tiler_strict_set(Eina_Tiler *t, Eina_Bool strict)
 {
    EINA_MAGIC_CHECK_TILER(t);
    t->strict = strict;
 }
 
-EAPI Eina_Iterator *eina_tiler_iterator_new(const Eina_Tiler *t)
+EINA_API Eina_Iterator *eina_tiler_iterator_new(const Eina_Tiler *t)
 {
    Eina_Iterator_Tiler *it;
 
@@ -1363,7 +1363,7 @@ EAPI Eina_Iterator *eina_tiler_iterator_new(const Eina_Tiler *t)
    return &it->iterator;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_tiler_union(Eina_Tiler *dst,
                  Eina_Tiler *src)
 {
@@ -1405,7 +1405,7 @@ eina_tiler_union(Eina_Tiler *dst,
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_tiler_subtract(Eina_Tiler *dst,
                     Eina_Tiler *src)
 {
@@ -1444,7 +1444,7 @@ eina_tiler_subtract(Eina_Tiler *dst,
    return EINA_TRUE;
 }
 
-EAPI Eina_Tiler *
+EINA_API Eina_Tiler *
 eina_tiler_intersection(Eina_Tiler *t1,
                         Eina_Tiler *t2)
 {
@@ -1527,7 +1527,7 @@ cleanup:
    return t;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_tiler_equal(const Eina_Tiler *t1,
                  const Eina_Tiler *t2)
 {
@@ -1604,7 +1604,7 @@ eina_tile_grid_slicer_iterator_next(Eina_Tile_Grid_Slicer_Iterator *it,
              (&it->priv, (const Eina_Tile_Grid_Info **)data);
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_tile_grid_slicer_iterator_new(int x,
                                    int y,
                                    int w,

--- a/src/lib/eina/eina_tiler.h
+++ b/src/lib/eina/eina_tiler.h
@@ -183,7 +183,7 @@ typedef struct _Eina_Tile_Grid_Slicer Eina_Tile_Grid_Slicer;
  *
  * @see eina_tiler_free()
  */
-EAPI Eina_Tiler        *eina_tiler_new(int w, int h);
+EINA_API Eina_Tiler        *eina_tiler_new(int w, int h);
 
 /**
  * @brief Frees a tiler.
@@ -193,7 +193,7 @@ EAPI Eina_Tiler        *eina_tiler_new(int w, int h);
  * This function frees @p t. It does not free the memory allocated for the
  * elements of @p t.
  */
-EAPI void               eina_tiler_free(Eina_Tiler *t);
+EINA_API void               eina_tiler_free(Eina_Tiler *t);
 
 /**
  * @brief Sets the size of tiles for a tiler.
@@ -206,7 +206,7 @@ EAPI void               eina_tiler_free(Eina_Tiler *t);
  * won't be changed.
  * @warning Tile size is not used!
  */
-EAPI void               eina_tiler_tile_size_set(Eina_Tiler *t, int w, int h);
+EINA_API void               eina_tiler_tile_size_set(Eina_Tiler *t, int w, int h);
 
 /**
  * @brief Changes the size of the area covered by the tiler.
@@ -219,7 +219,7 @@ EAPI void               eina_tiler_tile_size_set(Eina_Tiler *t, int w, int h);
  *
  * @warning Must clear the tiler before changing its size.
  */
-EAPI void               eina_tiler_area_size_set(Eina_Tiler *t, int w, int h);
+EINA_API void               eina_tiler_area_size_set(Eina_Tiler *t, int w, int h);
 
 /**
  * @brief Gets the size of the area covered by the tiler.
@@ -230,7 +230,7 @@ EAPI void               eina_tiler_area_size_set(Eina_Tiler *t, int w, int h);
  *
  * @since 1.8
  */
-EAPI void               eina_tiler_area_size_get(const Eina_Tiler *t, int *w, int *h);
+EINA_API void               eina_tiler_area_size_get(const Eina_Tiler *t, int *w, int *h);
 
 /**
  * @brief Defines if we need to follow a strict grid of tile or a loose one.
@@ -242,7 +242,7 @@ EAPI void               eina_tiler_area_size_get(const Eina_Tiler *t, int *w, in
  *
  * @since 1.8
  */
-EAPI void               eina_tiler_strict_set(Eina_Tiler *t, Eina_Bool strict);
+EINA_API void               eina_tiler_strict_set(Eina_Tiler *t, Eina_Bool strict);
 
 /**
  * @brief Tells if a tiler is empty or not.
@@ -252,7 +252,7 @@ EAPI void               eina_tiler_strict_set(Eina_Tiler *t, Eina_Bool strict);
  *
  * @since 1.8
  */
-EAPI Eina_Bool          eina_tiler_empty(const Eina_Tiler *t);
+EINA_API Eina_Bool          eina_tiler_empty(const Eina_Tiler *t);
 
 /**
  * @brief Adds a rectangle to a tiler.
@@ -263,7 +263,7 @@ EAPI Eina_Bool          eina_tiler_empty(const Eina_Tiler *t);
  *
  * @see eina_tiler_rect_del()
  */
-EAPI Eina_Bool          eina_tiler_rect_add(Eina_Tiler *t, const Eina_Rectangle *r);
+EINA_API Eina_Bool          eina_tiler_rect_add(Eina_Tiler *t, const Eina_Rectangle *r);
 
 /**
  * @brief Removes a rectangle from a tiler.
@@ -274,7 +274,7 @@ EAPI Eina_Bool          eina_tiler_rect_add(Eina_Tiler *t, const Eina_Rectangle 
  * @see eina_tiler_rect_add()
  * @see eina_tiler_clear()
  */
-EAPI void               eina_tiler_rect_del(Eina_Tiler *t, const Eina_Rectangle *r);
+EINA_API void               eina_tiler_rect_del(Eina_Tiler *t, const Eina_Rectangle *r);
 
 /**
  * @brief Removes all rectangles from tiles.
@@ -283,7 +283,7 @@ EAPI void               eina_tiler_rect_del(Eina_Tiler *t, const Eina_Rectangle 
  *
  * @see eina_tiler_rect_del()
  */
-EAPI void               eina_tiler_clear(Eina_Tiler *t);
+EINA_API void               eina_tiler_clear(Eina_Tiler *t);
 
 /**
  * @brief Creates a iterator to access the tilers calculated rectangles.
@@ -291,7 +291,7 @@ EAPI void               eina_tiler_clear(Eina_Tiler *t);
  * @param[in] t The tiler to iterate over.
  * @return A iterator containing Eina_Rectangle.
  */
-EAPI Eina_Iterator     *eina_tiler_iterator_new(const Eina_Tiler *t);
+EINA_API Eina_Iterator     *eina_tiler_iterator_new(const Eina_Tiler *t);
 
 /**
  * @brief Creates a new Eina_Iterator that iterates over a list of tiles.
@@ -312,7 +312,7 @@ EAPI Eina_Iterator     *eina_tiler_iterator_new(const Eina_Tiler *t);
  * equivalent to calling eina_tile_grid_slicer_setup() and calling
  * eina_tile_grid_slicer_next() until it returns #EINA_FALSE.
  */
-EAPI Eina_Iterator     *eina_tile_grid_slicer_iterator_new(int x, int y, int w, int h, int tile_w, int tile_h);
+EINA_API Eina_Iterator     *eina_tile_grid_slicer_iterator_new(int x, int y, int w, int h, int tile_w, int tile_h);
 
 /**
  * @brief Gets the union of two tilers.
@@ -325,7 +325,7 @@ EAPI Eina_Iterator     *eina_tile_grid_slicer_iterator_new(int x, int y, int w, 
  * The result is stored in @p dst. It returns #EINA_TRUE if it succeeds.
  * @since 1.11
  */
-EAPI Eina_Bool          eina_tiler_union(Eina_Tiler *dst, Eina_Tiler *src);
+EINA_API Eina_Bool          eina_tiler_union(Eina_Tiler *dst, Eina_Tiler *src);
 
 /**
  * @brief Subtracts two tilers.
@@ -338,7 +338,7 @@ EAPI Eina_Bool          eina_tiler_union(Eina_Tiler *dst, Eina_Tiler *src);
  * The result is stored in @p dst. It returns #EINA_TRUE if it succeeds.
  * @since 1.11
  */
-EAPI Eina_Bool          eina_tiler_subtract(Eina_Tiler *dst, Eina_Tiler *src);
+EINA_API Eina_Bool          eina_tiler_subtract(Eina_Tiler *dst, Eina_Tiler *src);
 
 /**
  * @brief Gets the intersection of two tilers.
@@ -351,7 +351,7 @@ EAPI Eina_Bool          eina_tiler_subtract(Eina_Tiler *dst, Eina_Tiler *src);
  * It returns a pointer of result if intersection of two tilers exists., otherwise returns NULL.
  * @since 1.11
  */
-EAPI Eina_Tiler        *eina_tiler_intersection(Eina_Tiler *t1, Eina_Tiler *t2);
+EINA_API Eina_Tiler        *eina_tiler_intersection(Eina_Tiler *t1, Eina_Tiler *t2);
 
 /**
  * @brief Gets whether two tilers are equal in rects or not.
@@ -364,7 +364,7 @@ EAPI Eina_Tiler        *eina_tiler_intersection(Eina_Tiler *t1, Eina_Tiler *t2);
  * It returns #EINA_TRUE if tilers are equal.
  * @since 1.11
  */
-EAPI Eina_Bool           eina_tiler_equal(const Eina_Tiler *t1, const Eina_Tiler *t2);
+EINA_API Eina_Bool           eina_tiler_equal(const Eina_Tiler *t1, const Eina_Tiler *t2);
 
 /**
  * @brief Iterates over the tiles set by eina_tile_grid_slicer_setup().

--- a/src/lib/eina/eina_tmpstr.c
+++ b/src/lib/eina/eina_tmpstr.c
@@ -63,7 +63,7 @@ eina_tmpstr_shutdown(void)
    return EINA_TRUE;
 }
 
-EAPI Eina_Tmpstr *
+EINA_API Eina_Tmpstr *
 eina_tmpstr_add_length(const char *str, size_t length)
 {
    Str *s;
@@ -83,7 +83,7 @@ eina_tmpstr_add_length(const char *str, size_t length)
    return s->str;
 }
 
-EAPI Eina_Tmpstr *
+EINA_API Eina_Tmpstr *
 eina_tmpstr_manage_new_length(char *str, size_t length)
 {
    Str *s;
@@ -101,7 +101,7 @@ eina_tmpstr_manage_new_length(char *str, size_t length)
    return s->str;
 }
 
-EAPI Eina_Tmpstr *
+EINA_API Eina_Tmpstr *
 eina_tmpstr_manage_new(char *str)
 {
    size_t len;
@@ -111,7 +111,7 @@ eina_tmpstr_manage_new(char *str)
    return eina_tmpstr_manage_new_length(str, len);
 }
 
-EAPI Eina_Tmpstr *
+EINA_API Eina_Tmpstr *
 eina_tmpstr_add(const char *str)
 {
    size_t len;
@@ -121,7 +121,7 @@ eina_tmpstr_add(const char *str)
    return eina_tmpstr_add_length(str, len);
 }
 
-EAPI void
+EINA_API void
 eina_tmpstr_del(Eina_Tmpstr *tmpstr)
 {
    Str *s, *sp;
@@ -142,14 +142,14 @@ eina_tmpstr_del(Eina_Tmpstr *tmpstr)
    eina_lock_release(&_mutex);
 }
 
-EAPI size_t
+EINA_API size_t
 eina_tmpstr_strlen(Eina_Tmpstr *tmpstr)
 {
    if (!tmpstr) return 0;
    return eina_tmpstr_len(tmpstr) + 1;
 }
 
-EAPI size_t
+EINA_API size_t
 eina_tmpstr_len(Eina_Tmpstr *tmpstr)
 {
    Str *s;

--- a/src/lib/eina/eina_tmpstr.h
+++ b/src/lib/eina/eina_tmpstr.h
@@ -162,7 +162,7 @@ typedef const char Eina_Tmpstr;
  *
  * @since 1.8.0
  */
-EAPI Eina_Tmpstr *eina_tmpstr_add(const char *str) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Tmpstr *eina_tmpstr_add(const char *str) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Adds a new temporary string based on the input string and length.
@@ -195,7 +195,7 @@ EAPI Eina_Tmpstr *eina_tmpstr_add(const char *str) EINA_WARN_UNUSED_RESULT;
  *
  * @since 1.8.0
  */
-EAPI Eina_Tmpstr *eina_tmpstr_add_length(const char *str, size_t length);
+EINA_API Eina_Tmpstr *eina_tmpstr_add_length(const char *str, size_t length);
 
 /**
  * @brief **Deprecated** Return the length of a temporary string including the '\0'.
@@ -208,7 +208,7 @@ EAPI Eina_Tmpstr *eina_tmpstr_add_length(const char *str, size_t length);
  * @see eina_tmpstr_len()
  * @since 1.8.0
  */
-EINA_DEPRECATED EAPI size_t eina_tmpstr_strlen(Eina_Tmpstr *tmpstr);
+EINA_DEPRECATED EINA_API size_t eina_tmpstr_strlen(Eina_Tmpstr *tmpstr);
 
 /**
  * @brief Returns the length of a temporary string.
@@ -219,7 +219,7 @@ EINA_DEPRECATED EAPI size_t eina_tmpstr_strlen(Eina_Tmpstr *tmpstr);
  *
  * @since 1.14.0
  */
-EAPI size_t eina_tmpstr_len(Eina_Tmpstr *tmpstr);
+EINA_API size_t eina_tmpstr_len(Eina_Tmpstr *tmpstr);
 
 /**
  * @brief Deletes the temporary string if it is one, or ignore it if it is not.
@@ -235,7 +235,7 @@ EAPI size_t eina_tmpstr_len(Eina_Tmpstr *tmpstr);
  *
  * @since 1.8.0
  */
-EAPI void eina_tmpstr_del(Eina_Tmpstr *tmpstr) EINA_ARG_NONNULL(1);
+EINA_API void eina_tmpstr_del(Eina_Tmpstr *tmpstr) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Adds a new temporary string using the passed string. The passed
@@ -250,7 +250,7 @@ EAPI void eina_tmpstr_del(Eina_Tmpstr *tmpstr) EINA_ARG_NONNULL(1);
  * @see eina_tmpstr_del()
  * @since 1.17.0
  */
-EAPI Eina_Tmpstr *eina_tmpstr_manage_new(char *str) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Tmpstr *eina_tmpstr_manage_new(char *str) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Adds a new temporary string using the passed string. The passed
@@ -267,7 +267,7 @@ EAPI Eina_Tmpstr *eina_tmpstr_manage_new(char *str) EINA_WARN_UNUSED_RESULT;
  * @see eina_tmpstr_del()
  * @since 1.17.0
  */
-EAPI Eina_Tmpstr *eina_tmpstr_manage_new_length(char *str, size_t length);
+EINA_API Eina_Tmpstr *eina_tmpstr_manage_new_length(char *str, size_t length);
 
 /**
  * @}

--- a/src/lib/eina/eina_types.h
+++ b/src/lib/eina/eina_types.h
@@ -33,43 +33,43 @@
  * @{
  */
 
-#ifdef EAPI
-# undef EAPI
+#ifdef EINA_API
+#error EINA_API should not be already defined
 #endif
 
 #ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
+# ifndef EINA_STATIC
+#  ifdef EINA_BUILD
+#   define EINA_API __declspec(dllexport)
 #  else
-#   define EAPI
+#   define EINA_API __declspec(dllimport)
 #  endif
 # else
-#  define EAPI __declspec(dllimport)
+#  define EINA_API
 # endif
-# define EAPI_WEAK
+# define EINA_API_WEAK
 #else
 # ifdef __GNUC__
 #  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#   define EAPI_WEAK __attribute__ ((weak))
+#   define EINA_API __attribute__ ((visibility("default")))
+#   define EINA_API_WEAK __attribute__ ((weak))
 #  else
-#   define EAPI
-#   define EAPI_WEAK
+#   define EINA_API
+#   define EINA_API_WEAK
 #  endif
 # else
 /**
- * @def EAPI
+ * @def EINA_API
  * @brief Used to export functions (by changing visibility).
  */
-#  define EAPI
+#  define EINA_API
 /**
- * @def EAPI_WEAK
+ * @def EINA_API_WEAK
  * @brief Weak symbol, primarily useful in defining library functions which
  * can be overridden in user code.
  * Note: Not supported on all platforms.
  */
-#  define EAPI_WEAK
+#  define EINA_API_WEAK
 #  endif
 #endif
 
@@ -78,7 +78,7 @@
  * @brief Weak symbols part of the EFL API.
  * Note: Not supported on all platforms.
  */
-#define EWAPI EAPI EAPI_WEAK
+#define EWAPI EINA_API EINA_API_WEAK
 
 #ifdef _WIN32
 # ifdef DLL_EXPORT
@@ -96,7 +96,7 @@
 # else
 /**
  * @def EXPORTAPI
- * @brief An alias for #EAPI.
+ * @brief An alias for #EINA_API.
  */
 #  define EXPORTAPI
 # endif

--- a/src/lib/eina/eina_unicode.c
+++ b/src/lib/eina/eina_unicode.c
@@ -34,8 +34,8 @@
 
 /* Maybe I'm too tired, but this is the only thing that actually worked. */
 const Eina_Unicode _EINA_UNICODE_EMPTY_STRING[1] = {0};
-EAPI const Eina_Unicode *EINA_UNICODE_EMPTY_STRING = _EINA_UNICODE_EMPTY_STRING;
-EAPI int
+EINA_API const Eina_Unicode *EINA_UNICODE_EMPTY_STRING = _EINA_UNICODE_EMPTY_STRING;
+EINA_API int
 eina_unicode_strcmp(const Eina_Unicode *a, const Eina_Unicode *b)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(a, -1);
@@ -51,7 +51,7 @@ eina_unicode_strcmp(const Eina_Unicode *a, const Eina_Unicode *b)
       return 1;
 }
 
-EAPI Eina_Unicode *
+EINA_API Eina_Unicode *
 eina_unicode_strcpy(Eina_Unicode *dest, const Eina_Unicode *source)
 {
    Eina_Unicode *ret = dest;
@@ -65,7 +65,7 @@ eina_unicode_strcpy(Eina_Unicode *dest, const Eina_Unicode *source)
    return ret;
 }
 
-EAPI Eina_Unicode *
+EINA_API Eina_Unicode *
 eina_unicode_strncpy(Eina_Unicode *dest, const Eina_Unicode *source, size_t n)
 {
    Eina_Unicode *ret = dest;
@@ -80,7 +80,7 @@ eina_unicode_strncpy(Eina_Unicode *dest, const Eina_Unicode *source, size_t n)
    return ret;
 }
 
-EAPI size_t
+EINA_API size_t
 eina_unicode_strlen(const Eina_Unicode *ustr)
 {
    const Eina_Unicode *end;
@@ -92,7 +92,7 @@ eina_unicode_strlen(const Eina_Unicode *ustr)
    return end - ustr;
 }
 
-EAPI size_t
+EINA_API size_t
 eina_unicode_strnlen(const Eina_Unicode *ustr, int n)
 {
    const Eina_Unicode *end;
@@ -108,7 +108,7 @@ eina_unicode_strnlen(const Eina_Unicode *ustr, int n)
 
 
 
-EAPI Eina_Unicode *
+EINA_API Eina_Unicode *
 eina_unicode_strndup(const Eina_Unicode *text, size_t n)
 {
    Eina_Unicode *ustr;
@@ -124,7 +124,7 @@ eina_unicode_strndup(const Eina_Unicode *text, size_t n)
    return ustr;
 }
 
-EAPI Eina_Unicode *
+EINA_API Eina_Unicode *
 eina_unicode_strdup(const Eina_Unicode *text)
 {
    size_t len;
@@ -135,7 +135,7 @@ eina_unicode_strdup(const Eina_Unicode *text)
    return eina_unicode_strndup(text, len);
 }
 
-EAPI Eina_Unicode *
+EINA_API Eina_Unicode *
 eina_unicode_strstr(const Eina_Unicode *haystack, const Eina_Unicode *needle)
 {
    const Eina_Unicode *i, *j;
@@ -158,7 +158,7 @@ eina_unicode_strstr(const Eina_Unicode *haystack, const Eina_Unicode *needle)
    return NULL;
 }
 
-EAPI Eina_Unicode *
+EINA_API Eina_Unicode *
 eina_unicode_escape(const Eina_Unicode *str)
 {
    Eina_Unicode *s2, *d;
@@ -190,7 +190,7 @@ eina_unicode_escape(const Eina_Unicode *str)
 /* The replacement range that will be used for bad utf8 chars. */
 #define ERROR_REPLACEMENT_END   0xDCFF
 
-EAPI Eina_Unicode
+EINA_API Eina_Unicode
 _eina_unicode_utf8_next_get(int ind,
                             unsigned char d,
                             const char *buf, 
@@ -278,7 +278,7 @@ error:
    return ERROR_REPLACEMENT_BASE | d;
 }
 
-EAPI Eina_Unicode
+EINA_API Eina_Unicode
 eina_unicode_utf8_get_prev(const char *buf, int *iindex)
 {
    int r, ind;
@@ -305,7 +305,7 @@ eina_unicode_utf8_get_prev(const char *buf, int *iindex)
    return r;
 }
 
-EAPI int
+EINA_API int
 eina_unicode_utf8_get_len(const char *buf)
 {
    /* returns the number of utf8 characters (not bytes) in the string */
@@ -319,7 +319,7 @@ eina_unicode_utf8_get_len(const char *buf)
    return len;
 }
 
-EAPI Eina_Unicode *
+EINA_API Eina_Unicode *
 eina_unicode_utf8_to_unicode(const char *utf, int *_len)
 {
    /* FIXME: Should optimize! */
@@ -343,7 +343,7 @@ eina_unicode_utf8_to_unicode(const char *utf, int *_len)
    return buf;
 }
 
-EAPI char *
+EINA_API char *
 eina_unicode_unicode_to_utf8_range(const Eina_Unicode *uni, int ulen, int *_len)
 {
    char *buf, *buf2;
@@ -426,7 +426,7 @@ eina_unicode_unicode_to_utf8_range(const Eina_Unicode *uni, int ulen, int *_len)
    return buf2;
 }
 
-EAPI char *
+EINA_API char *
 eina_unicode_unicode_to_utf8(const Eina_Unicode *uni, int *_len)
 {
    int len = eina_unicode_strlen(uni);

--- a/src/lib/eina/eina_unicode.h
+++ b/src/lib/eina/eina_unicode.h
@@ -36,9 +36,9 @@ typedef uint32_t Eina_Unicode;
 /**
  * @brief Same as the standard strlen just with Eina_Unicode instead of char.
  */
-EAPI extern const Eina_Unicode *EINA_UNICODE_EMPTY_STRING;
+EINA_API extern const Eina_Unicode *EINA_UNICODE_EMPTY_STRING;
 
-EAPI size_t        eina_unicode_strlen(const Eina_Unicode *ustr) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+EINA_API size_t        eina_unicode_strlen(const Eina_Unicode *ustr) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief Returns the length of a Eina_Unicode string, up to a limit.
@@ -51,7 +51,7 @@ EAPI size_t        eina_unicode_strlen(const Eina_Unicode *ustr) EINA_ARG_NONNUL
  * @param[in] n Max length to search
  * @return Number of characters or n.
  */
-EAPI size_t        eina_unicode_strnlen(const Eina_Unicode *ustr, int n) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+EINA_API size_t        eina_unicode_strnlen(const Eina_Unicode *ustr, int n) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief Same as the standard strdup just with Eina_Unicode instead of char.
@@ -59,7 +59,7 @@ EAPI size_t        eina_unicode_strnlen(const Eina_Unicode *ustr, int n) EINA_AR
  * @param[in] text The text to duplicate.
  * @return The duplicated string.
  */
-EAPI Eina_Unicode *eina_unicode_strdup(const Eina_Unicode *text) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API Eina_Unicode *eina_unicode_strdup(const Eina_Unicode *text) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * @brief Same as strdup but cuts on the given size. Assumes n < len
@@ -74,7 +74,7 @@ EAPI Eina_Unicode *eina_unicode_strdup(const Eina_Unicode *text) EINA_WARN_UNUSE
  *
  * @since 1.1.0
  */
-EAPI Eina_Unicode *eina_unicode_strndup(const Eina_Unicode *text, size_t n) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API Eina_Unicode *eina_unicode_strndup(const Eina_Unicode *text, size_t n) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * @brief Same as the standard strcmp just with Eina_Unicode instead of char.
@@ -83,7 +83,7 @@ EAPI Eina_Unicode *eina_unicode_strndup(const Eina_Unicode *text, size_t n) EINA
  * @param[in] b The text to be compared.
  * @return An integer value indicating the ordinal relation of @p a to @p b.
  */
-EAPI int           eina_unicode_strcmp(const Eina_Unicode *a, const Eina_Unicode *b) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1, 2) EINA_PURE;
+EINA_API int           eina_unicode_strcmp(const Eina_Unicode *a, const Eina_Unicode *b) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1, 2) EINA_PURE;
 
 /**
  * @brief Same as the standard strcpy just with Eina_Unicode instead of char.
@@ -92,7 +92,7 @@ EAPI int           eina_unicode_strcmp(const Eina_Unicode *a, const Eina_Unicode
  * @param[in] source The text to copy from.
  * @return @p dest is returned.
  */
-EAPI Eina_Unicode *eina_unicode_strcpy(Eina_Unicode *dest, const Eina_Unicode *source) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Unicode *eina_unicode_strcpy(Eina_Unicode *dest, const Eina_Unicode *source) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Same as the standard strstr just with Eina_Unicode instead of char.
@@ -102,7 +102,7 @@ EAPI Eina_Unicode *eina_unicode_strcpy(Eina_Unicode *dest, const Eina_Unicode *s
  * @return The substring of @p haystack which starts with @p needle
  *         when @p needle is founded in @p haystack, or NULL is returned.
  */
-EAPI Eina_Unicode *eina_unicode_strstr(const Eina_Unicode *haystack, const Eina_Unicode *needle) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1, 2) EINA_PURE;
+EINA_API Eina_Unicode *eina_unicode_strstr(const Eina_Unicode *haystack, const Eina_Unicode *needle) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1, 2) EINA_PURE;
 
 /**
  * @brief Same as the standard strncpy just with Eina_Unicode instead of char.
@@ -112,7 +112,7 @@ EAPI Eina_Unicode *eina_unicode_strstr(const Eina_Unicode *haystack, const Eina_
  * @param[in] n Maximum number of characters to be copied from @p source.
  * @return @p dest is returned.
  */
-EAPI Eina_Unicode *eina_unicode_strncpy(Eina_Unicode *dest, const Eina_Unicode *source, size_t n) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Unicode *eina_unicode_strncpy(Eina_Unicode *dest, const Eina_Unicode *source, size_t n) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @see eina_str_escape()
@@ -120,7 +120,7 @@ EAPI Eina_Unicode *eina_unicode_strncpy(Eina_Unicode *dest, const Eina_Unicode *
  * @param[in] str The string to escape.
  * @return The escaped string.
  */
-EAPI Eina_Unicode *eina_unicode_escape(const Eina_Unicode *str) EINA_ARG_NONNULL(1) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Unicode *eina_unicode_escape(const Eina_Unicode *str) EINA_ARG_NONNULL(1) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /* UTF-8 Handling */
 
@@ -157,7 +157,7 @@ static inline Eina_Unicode eina_unicode_utf8_next_get(const char *buf, int *iind
  *
  * @since 1.1.0
  */
-EAPI Eina_Unicode eina_unicode_utf8_get_next(const char *buf, int *iindex) EINA_ARG_NONNULL(1, 2) EINA_DEPRECATED;
+EINA_API Eina_Unicode eina_unicode_utf8_get_next(const char *buf, int *iindex) EINA_ARG_NONNULL(1, 2) EINA_DEPRECATED;
 
 /**
  * Reads UTF8 bytes from @p buf, starting at @p iindex and returns
@@ -174,7 +174,7 @@ EAPI Eina_Unicode eina_unicode_utf8_get_next(const char *buf, int *iindex) EINA_
  *
  * @since 1.1.0
  */
-EAPI Eina_Unicode eina_unicode_utf8_get_prev(const char *buf, int *iindex) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Unicode eina_unicode_utf8_get_prev(const char *buf, int *iindex) EINA_ARG_NONNULL(1, 2);
 
 /**
  * Returns the number of unicode characters in the string. That is,
@@ -186,7 +186,7 @@ EAPI Eina_Unicode eina_unicode_utf8_get_prev(const char *buf, int *iindex) EINA_
  *
  * @since 1.1.0
  */
-EAPI int eina_unicode_utf8_get_len(const char *buf) EINA_ARG_NONNULL(1);
+EINA_API int eina_unicode_utf8_get_len(const char *buf) EINA_ARG_NONNULL(1);
 
 /**
  * Converts a utf-8 string to a newly allocated Eina_Unicode string.
@@ -197,7 +197,7 @@ EAPI int eina_unicode_utf8_get_len(const char *buf) EINA_ARG_NONNULL(1);
  *
  * @since 1.1.0
  */
-EAPI Eina_Unicode *eina_unicode_utf8_to_unicode(const char *utf, int *_len) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API Eina_Unicode *eina_unicode_utf8_to_unicode(const char *utf, int *_len) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * Converts an Eina_Unicode string to a newly allocated utf-8 substring at given length.
@@ -209,7 +209,7 @@ EAPI Eina_Unicode *eina_unicode_utf8_to_unicode(const char *utf, int *_len) EINA
  *
  * @since 1.17
  */
-EAPI char * eina_unicode_unicode_to_utf8_range(const Eina_Unicode *uni, int ulen, int *_len) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API char * eina_unicode_unicode_to_utf8_range(const Eina_Unicode *uni, int ulen, int *_len) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 /**
  * Converts an Eina_Unicode string to a newly allocated utf-8 string.
@@ -220,7 +220,7 @@ EAPI char * eina_unicode_unicode_to_utf8_range(const Eina_Unicode *uni, int ulen
  *
  * @since 1.1.0
  */
-EAPI char * eina_unicode_unicode_to_utf8(const Eina_Unicode *uni, int *_len) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
+EINA_API char * eina_unicode_unicode_to_utf8(const Eina_Unicode *uni, int *_len) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_MALLOC;
 
 #include "eina_inline_unicode.x"
 

--- a/src/lib/eina/eina_ustrbuf.h
+++ b/src/lib/eina/eina_ustrbuf.h
@@ -46,7 +46,7 @@ typedef struct _Eina_Strbuf Eina_UStrbuf;
  * @see eina_ustrbuf_append()
  * @see eina_ustrbuf_string_get()
  */
-EAPI Eina_UStrbuf *eina_ustrbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_UStrbuf *eina_ustrbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates a new string buffer using the passed string.
@@ -65,7 +65,7 @@ EAPI Eina_UStrbuf *eina_ustrbuf_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
  *
  * @since 1.1.0
  */
-EAPI Eina_UStrbuf *eina_ustrbuf_manage_new(Eina_Unicode *str) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_UStrbuf *eina_ustrbuf_manage_new(Eina_Unicode *str) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Creates a new string buffer using the passed string.
@@ -83,7 +83,7 @@ EAPI Eina_UStrbuf *eina_ustrbuf_manage_new(Eina_Unicode *str) EINA_MALLOC EINA_W
  *
  * @since 1.2.0
  */
-EAPI Eina_UStrbuf *eina_ustrbuf_manage_new_length(Eina_Unicode *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_UStrbuf *eina_ustrbuf_manage_new_length(Eina_Unicode *str, size_t length) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Frees a string buffer.
@@ -93,7 +93,7 @@ EAPI Eina_UStrbuf *eina_ustrbuf_manage_new_length(Eina_Unicode *str, size_t leng
  * This function frees the memory of @p buf. @p buf must have been
  * created by eina_ustrbuf_new().
  */
-EAPI void eina_ustrbuf_free(Eina_UStrbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_ustrbuf_free(Eina_UStrbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Resets a string buffer.
@@ -103,7 +103,7 @@ EAPI void eina_ustrbuf_free(Eina_UStrbuf *buf) EINA_ARG_NONNULL(1);
  * This function resets @p buf: the buffer len is set to 0, and the
  * string data is set to '\\0'. No memory is freed.
  */
-EAPI void eina_ustrbuf_reset(Eina_UStrbuf *buf) EINA_ARG_NONNULL(1);
+EINA_API void eina_ustrbuf_reset(Eina_UStrbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Appends a string to a buffer, reallocating as necessary.
@@ -120,7 +120,7 @@ EAPI void eina_ustrbuf_reset(Eina_UStrbuf *buf) EINA_ARG_NONNULL(1);
  * @see eina_ustrbuf_append()
  * @see eina_ustrbuf_append_length()
  */
-EAPI Eina_Bool eina_ustrbuf_append(Eina_UStrbuf *buf, const Eina_Unicode *str) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_ustrbuf_append(Eina_UStrbuf *buf, const Eina_Unicode *str) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends an escaped string to a buffer, reallocating as necessary.
@@ -131,7 +131,7 @@ EAPI Eina_Bool eina_ustrbuf_append(Eina_UStrbuf *buf, const Eina_Unicode *str) E
  *
  * This function appends the escaped string @p str to @p buf.
  */
-EAPI Eina_Bool eina_ustrbuf_append_escaped(Eina_UStrbuf *buf, const Eina_Unicode *str) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_ustrbuf_append_escaped(Eina_UStrbuf *buf, const Eina_Unicode *str) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a string to a buffer, reallocating as necessary,
@@ -152,7 +152,7 @@ EAPI Eina_Bool eina_ustrbuf_append_escaped(Eina_UStrbuf *buf, const Eina_Unicode
  * @see eina_ustrbuf_append()
  * @see eina_ustrbuf_append_length()
  */
-EAPI Eina_Bool eina_ustrbuf_append_n(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t maxlen) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_ustrbuf_append_n(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t maxlen) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a string of exact length to a buffer, reallocating as
@@ -172,7 +172,7 @@ EAPI Eina_Bool eina_ustrbuf_append_n(Eina_UStrbuf *buf, const Eina_Unicode *str,
  * @see eina_ustrbuf_append()
  * @see eina_ustrbuf_append_n()
  */
-EAPI Eina_Bool eina_ustrbuf_append_length(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t length) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_ustrbuf_append_length(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t length) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Appends a slice to a buffer, reallocating as necessary.
@@ -185,7 +185,7 @@ EAPI Eina_Bool eina_ustrbuf_append_length(Eina_UStrbuf *buf, const Eina_Unicode 
  *
  * @since 1.19.0
  */
-EAPI Eina_Bool eina_ustrbuf_append_slice(Eina_UStrbuf *buf, const Eina_Slice slice) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_ustrbuf_append_slice(Eina_UStrbuf *buf, const Eina_Slice slice) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Appends a character to a string buffer, reallocating as
@@ -197,7 +197,7 @@ EAPI Eina_Bool eina_ustrbuf_append_slice(Eina_UStrbuf *buf, const Eina_Slice sli
  *
  * This function appends @p c to @p buf.
  */
-EAPI Eina_Bool eina_ustrbuf_append_char(Eina_UStrbuf *buf, Eina_Unicode c) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_ustrbuf_append_char(Eina_UStrbuf *buf, Eina_Unicode c) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Inserts a string to a buffer, reallocating as necessary.
@@ -212,7 +212,7 @@ EAPI Eina_Bool eina_ustrbuf_append_char(Eina_UStrbuf *buf, Eina_Unicode c) EINA_
  * eina_ustrbuf_insert_length(). If  the length is known beforehand,
  * consider using that variant.
  */
-EAPI Eina_Bool eina_ustrbuf_insert(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_ustrbuf_insert(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts an escaped string to a buffer, reallocating as
@@ -226,7 +226,7 @@ EAPI Eina_Bool eina_ustrbuf_insert(Eina_UStrbuf *buf, const Eina_Unicode *str, s
  * This function inserts the escaped string @p str to @p buf at
  * position @p pos.
  */
-EAPI Eina_Bool eina_ustrbuf_insert_escaped(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_ustrbuf_insert_escaped(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts a string to a buffer, reallocating as necessary. Limited by maxlen.
@@ -245,7 +245,7 @@ EAPI Eina_Bool eina_ustrbuf_insert_escaped(Eina_UStrbuf *buf, const Eina_Unicode
  * should then be checked so that it is greater than the size of
  * @p str).
  */
-EAPI Eina_Bool eina_ustrbuf_insert_n(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t maxlen, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_ustrbuf_insert_n(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t maxlen, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts a string of exact length to a buffer, reallocating as necessary.
@@ -265,7 +265,7 @@ EAPI Eina_Bool eina_ustrbuf_insert_n(Eina_UStrbuf *buf, const Eina_Unicode *str,
  * @see eina_ustrbuf_insert()
  * @see eina_ustrbuf_insert_n()
  */
-EAPI Eina_Bool eina_ustrbuf_insert_length(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t length, size_t pos) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_ustrbuf_insert_length(Eina_UStrbuf *buf, const Eina_Unicode *str, size_t length, size_t pos) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Inserts a slice to a buffer, reallocating as necessary.
@@ -279,7 +279,7 @@ EAPI Eina_Bool eina_ustrbuf_insert_length(Eina_UStrbuf *buf, const Eina_Unicode 
  *
  * @since 1.19.0
  */
-EAPI Eina_Bool eina_ustrbuf_insert_slice(Eina_UStrbuf *buf, const Eina_Slice slice, size_t pos) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_ustrbuf_insert_slice(Eina_UStrbuf *buf, const Eina_Slice slice, size_t pos) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Inserts a character to a string buffer, reallocating as
@@ -292,7 +292,7 @@ EAPI Eina_Bool eina_ustrbuf_insert_slice(Eina_UStrbuf *buf, const Eina_Slice sli
  *
  * This function inserts @p c to @p buf at position @p pos.
  */
-EAPI Eina_Bool eina_ustrbuf_insert_char(Eina_UStrbuf *buf, Eina_Unicode c, size_t pos) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_ustrbuf_insert_char(Eina_UStrbuf *buf, Eina_Unicode c, size_t pos) EINA_ARG_NONNULL(1);
 
 /**
  * @def eina_ustrbuf_prepend(buf, str)
@@ -370,7 +370,7 @@ EAPI Eina_Bool eina_ustrbuf_insert_char(Eina_UStrbuf *buf, Eina_Unicode c, size_
  * (inclusive) and ending at @p end (non-inclusive). Both values are
  * in bytes.
  */
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_ustrbuf_remove(Eina_UStrbuf *buf, size_t start, size_t end) EINA_ARG_NONNULL(1);
 
 /**
@@ -386,7 +386,7 @@ eina_ustrbuf_remove(Eina_UStrbuf *buf, size_t start, size_t end) EINA_ARG_NONNUL
  *
  * @see eina_ustrbuf_string_steal()
  */
-EAPI const Eina_Unicode *
+EINA_API const Eina_Unicode *
 eina_ustrbuf_string_get(const Eina_UStrbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -402,7 +402,7 @@ eina_ustrbuf_string_get(const Eina_UStrbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_U
  *
  * @see eina_ustrbuf_string_get()
  */
-EAPI Eina_Unicode *
+EINA_API Eina_Unicode *
 eina_ustrbuf_string_steal(Eina_UStrbuf *buf) EINA_MALLOC EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
@@ -413,7 +413,7 @@ eina_ustrbuf_string_steal(Eina_UStrbuf *buf) EINA_MALLOC EINA_WARN_UNUSED_RESULT
  * This function frees the string contained in @p buf without freeing
  * @p buf.
  */
-EAPI void
+EINA_API void
 eina_ustrbuf_string_free(Eina_UStrbuf *buf) EINA_ARG_NONNULL(1);
 
 /**
@@ -424,7 +424,7 @@ eina_ustrbuf_string_free(Eina_UStrbuf *buf) EINA_ARG_NONNULL(1);
  *
  * This function returns the length of @p buf.
  */
-EAPI size_t
+EINA_API size_t
 eina_ustrbuf_length_get(const Eina_UStrbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
@@ -436,7 +436,7 @@ eina_ustrbuf_length_get(const Eina_UStrbuf *buf) EINA_ARG_NONNULL(1) EINA_WARN_U
  *
  * @since 1.19
  */
-EAPI Eina_Slice eina_ustrbuf_slice_get(const Eina_UStrbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Slice eina_ustrbuf_slice_get(const Eina_UStrbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Gets a read-write slice of the buffer contents.
@@ -448,7 +448,7 @@ EAPI Eina_Slice eina_ustrbuf_slice_get(const Eina_UStrbuf *buf) EINA_WARN_UNUSED
  *
  * @since 1.19.0
  */
-EAPI Eina_Rw_Slice eina_ustrbuf_rw_slice_get(const Eina_UStrbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Rw_Slice eina_ustrbuf_rw_slice_get(const Eina_UStrbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @brief Frees the buffer, returning its old contents.
@@ -459,7 +459,7 @@ EAPI Eina_Rw_Slice eina_ustrbuf_rw_slice_get(const Eina_UStrbuf *buf) EINA_WARN_
  *
  * @since 1.19
  */
-EAPI Eina_Unicode* eina_ustrbuf_release(Eina_UStrbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
+EINA_API Eina_Unicode* eina_ustrbuf_release(Eina_UStrbuf *buf) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1);
 
 /**
  * @}

--- a/src/lib/eina/eina_ustringshare.c
+++ b/src/lib/eina/eina_ustringshare.c
@@ -138,7 +138,7 @@ eina_ustringshare_shutdown(void)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI void
+EINA_API void
 eina_ustringshare_del(const Eina_Unicode *str)
 {
    if (!str)
@@ -148,7 +148,7 @@ eina_ustringshare_del(const Eina_Unicode *str)
      CRI("EEEK trying to del non-shared ustringshare \"%s\"", (const char *)str);
 }
 
-EAPI const Eina_Unicode *
+EINA_API const Eina_Unicode *
 eina_ustringshare_add_length(const Eina_Unicode *str, unsigned int slen)
 {
    return (const Eina_Unicode *)eina_share_common_add_length(ustringshare_share,
@@ -160,21 +160,21 @@ eina_ustringshare_add_length(const Eina_Unicode *str, unsigned int slen)
                                                                 Eina_Unicode));
 }
 
-EAPI const Eina_Unicode *
+EINA_API const Eina_Unicode *
 eina_ustringshare_add(const Eina_Unicode *str)
 {
    int slen = (str) ? (int)eina_unicode_strlen(str) : -1;
    return eina_ustringshare_add_length(str, slen);
 }
 
-EAPI const Eina_Unicode *
+EINA_API const Eina_Unicode *
 eina_ustringshare_ref(const Eina_Unicode *str)
 {
    return (const Eina_Unicode *)eina_share_common_ref(ustringshare_share,
                                                       (const char *)str);
 }
 
-EAPI int
+EINA_API int
 eina_ustringshare_strlen(const Eina_Unicode *str)
 {
    int len = eina_share_common_length(ustringshare_share, (const char *)str);
@@ -182,7 +182,7 @@ eina_ustringshare_strlen(const Eina_Unicode *str)
    return len;
 }
 
-EAPI void
+EINA_API void
 eina_ustringshare_dump(void)
 {
    eina_share_common_dump(ustringshare_share, NULL, 0);

--- a/src/lib/eina/eina_ustringshare.h
+++ b/src/lib/eina/eina_ustringshare.h
@@ -109,7 +109,7 @@
  *
  * @see eina_ustringshare_add()
  */
-EAPI const Eina_Unicode *eina_ustringshare_add_length(const Eina_Unicode *str, unsigned int slen) EINA_WARN_UNUSED_RESULT;
+EINA_API const Eina_Unicode *eina_ustringshare_add_length(const Eina_Unicode *str, unsigned int slen) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Retrieves an instance of a string for use in a program.
@@ -130,7 +130,7 @@ EAPI const Eina_Unicode *eina_ustringshare_add_length(const Eina_Unicode *str, u
  *
  * @see eina_ustringshare_add_length()
  */
-EAPI const Eina_Unicode *eina_ustringshare_add(const Eina_Unicode *str) EINA_WARN_UNUSED_RESULT;
+EINA_API const Eina_Unicode *eina_ustringshare_add(const Eina_Unicode *str) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Increments references of the given shared string.
@@ -146,7 +146,7 @@ EAPI const Eina_Unicode *eina_ustringshare_add(const Eina_Unicode *str) EINA_WAR
  *
  * There is no unref since this is the work of eina_ustringshare_del().
  */
-EAPI const Eina_Unicode *eina_ustringshare_ref(const Eina_Unicode *str);
+EINA_API const Eina_Unicode *eina_ustringshare_ref(const Eina_Unicode *str);
 
 /**
  * @brief Notes that the given string has lost an instance.
@@ -161,7 +161,7 @@ EAPI const Eina_Unicode *eina_ustringshare_ref(const Eina_Unicode *str);
  * @note If the given pointer is not shared, bad things will happen, likely a
  * segmentation fault.
  */
-EAPI void                eina_ustringshare_del(const Eina_Unicode *str);
+EINA_API void                eina_ustringshare_del(const Eina_Unicode *str);
 
 /**
  * @brief Notes that the given string @b must be shared.
@@ -176,7 +176,7 @@ EAPI void                eina_ustringshare_del(const Eina_Unicode *str);
  * @note If the given pointer is not shared, bad things will happen, likely a
  * segmentation fault. If in doubt, try strlen().
  */
-EAPI int                 eina_ustringshare_strlen(const Eina_Unicode *str) EINA_PURE EINA_WARN_UNUSED_RESULT;
+EINA_API int                 eina_ustringshare_strlen(const Eina_Unicode *str) EINA_PURE EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Dumps the contents of the share_common.
@@ -184,7 +184,7 @@ EAPI int                 eina_ustringshare_strlen(const Eina_Unicode *str) EINA_
  * This function dumps all strings in the share_common to stdout with a
  * DDD: prefix per line and a memory usage summary.
  */
-EAPI void                eina_ustringshare_dump(void);
+EINA_API void                eina_ustringshare_dump(void);
 
 static inline Eina_Bool  eina_ustringshare_replace(const Eina_Unicode **p_str, const Eina_Unicode *news) EINA_ARG_NONNULL(1);
 static inline Eina_Bool  eina_ustringshare_replace_length(const Eina_Unicode **p_str, const Eina_Unicode *news, unsigned int slen) EINA_ARG_NONNULL(1);

--- a/src/lib/eina/eina_util.c
+++ b/src/lib/eina/eina_util.c
@@ -47,7 +47,7 @@
  *                                   API                                      *
  *============================================================================*/
 
-EAPI const char *
+EINA_API const char *
 eina_environment_home_get(void)
 {
    static char *home = NULL;
@@ -93,7 +93,7 @@ eina_environment_home_get(void)
    return home;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_environment_tmp_get(void)
 {
    static char *tmp = NULL;

--- a/src/lib/eina/eina_util.h
+++ b/src/lib/eina/eina_util.h
@@ -37,7 +37,7 @@
  *
  * @since 1.15
  */
-EAPI const char *eina_environment_home_get(void);
+EINA_API const char *eina_environment_home_get(void);
 
 /**
  * @brief Returns the content of the environment referred as TMPDIR on this system.
@@ -48,7 +48,7 @@ EAPI const char *eina_environment_home_get(void);
  *
  * @since 1.15
  */
-EAPI const char *eina_environment_tmp_get(void);
+EINA_API const char *eina_environment_tmp_get(void);
 
 /**
  * @brief Warningless comparison of doubles using ==

--- a/src/lib/eina/eina_value.c
+++ b/src/lib/eina/eina_value.c
@@ -52,7 +52,7 @@
 # include <evil_private.h>
 #endif
 
-EAPI Eina_Error EINA_ERROR_VALUE_FAILED = 0;
+EINA_API Eina_Error EINA_ERROR_VALUE_FAILED = 0;
 
 /*============================================================================*
 *                                  Local                                     *
@@ -4103,7 +4103,7 @@ _eina_value_type_struct_ops_get(const Eina_Value_Struct *st)
    return st->desc->ops;
 }
 
-EAPI const Eina_Value_Struct_Member *
+EINA_API const Eina_Value_Struct_Member *
 eina_value_struct_member_find(const Eina_Value_Struct *st, const char *name)
 {
    const Eina_Value_Struct_Operations *ops;
@@ -4588,7 +4588,7 @@ _eina_value_type_optional_flush(const Eina_Value_Type *type EINA_UNUSED, void *m
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_value_optional_reset(Eina_Value *value)
 {
    void *mem = eina_value_memory_get(value);
@@ -4597,7 +4597,7 @@ eina_value_optional_reset(Eina_Value *value)
    return _eina_value_type_optional_flush(EINA_VALUE_TYPE_OPTIONAL, mem);
 }
 
-EAPI Eina_Value*
+EINA_API Eina_Value*
 eina_value_optional_new(Eina_Value_Type const *subtype,
                         const void* initial_value) EINA_ARG_NONNULL(1, 2)
 {
@@ -4620,7 +4620,7 @@ eina_value_optional_new(Eina_Value_Type const *subtype,
    return value;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_value_optional_pset(Eina_Value *value,
                          Eina_Value_Type const* subtype,
                          const void *subvalue) EINA_ARG_NONNULL(1, 2, 3)
@@ -4653,7 +4653,7 @@ eina_value_optional_pset(Eina_Value *value,
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_value_optional_pget(Eina_Value *value, void *subvalue) EINA_ARG_NONNULL(1, 2, 3)
 {
    if(sizeof(Eina_Value_Optional_Outer) <= sizeof(Eina_Value_Union))
@@ -4775,7 +4775,7 @@ _eina_value_type_eina_error_convert_to(const Eina_Value_Type *type, const Eina_V
    return _eina_value_type_int_convert_to(type, convert, type_mem, convert_mem);
 }
 
-EAPI const Eina_Value_Type _EINA_VALUE_TYPE_OPTIONAL = {
+EINA_API const Eina_Value_Type _EINA_VALUE_TYPE_OPTIONAL = {
   EINA_VALUE_TYPE_VERSION,
   sizeof(Eina_Value_Union),
   "optional",
@@ -4906,7 +4906,7 @@ _eina_value_type_file_pget(const Eina_Value_Type *type EINA_UNUSED, const void *
    return EINA_TRUE;
 }
 
-EAPI const Eina_Value_Type _EINA_VALUE_TYPE_FILE = {
+EINA_API const Eina_Value_Type _EINA_VALUE_TYPE_FILE = {
   EINA_VALUE_TYPE_VERSION,
   sizeof (Eina_File *),
   "Eina_File",
@@ -5020,7 +5020,7 @@ _eina_value_type_rectangle_pget(const Eina_Value_Type *type EINA_UNUSED, const v
    return EINA_TRUE;
 }
 
-EAPI const Eina_Value_Type _EINA_VALUE_TYPE_RECTANGLE = {
+EINA_API const Eina_Value_Type _EINA_VALUE_TYPE_RECTANGLE = {
   EINA_VALUE_TYPE_VERSION,
   sizeof (Eina_Rectangle),
   "Eina_Rectangle",
@@ -5380,7 +5380,7 @@ _eina_value_inner_free_internal(int size, void *mem)
    _eina_value_inner_mp_dispose(size, imp);
 }
 
-EAPI void *
+EINA_API void *
 eina_value_inner_alloc(size_t size)
 {
    void *mem;
@@ -5394,7 +5394,7 @@ eina_value_inner_alloc(size_t size)
    return mem;
 }
 
-EAPI void
+EINA_API void
 eina_value_inner_free(size_t size, void *mem)
 {
    if (size > 256)
@@ -5598,45 +5598,45 @@ eina_value_shutdown(void)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_START = NULL;
-EAPI const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_END = NULL;
+EINA_API const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_START = NULL;
+EINA_API const Eina_Value_Type *_EINA_VALUE_TYPE_BASICS_END = NULL;
 
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_VALUE = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_ERROR = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_UCHAR = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_BOOL = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_USHORT = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_UINT = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_ULONG = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_TIMESTAMP = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_UINT64 = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_CHAR = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_SHORT = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_INT = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_LONG = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_INT64 = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_FLOAT = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_DOUBLE = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_STRINGSHARE = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_STRING = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_ARRAY = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_LIST = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_HASH = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_TIMEVAL = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_BLOB = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_STRUCT = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_OPTIONAL = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_FILE = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_RECTANGLE = NULL;
-EAPI const Eina_Value_Type *EINA_VALUE_TYPE_TM = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_VALUE = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_ERROR = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_UCHAR = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_BOOL = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_USHORT = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_UINT = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_ULONG = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_TIMESTAMP = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_UINT64 = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_CHAR = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_SHORT = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_INT = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_LONG = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_INT64 = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_FLOAT = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_DOUBLE = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_STRINGSHARE = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_STRING = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_ARRAY = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_LIST = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_HASH = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_TIMEVAL = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_BLOB = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_STRUCT = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_OPTIONAL = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_FILE = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_RECTANGLE = NULL;
+EINA_API const Eina_Value_Type *EINA_VALUE_TYPE_TM = NULL;
 
 
-EAPI const Eina_Value_Blob_Operations *EINA_VALUE_BLOB_OPERATIONS_MALLOC = NULL;
+EINA_API const Eina_Value_Blob_Operations *EINA_VALUE_BLOB_OPERATIONS_MALLOC = NULL;
 
-EAPI const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_BINSEARCH = NULL;
-EAPI const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_STRINGSHARE = NULL;
+EINA_API const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_BINSEARCH = NULL;
+EINA_API const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_STRINGSHARE = NULL;
 
-EAPI Eina_Value *
+EINA_API Eina_Value *
 eina_value_new(const Eina_Value_Type *type)
 {
    Eina_Value *value = eina_mempool_malloc(_eina_value_mp, sizeof(Eina_Value));
@@ -5654,7 +5654,7 @@ eina_value_new(const Eina_Value_Type *type)
    return value;
 }
 
-EAPI void
+EINA_API void
 eina_value_free(Eina_Value *value)
 {
    if (!value) return;
@@ -5663,7 +5663,7 @@ eina_value_free(Eina_Value *value)
 }
 
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_value_copy(const Eina_Value *value, Eina_Value *copy)
 {
    const Eina_Value_Type *type;
@@ -5697,7 +5697,7 @@ eina_value_copy(const Eina_Value *value, Eina_Value *copy)
    return ret;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_value_convert(const Eina_Value *value, Eina_Value *convert)
 {
    Eina_Bool ret = EINA_FALSE;
@@ -5728,7 +5728,7 @@ eina_value_convert(const Eina_Value *value, Eina_Value *convert)
    return ret;
 }
 
-EAPI char *
+EINA_API char *
 eina_value_to_string(const Eina_Value *value)
 {
    Eina_Value tmp;
@@ -5744,7 +5744,7 @@ eina_value_to_string(const Eina_Value *value)
    return tmp.value.ptr; /* steal value */
 }
 
-EAPI Eina_Binbuf *
+EINA_API Eina_Binbuf *
 eina_value_to_binbuf(Eina_Value *value)
 {
    Eina_Value tmp = EINA_VALUE_EMPTY;
@@ -5772,7 +5772,7 @@ eina_value_to_binbuf(Eina_Value *value)
    return buf;
 }
 
-EAPI Eina_Value *
+EINA_API Eina_Value *
 eina_value_array_new(const Eina_Value_Type *subtype, unsigned int step)
 {
    Eina_Value *value;
@@ -5792,7 +5792,7 @@ eina_value_array_new(const Eina_Value_Type *subtype, unsigned int step)
    return value;
 }
 
-EAPI Eina_Value *
+EINA_API Eina_Value *
 eina_value_list_new(const Eina_Value_Type *subtype)
 {
    Eina_Value *value;
@@ -5812,7 +5812,7 @@ eina_value_list_new(const Eina_Value_Type *subtype)
    return value;
 }
 
-EAPI Eina_Value *
+EINA_API Eina_Value *
 eina_value_hash_new(const Eina_Value_Type *subtype, unsigned int buckets_power_size)
 {
    Eina_Value *value;
@@ -5832,7 +5832,7 @@ eina_value_hash_new(const Eina_Value_Type *subtype, unsigned int buckets_power_s
    return value;
 }
 
-EAPI Eina_Value *
+EINA_API Eina_Value *
 eina_value_struct_new(const Eina_Value_Struct_Desc *desc)
 {
    Eina_Value *value;
@@ -5850,14 +5850,14 @@ eina_value_struct_new(const Eina_Value_Struct_Desc *desc)
    return value;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_value_type_check(const Eina_Value_Type *type)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(type, EINA_FALSE);
    return type->version == EINA_VALUE_TYPE_VERSION;
 }
 
-EAPI const char *
+EINA_API const char *
 eina_value_type_name_get(const Eina_Value_Type *type)
 {
    EINA_SAFETY_ON_FALSE_RETURN_VAL(eina_value_type_check(type), NULL);

--- a/src/lib/eina/eina_value.h
+++ b/src/lib/eina/eina_value.h
@@ -361,7 +361,7 @@ union _Eina_Value_Union
  *
  * @since 1.21
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_ERROR;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_ERROR;
 
 /**
  * @var EINA_VALUE_TYPE_VALUE
@@ -372,7 +372,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_ERROR;
  *
  * @since 1.21
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_VALUE;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_VALUE;
 
 /**
  * @var EINA_VALUE_TYPE_UCHAR
@@ -380,7 +380,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_VALUE;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_UCHAR;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_UCHAR;
 
 /**
  * @var EINA_VALUE_TYPE_UCHAR
@@ -388,7 +388,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_UCHAR;
  *
  * @since 1.21
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_BOOL;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_BOOL;
 
 /**
  * @var EINA_VALUE_TYPE_USHORT
@@ -396,7 +396,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_BOOL;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_USHORT;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_USHORT;
 
 /**
  * @var EINA_VALUE_TYPE_UINT
@@ -404,7 +404,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_USHORT;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_UINT;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_UINT;
 
 /**
  * @var EINA_VALUE_TYPE_ULONG
@@ -412,7 +412,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_UINT;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_ULONG;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_ULONG;
 
 /**
  * @var EINA_VALUE_TYPE_TIMESTAMP
@@ -421,7 +421,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_ULONG;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_TIMESTAMP;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_TIMESTAMP;
 
 /**
  * @var EINA_VALUE_TYPE_UINT64
@@ -429,7 +429,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_TIMESTAMP;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_UINT64;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_UINT64;
 
 /**
  * @var EINA_VALUE_TYPE_CHAR
@@ -437,7 +437,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_UINT64;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_CHAR;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_CHAR;
 
 /**
  * @var EINA_VALUE_TYPE_SHORT
@@ -445,7 +445,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_CHAR;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_SHORT;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_SHORT;
 
 /**
  * @var EINA_VALUE_TYPE_INT
@@ -453,7 +453,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_SHORT;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_INT;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_INT;
 
 /**
  * @var EINA_VALUE_TYPE_LONG
@@ -461,7 +461,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_INT;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_LONG;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_LONG;
 
 /**
  * @var EINA_VALUE_TYPE_INT64
@@ -469,7 +469,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_LONG;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_INT64;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_INT64;
 
 /**
  * @var EINA_VALUE_TYPE_FLOAT
@@ -477,7 +477,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_INT64;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_FLOAT;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_FLOAT;
 
 /**
  * @var EINA_VALUE_TYPE_DOUBLE
@@ -485,7 +485,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_FLOAT;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_DOUBLE;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_DOUBLE;
 
 /**
  * @var EINA_VALUE_TYPE_STRINGSHARE
@@ -493,7 +493,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_DOUBLE;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_STRINGSHARE;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_STRINGSHARE;
 
 /**
  * @var EINA_VALUE_TYPE_STRING
@@ -501,7 +501,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_STRINGSHARE;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_STRING;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_STRING;
 
 
 /**
@@ -525,7 +525,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_STRING;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_ARRAY;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_ARRAY;
 
 /**
  * @var EINA_VALUE_TYPE_LIST
@@ -547,7 +547,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_ARRAY;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_LIST;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_LIST;
 
 /**
  * @var EINA_VALUE_TYPE_HASH
@@ -576,7 +576,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_LIST;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_HASH;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_HASH;
 
 /**
  * @var EINA_VALUE_TYPE_TIMEVAL
@@ -590,7 +590,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_HASH;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_TIMEVAL;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_TIMEVAL;
 
 /**
  * @var EINA_VALUE_TYPE_BLOB
@@ -606,7 +606,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_TIMEVAL;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_BLOB;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_BLOB;
 
 /**
  * @var EINA_VALUE_TYPE_STRUCT
@@ -628,7 +628,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_BLOB;
  *
  * @since 1.2
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_STRUCT;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_STRUCT;
 
 /**
  * @var EINA_VALUE_TYPE_TM
@@ -642,9 +642,9 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_STRUCT;
  *
  * @since 1.21
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_TM;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_TM;
 
-EAPI extern Eina_Error EINA_ERROR_VALUE_FAILED;
+EINA_API extern Eina_Error EINA_ERROR_VALUE_FAILED;
 
 /**
  * @defgroup Eina_Value_Value_Group Generic Value management
@@ -686,7 +686,7 @@ struct _Eina_Value
  *
  * @since 1.2
  */
-EAPI Eina_Value *eina_value_new(const Eina_Value_Type *type) EINA_ARG_NONNULL(1) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Value *eina_value_new(const Eina_Value_Type *type) EINA_ARG_NONNULL(1) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Frees value and its data.
@@ -696,7 +696,7 @@ EAPI Eina_Value *eina_value_new(const Eina_Value_Type *type) EINA_ARG_NONNULL(1)
  *
  * @since 1.2
  */
-EAPI void eina_value_free(Eina_Value *value);
+EINA_API void eina_value_free(Eina_Value *value);
 
 /**
  * @brief Initializes generic value storage.
@@ -758,7 +758,7 @@ static inline void eina_value_flush(Eina_Value *value) EINA_ARG_NONNULL(1);
  *
  * @since 1.2
  */
-EAPI Eina_Bool eina_value_copy(const Eina_Value *value,
+EINA_API Eina_Bool eina_value_copy(const Eina_Value *value,
                                Eina_Value *copy) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -1105,7 +1105,7 @@ static inline Eina_Bool eina_value_pget(const Eina_Value *value,
  *
  * @since 1.2
  */
-EAPI Eina_Bool eina_value_convert(const Eina_Value *value,
+EINA_API Eina_Bool eina_value_convert(const Eina_Value *value,
                                   Eina_Value *convert) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -1124,7 +1124,7 @@ EAPI Eina_Bool eina_value_convert(const Eina_Value *value,
  *
  * @since 1.20
  */
-EAPI Eina_Binbuf *eina_value_to_binbuf(Eina_Value *value);
+EINA_API Eina_Binbuf *eina_value_to_binbuf(Eina_Value *value);
 
 /**
  * @brief Converts value to string.
@@ -1136,7 +1136,7 @@ EAPI Eina_Binbuf *eina_value_to_binbuf(Eina_Value *value);
  * @see eina_value_to_binbuf()
  * @since 1.2
  */
-EAPI char *eina_value_to_string(const Eina_Value *value) EINA_ARG_NONNULL(1);
+EINA_API char *eina_value_to_string(const Eina_Value *value) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Queries value type.
@@ -1203,7 +1203,7 @@ struct _Eina_Value_Array
  *
  * @since 1.2
  */
-EAPI Eina_Value *eina_value_array_new(const Eina_Value_Type *subtype,
+EINA_API Eina_Value *eina_value_array_new(const Eina_Value_Type *subtype,
                                       unsigned int step) EINA_ARG_NONNULL(1);
 
 /**
@@ -1935,7 +1935,7 @@ struct _Eina_Value_List
  *
  * @since 1.2
  */
-EAPI Eina_Value *eina_value_list_new(const Eina_Value_Type *subtype) EINA_ARG_NONNULL(1);
+EINA_API Eina_Value *eina_value_list_new(const Eina_Value_Type *subtype) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Initializes generic value storage of type list.
@@ -2605,7 +2605,7 @@ struct _Eina_Value_Hash
  *
  * @since 1.2
  */
-EAPI Eina_Value *eina_value_hash_new(const Eina_Value_Type *subtype, unsigned int buckets_power_size) EINA_ARG_NONNULL(1);
+EINA_API Eina_Value *eina_value_hash_new(const Eina_Value_Type *subtype, unsigned int buckets_power_size) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Initializes generic value storage of type hash.
@@ -2970,7 +2970,7 @@ struct _Eina_Value_Blob_Operations
  *
  * No compare or to_string are provided, defaults will be used.
  */
-EAPI extern const Eina_Value_Blob_Operations *EINA_VALUE_BLOB_OPERATIONS_MALLOC;
+EINA_API extern const Eina_Value_Blob_Operations *EINA_VALUE_BLOB_OPERATIONS_MALLOC;
 
 /**
  * @typedef Eina_Value_Blob
@@ -3083,7 +3083,7 @@ struct _Eina_Value_Struct_Operations
  * No other methods are set (alloc, free, copy, compare), then it uses
  * the default operations.
  */
-EAPI extern const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_BINSEARCH;
+EINA_API extern const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_BINSEARCH;
 
 /**
  * @var EINA_VALUE_STRUCT_OPERATIONS_STRINGSHARE
@@ -3098,7 +3098,7 @@ EAPI extern const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_BIN
  * No other methods are set (alloc, free, copy, compare), then it uses
  * the default operations.
  */
-EAPI extern const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_STRINGSHARE;
+EINA_API extern const Eina_Value_Struct_Operations *EINA_VALUE_STRUCT_OPERATIONS_STRINGSHARE;
 
 /**
  * @struct _Eina_Value_Struct_Member
@@ -3223,7 +3223,7 @@ struct _Eina_Value_Struct
  *
  * @since 1.2
  */
-EAPI Eina_Value *eina_value_struct_new(const Eina_Value_Struct_Desc *desc) EINA_ARG_NONNULL(1);
+EINA_API Eina_Value *eina_value_struct_new(const Eina_Value_Struct_Desc *desc) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Initializes generic value storage of type struct.
@@ -3698,7 +3698,7 @@ struct _Eina_Value_Type
  *
  * @since 1.2
  */
-EAPI const char *eina_value_type_name_get(const Eina_Value_Type *type) EINA_PURE EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API const char *eina_value_type_name_get(const Eina_Value_Type *type) EINA_PURE EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Checks if type is valid.
@@ -3711,7 +3711,7 @@ EAPI const char *eina_value_type_name_get(const Eina_Value_Type *type) EINA_PURE
  *
  * @since 1.2
  */
-EAPI Eina_Bool eina_value_type_check(const Eina_Value_Type *type) EINA_PURE EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Bool eina_value_type_check(const Eina_Value_Type *type) EINA_PURE EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Initializes memory using type descriptor.
@@ -3837,7 +3837,7 @@ static inline Eina_Bool eina_value_type_pget(const Eina_Value_Type *type, const 
  *
  * @since 1.17
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_OPTIONAL;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_OPTIONAL;
 
 /**
  * @typedef Eina_Value_Optional type to be used with Eina_Value_Struct
@@ -3864,7 +3864,7 @@ static inline Eina_Value *eina_value_optional_empty_new(void);
  *
  * @since 1.17
  */
-EAPI Eina_Value *eina_value_optional_new(const Eina_Value_Type *subtype,
+EINA_API Eina_Value *eina_value_optional_new(const Eina_Value_Type *subtype,
                                          const void* value) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -3889,7 +3889,7 @@ static inline Eina_Bool eina_value_optional_empty_is(const Eina_Value *value,
  *
  * @since 1.17
  */
-EAPI Eina_Bool eina_value_optional_pset(Eina_Value *value,
+EINA_API Eina_Bool eina_value_optional_pset(Eina_Value *value,
                                         Eina_Value_Type const* subtype,
                                         const void *subvalue) EINA_ARG_NONNULL(1, 2, 3);
 
@@ -3903,7 +3903,7 @@ EAPI Eina_Bool eina_value_optional_pset(Eina_Value *value,
  *
  * @since 1.17
  */
-EAPI Eina_Bool eina_value_optional_pget(Eina_Value *value,
+EINA_API Eina_Bool eina_value_optional_pget(Eina_Value *value,
                                         void *subvalue) EINA_ARG_NONNULL(1, 2);
 
 /**
@@ -3914,7 +3914,7 @@ EAPI Eina_Bool eina_value_optional_pget(Eina_Value *value,
  *
  * @since 1.17
  */
-EAPI Eina_Bool eina_value_optional_reset(Eina_Value *value) EINA_ARG_NONNULL(1);
+EINA_API Eina_Bool eina_value_optional_reset(Eina_Value *value) EINA_ARG_NONNULL(1);
 
 /**
  *
@@ -3933,7 +3933,7 @@ static inline const Eina_Value_Type *eina_value_optional_type_get(Eina_Value *va
  *
  * @since 1.21
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_FILE;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_FILE;
 
 /**
  * @var EINA_VALUE_TYPE_RECTANGLE
@@ -3941,7 +3941,7 @@ EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_FILE;
  *
  * @since 1.21
  */
-EAPI extern const Eina_Value_Type *EINA_VALUE_TYPE_RECTANGLE;
+EINA_API extern const Eina_Value_Type *EINA_VALUE_TYPE_RECTANGLE;
 
 /**
  * @}

--- a/src/lib/eina/eina_value_util.c
+++ b/src/lib/eina/eina_value_util.c
@@ -73,7 +73,7 @@ static Eina_Value_Struct_Operations operations =
    NULL
 };
 
-EAPI Eina_Value_Struct_Desc *
+EINA_API Eina_Value_Struct_Desc *
 eina_value_util_struct_desc_new(void)
 {
    Eina_Value_Util_Struct_Desc *st_desc;
@@ -85,7 +85,7 @@ eina_value_util_struct_desc_new(void)
    return (Eina_Value_Struct_Desc*)st_desc;
 }
 
-EAPI Eina_Value *
+EINA_API Eina_Value *
 eina_value_util_time_string_new(const char *timestr)
 {
    Eina_Value *v;

--- a/src/lib/eina/eina_value_util.h
+++ b/src/lib/eina/eina_value_util.h
@@ -35,7 +35,7 @@
  *
  * @since 1.12
  */
-EAPI Eina_Value_Struct_Desc *eina_value_util_struct_desc_new(void);
+EINA_API Eina_Value_Struct_Desc *eina_value_util_struct_desc_new(void);
 
 /**
  * @brief Creates a new #Eina_Value containing the passed parameter.
@@ -45,7 +45,7 @@ EAPI Eina_Value_Struct_Desc *eina_value_util_struct_desc_new(void);
  *
  * @since 1.12
  */
-EAPI Eina_Value *eina_value_util_time_string_new(const char *timestr);
+EINA_API Eina_Value *eina_value_util_time_string_new(const char *timestr);
 
 #include "eina_inline_value_util.x"
 

--- a/src/lib/eina/eina_vpath.c
+++ b/src/lib/eina/eina_vpath.c
@@ -323,7 +323,7 @@ _eina_vpath_resolve(const char *path, char *str, size_t size)
    return 0;
 }
 
-EAPI char *
+EINA_API char *
 eina_vpath_resolve(const char* path)
 {
    char buf[PATH_MAX];
@@ -334,7 +334,7 @@ eina_vpath_resolve(const char* path)
    return NULL;
 }
 
-EAPI int
+EINA_API int
 eina_vpath_resolve_snprintf(char *str, size_t size, const char *format, ...)
 {
    va_list args;
@@ -364,7 +364,7 @@ eina_vpath_resolve_snprintf(char *str, size_t size, const char *format, ...)
    return 0;
 }
 
-EAPI void
+EINA_API void
 eina_vpath_interface_app_set(const char *app_domain, Eina_Prefix *app_pfx)
 {
    char buf[PATH_MAX];
@@ -391,7 +391,7 @@ eina_vpath_interface_app_set(const char *app_domain, Eina_Prefix *app_pfx)
    _eina_vpath_data_add("app.tmp", buf);
 }
 
-EAPI void
+EINA_API void
 eina_vpath_interface_user_set(Eina_Vpath_Interface_User *user)
 {
    Eina_Bool free_run = EINA_FALSE;

--- a/src/lib/eina/eina_vpath.h
+++ b/src/lib/eina/eina_vpath.h
@@ -98,7 +98,7 @@ typedef const char * Eina_Vpath;
  * @since 1.21
  *
  */
-EAPI char *eina_vpath_resolve(Eina_Vpath path);
+EINA_API char *eina_vpath_resolve(Eina_Vpath path);
 
 /**
  * Translate a virtual path into a normal path, and print it into str.
@@ -113,6 +113,6 @@ EAPI char *eina_vpath_resolve(Eina_Vpath path);
  * @since 1.21
  *
  */
-EAPI int eina_vpath_resolve_snprintf(char *str, size_t size, const char *format, ...);
+EINA_API int eina_vpath_resolve_snprintf(char *str, size_t size, const char *format, ...);
 #endif
 #endif

--- a/src/lib/eina/eina_xattr.c
+++ b/src/lib/eina/eina_xattr.c
@@ -183,7 +183,7 @@ _eina_xattr_ls_iterator_free(Eina_Xattr_Iterator *it)
  *                                   API                                      *
  *============================================================================*/
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_xattr_value_fd_ls(int fd)
 {
 #ifdef HAVE_XATTR
@@ -227,7 +227,7 @@ eina_xattr_value_fd_ls(int fd)
 #endif
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_xattr_fd_ls(int fd)
 {
 #ifdef HAVE_XATTR
@@ -263,7 +263,7 @@ eina_xattr_fd_ls(int fd)
 #endif
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_xattr_ls(const char *file)
 {
 #ifdef HAVE_XATTR
@@ -299,7 +299,7 @@ eina_xattr_ls(const char *file)
 #endif
 }
 
-EAPI Eina_Iterator *
+EINA_API Eina_Iterator *
 eina_xattr_value_ls(const char *file)
 {
 #ifdef HAVE_XATTR
@@ -345,7 +345,7 @@ eina_xattr_value_ls(const char *file)
 #endif
 }
 
-EAPI void *
+EINA_API void *
 eina_xattr_get(const char *file, const char *attribute, ssize_t *size)
 {
 #ifdef HAVE_XATTR
@@ -384,7 +384,7 @@ eina_xattr_get(const char *file, const char *attribute, ssize_t *size)
 #endif
 }
 
-EAPI void *
+EINA_API void *
 eina_xattr_fd_get(int fd, const char *attribute, ssize_t *size)
 {
 #ifdef HAVE_XATTR
@@ -422,7 +422,7 @@ eina_xattr_fd_get(int fd, const char *attribute, ssize_t *size)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_set(const char *file, const char *attribute, const void *data, ssize_t length, Eina_Xattr_Flags flags)
 {
 #ifdef HAVE_XATTR
@@ -455,7 +455,7 @@ eina_xattr_set(const char *file, const char *attribute, const void *data, ssize_
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_fd_set(int fd, const char *attribute, const void *data, ssize_t length, Eina_Xattr_Flags flags)
 {
 #ifdef HAVE_XATTR
@@ -487,7 +487,7 @@ eina_xattr_fd_set(int fd, const char *attribute, const void *data, ssize_t lengt
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_del(const char *file, const char *attribute)
 {
 #ifdef HAVE_XATTR
@@ -501,7 +501,7 @@ eina_xattr_del(const char *file, const char *attribute)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_fd_del(int fd, const char *attribute)
 {
 #ifdef HAVE_XATTR
@@ -514,7 +514,7 @@ eina_xattr_fd_del(int fd, const char *attribute)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_string_set(const char *file, const char *attribute, const char *data, Eina_Xattr_Flags flags)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(data, EINA_FALSE);
@@ -522,7 +522,7 @@ eina_xattr_string_set(const char *file, const char *attribute, const char *data,
    return eina_xattr_set(file, attribute, data, strlen(data) + 1, flags);
 }
 
-EAPI char *
+EINA_API char *
 eina_xattr_string_get(const char *file, const char *attribute)
 {
    char *tmp;
@@ -540,7 +540,7 @@ eina_xattr_string_get(const char *file, const char *attribute)
    return tmp;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_double_set(const char *file, const char *attribute, double value, Eina_Xattr_Flags flags)
 {
    char buffer[128];
@@ -549,7 +549,7 @@ eina_xattr_double_set(const char *file, const char *attribute, double value, Ein
    return eina_xattr_string_set(file, attribute, buffer, flags);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_double_get(const char *file, const char *attribute, double *value)
 {
    char *tmp;
@@ -573,7 +573,7 @@ eina_xattr_double_get(const char *file, const char *attribute, double *value)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_int_set(const char *file, const char *attribute, int value, Eina_Xattr_Flags flags)
 {
    char buffer[10];
@@ -582,7 +582,7 @@ eina_xattr_int_set(const char *file, const char *attribute, int value, Eina_Xatt
    return eina_xattr_string_set(file, attribute, buffer, flags);
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_int_get(const char *file, const char *attribute, int *value)
 {
    char *tmp;
@@ -601,7 +601,7 @@ eina_xattr_int_get(const char *file, const char *attribute, int *value)
    return result;
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_copy(const char *src, const char *dst)
 {
 #ifdef HAVE_XATTR
@@ -632,7 +632,7 @@ eina_xattr_copy(const char *src, const char *dst)
 #endif
 }
 
-EAPI Eina_Bool
+EINA_API Eina_Bool
 eina_xattr_fd_copy(int src, int dst)
 {
 #ifdef HAVE_XATTR

--- a/src/lib/eina/eina_xattr.h
+++ b/src/lib/eina/eina_xattr.h
@@ -67,7 +67,7 @@ struct _Eina_Xattr
  *
  * @since 1.1
  */
-EAPI Eina_Iterator *eina_xattr_ls(const char *file) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_xattr_ls(const char *file) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets an iterator that list all extended attribute value related to a fd.
@@ -80,7 +80,7 @@ EAPI Eina_Iterator *eina_xattr_ls(const char *file) EINA_ARG_NONNULL(1) EINA_WAR
  *
  * @since 1.2
  */
-EAPI Eina_Iterator *eina_xattr_value_ls(const char *file) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_xattr_value_ls(const char *file) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets an iterator that list all extended attribute related to a fd.
@@ -93,7 +93,7 @@ EAPI Eina_Iterator *eina_xattr_value_ls(const char *file) EINA_ARG_NONNULL(1) EI
  *
  * @since 1.2
  */
-EAPI Eina_Iterator *eina_xattr_fd_ls(int fd) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_xattr_fd_ls(int fd) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Gets an iterator that list all extended attribute value related to a fd.
@@ -106,7 +106,7 @@ EAPI Eina_Iterator *eina_xattr_fd_ls(int fd) EINA_WARN_UNUSED_RESULT;
  *
  * @since 1.2
  */
-EAPI Eina_Iterator *eina_xattr_value_fd_ls(int fd) EINA_WARN_UNUSED_RESULT;
+EINA_API Eina_Iterator *eina_xattr_value_fd_ls(int fd) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Copies the extended attribute from one file to another.
@@ -119,7 +119,7 @@ EAPI Eina_Iterator *eina_xattr_value_fd_ls(int fd) EINA_WARN_UNUSED_RESULT;
  *
  * @since 1.8
  */
-EAPI Eina_Bool eina_xattr_copy(const char *src, const char *dst) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_xattr_copy(const char *src, const char *dst) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Copies the extended attribute from one file descriptor to another.
@@ -132,7 +132,7 @@ EAPI Eina_Bool eina_xattr_copy(const char *src, const char *dst) EINA_ARG_NONNUL
  *
  * @since 1.8
  */
-EAPI Eina_Bool eina_xattr_fd_copy(int src, int dst);
+EINA_API Eina_Bool eina_xattr_fd_copy(int src, int dst);
 
 /**
  * @brief Retrieves an extended attribute from a file.
@@ -146,7 +146,7 @@ EAPI Eina_Bool eina_xattr_fd_copy(int src, int dst);
  *
  * @since 1.1
  */
-EAPI void *eina_xattr_get(const char *file, const char *attribute, ssize_t *size) EINA_ARG_NONNULL(1, 2, 3) EINA_WARN_UNUSED_RESULT;
+EINA_API void *eina_xattr_get(const char *file, const char *attribute, ssize_t *size) EINA_ARG_NONNULL(1, 2, 3) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Retrieves an extended attribute from a file descriptor.
@@ -160,7 +160,7 @@ EAPI void *eina_xattr_get(const char *file, const char *attribute, ssize_t *size
  *
  * @since 1.8
  */
-EAPI void *eina_xattr_fd_get(int fd, const char *attribute, ssize_t *size) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
+EINA_API void *eina_xattr_fd_get(int fd, const char *attribute, ssize_t *size) EINA_ARG_NONNULL(2, 3) EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Sets an extended attribute on a file.
@@ -174,7 +174,7 @@ EAPI void *eina_xattr_fd_get(int fd, const char *attribute, ssize_t *size) EINA_
  *
  * @since 1.1
  */
-EAPI Eina_Bool eina_xattr_set(const char *file, const char *attribute, const void *data, ssize_t length, Eina_Xattr_Flags flags) EINA_ARG_NONNULL(1, 2, 3);
+EINA_API Eina_Bool eina_xattr_set(const char *file, const char *attribute, const void *data, ssize_t length, Eina_Xattr_Flags flags) EINA_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief Sets an extended attribute on a file descriptor.
@@ -188,7 +188,7 @@ EAPI Eina_Bool eina_xattr_set(const char *file, const char *attribute, const voi
  *
  * @since 1.8
  */
-EAPI Eina_Bool eina_xattr_fd_set(int fd, const char *attribute, const void *data, ssize_t length, Eina_Xattr_Flags flags) EINA_ARG_NONNULL(2, 3);
+EINA_API Eina_Bool eina_xattr_fd_set(int fd, const char *attribute, const void *data, ssize_t length, Eina_Xattr_Flags flags) EINA_ARG_NONNULL(2, 3);
 
 
 /**
@@ -200,7 +200,7 @@ EAPI Eina_Bool eina_xattr_fd_set(int fd, const char *attribute, const void *data
  *
  * @since 1.8
  */
-EAPI Eina_Bool eina_xattr_del(const char *file, const char *attribute) EINA_ARG_NONNULL(1, 2);
+EINA_API Eina_Bool eina_xattr_del(const char *file, const char *attribute) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief Deletes (removes) an extended attribute from a file descriptor.
@@ -211,7 +211,7 @@ EAPI Eina_Bool eina_xattr_del(const char *file, const char *attribute) EINA_ARG_
  *
  * @since 1.8
  */
-EAPI Eina_Bool eina_xattr_fd_del(int fd, const char *attribute) EINA_ARG_NONNULL(2);
+EINA_API Eina_Bool eina_xattr_fd_del(int fd, const char *attribute) EINA_ARG_NONNULL(2);
 
 /**
  * @brief Sets a string as a extended attribute properties.
@@ -224,7 +224,7 @@ EAPI Eina_Bool eina_xattr_fd_del(int fd, const char *attribute) EINA_ARG_NONNULL
  *
  * @since 1.1
  */
-EAPI Eina_Bool eina_xattr_string_set(const char *file, const char *attribute, const char *data, Eina_Xattr_Flags flags);
+EINA_API Eina_Bool eina_xattr_string_set(const char *file, const char *attribute, const char *data, Eina_Xattr_Flags flags);
 
 /**
  * @brief Gets a string from an extended attribute properties.
@@ -237,7 +237,7 @@ EAPI Eina_Bool eina_xattr_string_set(const char *file, const char *attribute, co
  *
  * @since 1.1
  */
-EAPI char *eina_xattr_string_get(const char *file, const char *attribute);
+EINA_API char *eina_xattr_string_get(const char *file, const char *attribute);
 
 /**
  * @brief Sets a double as a extended attribute properties.
@@ -250,7 +250,7 @@ EAPI char *eina_xattr_string_get(const char *file, const char *attribute);
  *
  * @since 1.1
  */
-EAPI Eina_Bool eina_xattr_double_set(const char *file, const char *attribute, double value, Eina_Xattr_Flags flags);
+EINA_API Eina_Bool eina_xattr_double_set(const char *file, const char *attribute, double value, Eina_Xattr_Flags flags);
 
 /**
  * @brief Gets a double from an extended attribute properties.
@@ -264,7 +264,7 @@ EAPI Eina_Bool eina_xattr_double_set(const char *file, const char *attribute, do
  *
  * @since 1.1
  */
-EAPI Eina_Bool eina_xattr_double_get(const char *file, const char *attribute, double *value);
+EINA_API Eina_Bool eina_xattr_double_get(const char *file, const char *attribute, double *value);
 
 /**
  * @brief Sets an int as a extended attribute properties.
@@ -277,7 +277,7 @@ EAPI Eina_Bool eina_xattr_double_get(const char *file, const char *attribute, do
  *
  * @since 1.1
  */
-EAPI Eina_Bool eina_xattr_int_set(const char *file, const char *attribute, int value, Eina_Xattr_Flags flags);
+EINA_API Eina_Bool eina_xattr_int_set(const char *file, const char *attribute, int value, Eina_Xattr_Flags flags);
 
 /**
  * @brief Gets a int from an extended attribute properties.
@@ -291,7 +291,7 @@ EAPI Eina_Bool eina_xattr_int_set(const char *file, const char *attribute, int v
  *
  * @since 1.1
  */
-EAPI Eina_Bool eina_xattr_int_get(const char *file, const char *attribute, int *value);
+EINA_API Eina_Bool eina_xattr_int_get(const char *file, const char *attribute, int *value);
 
 /**
  * @}

--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -398,7 +398,7 @@ execinfo = cc.find_library('execinfo', required: false)
 eina_ext_deps += [execinfo]
 
 eina_lib = library('eina', eina_src,
-  c_args : package_c_args,
+  c_args : [package_c_args, '-DEINA_BUILD'],
   include_directories : config_dir,
   dependencies: eina_ext_deps + [eina_deps, evil],
   install: true,

--- a/src/lib/evas/common/evas_font_ot.h
+++ b/src/lib/evas/common/evas_font_ot.h
@@ -33,6 +33,7 @@ struct _Evas_Font_OT_Info
 # endif
 
 #include "evas_font.h"
+#include "Evas.h"
 
 EAPI int
 evas_common_font_ot_cluster_size_get(const Evas_Text_Props *props, size_t char_index);

--- a/src/lib/evas/common/evas_op_blend/op_blend_master_sse3.c
+++ b/src/lib/evas/common/evas_op_blend/op_blend_master_sse3.c
@@ -1,7 +1,7 @@
 #define NEED_SSE3 1
 
 #include "Eina.h"
-
+#include "Evas.h"
 #include "evas_common_types.h"
 
 EAPI void evas_common_cpu_end_opt(void);

--- a/src/tests/eina/eina_test_abi.c
+++ b/src/tests/eina/eina_test_abi.c
@@ -43,8 +43,6 @@ typedef uint32_t Eina_Unicode;
 #include "eina_main.h"
 #include "eina_safety_checks.h"
 
-EAPI Eina_Unicode eina_unicode_utf8_get_next(const char *buf, int *iindex);
-
 EFL_START_TEST(eina_unicode_utf8)
 {
    int ind;

--- a/src/tests/eina/eina_test_module_dummy.c
+++ b/src/tests/eina/eina_test_module_dummy.c
@@ -16,7 +16,7 @@ void dummy_module_shutdown(void)
 
 }
 
-EAPI int dummy_symbol = 0xbad;
+EINA_API int dummy_symbol = 0xbad;
 
 EINA_MODULE_INIT(dummy_module_init);
 EINA_MODULE_SHUTDOWN(dummy_module_shutdown);


### PR DESCRIPTION
Separate Eina exporting/importing symbols from other libraries. Other
libraries will also be separated.

This makes it easier to rationalize and fix problems when
importing/exporting symbols in platforms such as Windows which
separates importing from exporting.

Also, I've made DLL standard. If built as static needs to define
EINA_STATIC. This way, users of the shared library will not need
to define anything to use it.

Differential Revision: https://phab.enlightenment.org/D11993