### PR TITLE
Declare ignored subprojects as empty dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -540,6 +540,7 @@ foreach package : subprojects
 
   if package_name in ignored_subprojects
     warning('Ignoring package ' + package_name)
+    set_variable(package_name, declare_dependency())
     continue
   endif
   message('Including package ' + package_name)


### PR DESCRIPTION
Some libs may try to use libs that are being ignored those causing
an undefined symbol at `configure.bat`, by declaring them as empty
dependencies this isn't a problem.