### PR TITLE
build: Use PKG_CONFIG_LIBDIR to ignore pkg-config from strawberry-perl

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -36,6 +36,8 @@ exit /B %errorlevel%
         exit /B 1
     )
     set all_set=
+
+    set pkg_config_libdir=thistotallydoesnotexist
 exit /B 0
 
 


### PR DESCRIPTION
This will probably make some new breaking changes, e.g. `libjpeg` not being found anymore :) But it is for good.