### PR TITLE
Resolve typo `EDJE_WEAK_API` to `EDJE_API_WEAK`

### DIFF
--- a/src/lib/edje/edje_edit_eo.h
+++ b/src/lib/edje/edje_edit_eo.h
@@ -23,6 +23,6 @@ typedef Eo Edje_Edit;
  */
 #define EDJE_EDIT_CLASS edje_edit_class_get()
 
-EDJE_API EDJE_WEAK_API const Efl_Class *edje_edit_class_get(void);
+EDJE_API EDJE_API_WEAK const Efl_Class *edje_edit_class_get(void);
 
 #endif


### PR DESCRIPTION
This should resolve the current CI error.
It needs #200 and #201 to see the error, You can see it at the build log given at #201.
This [branch](https://github.com/expertisesolutions/efl/tree/devs/coquinho/edje_api_weak) has #200, #201 and this one so you can see a new [log](https://travis-ci.com/github/expertisesolutions/efl/builds/173753227).
The error shown *should* be addressed by #180  