### PR TITLE
Add dependency guards

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -763,12 +763,18 @@ foreach package : subprojects
 endforeach
 
 #build this later, as the debug services are depending on ecore
-if 'ecore' not in ignored_subprojects
+if 'ecore_con' not in ignored_subprojects
   subdir(join_paths('src', 'bin', 'efl'))
+endif
 
+if 'evas' not in ignored_subprojects
   subdir(join_paths('src', 'generic', 'evas'))
-  subdir('cmakeconfig')
-  subdir(join_paths('src', 'bindings'))
+endif
+
+subdir('cmakeconfig')
+subdir(join_paths('src', 'bindings'))
+
+if 'edje' not in ignored_subprojects
   subdir(join_paths('src', 'edje_external'))
   subdir(join_paths('data'))
 endif


### PR DESCRIPTION
While compiling `ecore` it was possible to notice that:
- `src/bin/efl` depends on `ecore_con`;
- `src/generic/evas` depends on `evas`;
- `src/edje_external` and `data` depends on `edje`;

So this PR adds some guards for them.