### PR TITLE
windows: Implement ftruncate

### DIFF
--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -93,21 +93,6 @@ evil_time_get(void)
    return (double)_evil_time_second + (double)(count.QuadPart - _evil_time_count)/ (double)_evil_time_freq;
 }
 
-void
-usleep(__int64 usec)
-{
-   HANDLE timer;
-   LARGE_INTEGER ft;
-
-   ft.QuadPart = -(10*usec); // Convert to 100 nanosecond interval, negative value indicates relative time
-
-   timer = CreateWaitableTimer(NULL, TRUE, NULL);
-   SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
-   WaitForSingleObject(timer, INFINITE);
-   CloseHandle(timer);
-}
-
-
 /*
  * Sockets and pipe related functions
  *

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -62,7 +62,7 @@ ftruncate(int fd, off_t size)
 {
    HANDLE file = (HANDLE)_get_osfhandle(fd);
 
-   if (SetFilePointer(file, (LONG)size, 0, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
+   if (SetFilePointer(file, (LONG)size, NULL, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
      {
        _set_errno(EINVAL);
        return -1;

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -64,12 +64,14 @@ ftruncate(int fd, off_t size)
 
    if (SetFilePointer(file, (LONG)size, 0, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
      {
-       return EINVAL;
+       _set_errno(EINVAL);
+       return -1;
      }
 
    if (!SetEndOfFile(file))
      {
-       return EIO;
+       _set_errno(EIO);
+       return -1;
      }
 
     return 0;

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -57,7 +57,7 @@ execvp(const char *file, char *const argv[])
    return _execvp(file, (const char *const *)argv);
 }
 
-int
+EVIL_API int
 ftruncate(int fd, off_t size)
 {
    HANDLE file = (HANDLE)_get_osfhandle(fd);

--- a/src/lib/evil/evil_unistd.h
+++ b/src/lib/evil/evil_unistd.h
@@ -22,6 +22,7 @@
 #include <process.h> // for _execvp (but not execvp), getpid
 #undef execvp 
 EVIL_API int execvp(const char *file, char *const argv[]);
+EVIL_API int ftruncate(int fd, off_t size);
 
 /* Values for the second argument to access.  These may be OR'd together.  */
 #define R_OK    4       /* Test for read permission.  */

--- a/src/tests/evil/evil_suite.c
+++ b/src/tests/evil/evil_suite.c
@@ -33,7 +33,7 @@
 #include "../efl_check.h"
 
 static const Efl_Test_Case etc[] = {
-   // { "Dlfcn", evil_test_dlfcn },
+   { "Dlfcn", evil_test_dlfcn },
    /* { "Fcntl", evil_test_fcntl }, */
    /* { "Langinfo", evil_test_langinfo }, */
    { "Main", evil_test_main },

--- a/src/tests/evil/evil_suite.c
+++ b/src/tests/evil/evil_suite.c
@@ -33,7 +33,7 @@
 #include "../efl_check.h"
 
 static const Efl_Test_Case etc[] = {
-   { "Dlfcn", evil_test_dlfcn },
+   // { "Dlfcn", evil_test_dlfcn },
    /* { "Fcntl", evil_test_fcntl }, */
    /* { "Langinfo", evil_test_langinfo }, */
    { "Main", evil_test_main },


### PR DESCRIPTION
Recreating #151, now with native-windows as base.

Also reenables evil tests and implements a test case for ftruncate.
I noticed that evil_test_dlfcn is failing and I'll try to fix it in a subsequent PR.

Depends on #109 