### PR TITLE
[eet] Use EET_API instead of EAPI

### DIFF
--- a/src/lib/eet/Eet.h
+++ b/src/lib/eet/Eet.h
@@ -100,31 +100,7 @@
 #include <Eina.h>
 #include <Emile.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <eet_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -179,7 +155,7 @@ typedef struct _Eet_Version
    int revision; /** < svn revision (0 if a proper release or the svn revision number Eet is built from) */
 } Eet_Version;
 
-EAPI extern Eet_Version *eet_version;
+EET_API extern Eet_Version *eet_version;
 
 /**
  * @defgroup Eet_Group Top level functions
@@ -267,7 +243,7 @@ typedef enum _Eet_Compression
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_init(void);
 
 /**
@@ -283,7 +259,7 @@ eet_init(void);
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_shutdown(void);
 
 /**
@@ -302,7 +278,7 @@ eet_shutdown(void);
  *
  * @since 1.0.0
  */
-EAPI void
+EET_API void
 eet_clearcache(void);
 
 /**
@@ -592,7 +568,7 @@ struct _Eet_Entry
  *
  * @since 1.0.0
  */
-EAPI Eet_File *
+EET_API Eet_File *
 eet_open(const char *file,
          Eet_File_Mode mode);
 
@@ -618,7 +594,7 @@ eet_open(const char *file,
  *
  * @since 1.8.0
  */
-EAPI Eet_File *
+EET_API Eet_File *
 eet_mmap(const Eina_File *file);
 
 /**
@@ -635,7 +611,7 @@ eet_mmap(const Eina_File *file);
  *
  * @since 1.1.0
  */
-EAPI Eet_File *
+EET_API Eet_File *
 eet_memopen_read(const void *data,
                  size_t size);
 
@@ -647,7 +623,7 @@ eet_memopen_read(const void *data,
  *
  * @since 1.0.0
  */
-EAPI Eet_File_Mode
+EET_API Eet_File_Mode
 eet_mode_get(Eet_File *ef);
 
 /**
@@ -665,10 +641,10 @@ eet_mode_get(Eet_File *ef);
  * If the eet file handle is not valid nothing will be done.
  *
  * @since 1.0.0
- * 
+ *
  * @see eet_clearcache()
  */
-EAPI Eet_Error
+EET_API Eet_Error
 eet_close(Eet_File *ef);
 
 /**
@@ -684,7 +660,7 @@ eet_close(Eet_File *ef);
  *
  * @since 1.2.4
  */
-EAPI Eet_Error
+EET_API Eet_Error
 eet_sync(Eet_File *ef);
 
 /**
@@ -703,7 +679,7 @@ eet_sync(Eet_File *ef);
  *
  * @since 1.0.0
  */
-EAPI Eet_Dictionary *
+EET_API Eet_Dictionary *
 eet_dictionary_get(Eet_File *ef);
 
 /**
@@ -720,7 +696,7 @@ eet_dictionary_get(Eet_File *ef);
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_dictionary_string_check(Eet_Dictionary *ed,
                             const char *string);
 
@@ -732,7 +708,7 @@ eet_dictionary_string_check(Eet_Dictionary *ed,
  *
  * @since 1.6.0
  */
-EAPI int
+EET_API int
 eet_dictionary_count(const Eet_Dictionary *ed);
 
 /**
@@ -757,7 +733,7 @@ eet_dictionary_count(const Eet_Dictionary *ed);
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_read(Eet_File *ef,
          const char *name,
          int *size_ret);
@@ -782,7 +758,7 @@ eet_read(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI const void *
+EET_API const void *
 eet_read_direct(Eet_File *ef,
                 const char *name,
                 int *size_ret);
@@ -815,7 +791,7 @@ eet_read_direct(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_write(Eet_File *ef,
           const char *name,
           const void *data,
@@ -840,7 +816,7 @@ eet_write(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_delete(Eet_File *ef,
            const char *name);
 
@@ -859,7 +835,7 @@ eet_delete(Eet_File *ef,
  *
  * @since 1.3.3
  */
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_alias(Eet_File *ef,
           const char *name,
           const char *destination,
@@ -875,7 +851,7 @@ eet_alias(Eet_File *ef,
  *
  * @since 1.6
  */
-EAPI const char *
+EET_API const char *
 eet_file_get(Eet_File *ef);
 
 /**
@@ -889,7 +865,7 @@ eet_file_get(Eet_File *ef);
  *
  * @since 1.5
  */
-EAPI const char *
+EET_API const char *
 eet_alias_get(Eet_File *ef,
               const char *name);
 
@@ -923,7 +899,7 @@ eet_alias_get(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI char **
+EET_API char **
 eet_list(Eet_File *ef,
          const char *glob,
          int *count_ret);
@@ -937,7 +913,7 @@ eet_list(Eet_File *ef,
  * @since 1.8.0
  */
 
-EAPI Eina_Iterator *eet_list_entries(Eet_File *ef);
+EET_API Eina_Iterator *eet_list_entries(Eet_File *ef);
 
 /**
  * @ingroup Eet_File_Group
@@ -948,7 +924,7 @@ EAPI Eina_Iterator *eet_list_entries(Eet_File *ef);
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_num_entries(Eet_File *ef);
 
 /**
@@ -985,7 +961,7 @@ eet_num_entries(Eet_File *ef);
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_read_cipher(Eet_File *ef,
                 const char *name,
                 int *size_ret,
@@ -1020,7 +996,7 @@ eet_read_cipher(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_write_cipher(Eet_File *ef,
                  const char *name,
                  const void *data,
@@ -1084,7 +1060,7 @@ eet_write_cipher(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_image_header_read(Eet_File *ef,
                            const char *name,
                            unsigned int *w,
@@ -1129,7 +1105,7 @@ eet_data_image_header_read(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_image_read(Eet_File *ef,
                     const char *name,
                     unsigned int *w,
@@ -1187,7 +1163,7 @@ eet_data_image_read(Eet_File *ef,
  *
  * @since 1.0.2
  */
-EAPI int
+EET_API int
 eet_data_image_read_to_surface(Eet_File *ef,
                                const char *name,
                                unsigned int src_x,
@@ -1238,7 +1214,7 @@ eet_data_image_read_to_surface(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_image_write(Eet_File *ef,
                      const char *name,
                      const void *data,
@@ -1274,7 +1250,7 @@ eet_data_image_write(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_image_header_decode(const void *data,
                              int size,
                              unsigned int *w,
@@ -1314,7 +1290,7 @@ eet_data_image_header_decode(const void *data,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_image_decode(const void *data,
                       int size,
                       unsigned int *w,
@@ -1352,7 +1328,7 @@ eet_data_image_decode(const void *data,
  *
  * @since 1.0.2
  */
-EAPI int
+EET_API int
 eet_data_image_decode_to_surface(const void *data,
                                  int size,
                                  unsigned int src_x,
@@ -1396,7 +1372,7 @@ eet_data_image_decode_to_surface(const void *data,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_image_encode(const void *data,
                       int *size_ret,
                       unsigned int w,
@@ -1454,7 +1430,7 @@ eet_data_image_encode(const void *data,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_image_header_read_cipher(Eet_File *ef,
                                   const char *name,
                                   const char *cipher_key,
@@ -1477,7 +1453,7 @@ eet_data_image_header_read_cipher(Eet_File *ef,
  *
  * @since 1.10.0
  */
-EAPI int
+EET_API int
 eet_data_image_colorspace_get(Eet_File *ef,
                               const char *name,
                               const char *cipher_key,
@@ -1522,7 +1498,7 @@ eet_data_image_colorspace_get(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_image_read_cipher(Eet_File *ef,
                            const char *name,
                            const char *cipher_key,
@@ -1576,7 +1552,7 @@ eet_data_image_read_cipher(Eet_File *ef,
  *
  * @since 1.0.2
  */
-EAPI int
+EET_API int
 eet_data_image_read_to_surface_cipher(Eet_File *ef,
                                       const char *name,
                                       const char *cipher_key,
@@ -1637,7 +1613,7 @@ eet_data_image_read_to_surface_cipher(Eet_File *ef,
  *
  * @since 1.10.0
  */
-EAPI int
+EET_API int
 eet_data_image_read_to_cspace_surface_cipher(Eet_File     *ef,
                                              const char   *name,
                                              const char   *cipher_key,
@@ -1699,7 +1675,7 @@ eet_data_image_read_to_cspace_surface_cipher(Eet_File     *ef,
  * @since 1.10.0
  */
 
-EAPI int
+EET_API int
 eet_data_image_decode_to_cspace_surface_cipher(const void   *data,
                                                const char   *cipher_key,
                                                int           size,
@@ -1751,7 +1727,7 @@ eet_data_image_decode_to_cspace_surface_cipher(const void   *data,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_image_write_cipher(Eet_File *ef,
                             const char *name,
                             const char *cipher_key,
@@ -1800,7 +1776,7 @@ eet_data_image_write_cipher(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_image_header_decode_cipher(const void *data,
                                     const char *cipher_key,
                                     int size,
@@ -1850,7 +1826,7 @@ eet_data_image_header_decode_cipher(const void *data,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_image_decode_cipher(const void *data,
                              const char *cipher_key,
                              int size,
@@ -1902,7 +1878,7 @@ eet_data_image_decode_cipher(const void *data,
  *
  * @since 1.0.2
  */
-EAPI int
+EET_API int
 eet_data_image_decode_to_surface_cipher(const void *data,
                                         const char *cipher_key,
                                         int size,
@@ -1952,7 +1928,7 @@ eet_data_image_decode_to_surface_cipher(const void *data,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_image_encode_cipher(const void *data,
                              const char *cipher_key,
                              unsigned int w,
@@ -2020,14 +1996,14 @@ typedef int (*Eet_Key_Password_Callback)(char *buffer, int size, int rwflag, voi
  * @warning You need to compile signature support in EET.
  * @since 1.2.0
  */
-EAPI Eet_Key *
+EET_API Eet_Key *
 eet_identity_open(const char *certificate_file,
                   const char *private_key_file,
                   Eet_Key_Password_Callback cb);
 
 /**
  * @ingroup Eet_Cipher_Group
- * @brief Close and release all resource used by an Eet_Key. 
+ * @brief Close and release all resource used by an Eet_Key.
  * A reference counter prevent it from being freed until all file
  * using it are also closed.
  *
@@ -2035,7 +2011,7 @@ eet_identity_open(const char *certificate_file,
  *
  * @since 1.2.0
  */
-EAPI void
+EET_API void
 eet_identity_close(Eet_Key *key);
 
 /**
@@ -2049,7 +2025,7 @@ eet_identity_close(Eet_Key *key);
  *
  * @since 1.2.0
  */
-EAPI Eet_Error
+EET_API Eet_Error
 eet_identity_set(Eet_File *ef,
                  Eet_Key *key);
 
@@ -2063,7 +2039,7 @@ eet_identity_set(Eet_File *ef,
  * @warning You need to compile signature support in EET.
  * @since 1.2.0
  */
-EAPI void
+EET_API void
 eet_identity_print(Eet_Key *key,
                    FILE *out);
 
@@ -2086,7 +2062,7 @@ eet_identity_print(Eet_Key *key,
  * @warning You need to compile signature support in EET.
  * @since 1.13
  */
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_identity_verify(Eet_File *ef,
                     const char *certificate_file);
 
@@ -2101,7 +2077,7 @@ eet_identity_verify(Eet_File *ef,
  *
  * @since 1.2.0
  */
-EAPI const void *
+EET_API const void *
 eet_identity_x509(Eet_File *ef,
                   int *der_length);
 
@@ -2115,7 +2091,7 @@ eet_identity_x509(Eet_File *ef,
  * @return The raw signature or @c NULL on error.
  *
  */
-EAPI const void *
+EET_API const void *
 eet_identity_signature(Eet_File *ef,
                        int *signature_length);
 
@@ -2131,7 +2107,7 @@ eet_identity_signature(Eet_File *ef,
  *
  * @since 1.2.0
  */
-EAPI const void *
+EET_API const void *
 eet_identity_sha1(Eet_File *ef,
                   int *sha1_length);
 
@@ -2146,7 +2122,7 @@ eet_identity_sha1(Eet_File *ef,
  * @warning You need to compile signature support in EET.
  * @since 1.2.0
  */
-EAPI void
+EET_API void
 eet_identity_certificate_print(const unsigned char *certificate,
                                int der_length,
                                FILE *out);
@@ -2890,7 +2866,7 @@ struct _Eet_Data_Descriptor_Class
  * @since 1.0.0
  *
  */
-EINA_DEPRECATED EAPI Eet_Data_Descriptor *
+EINA_DEPRECATED EET_API Eet_Data_Descriptor *
 eet_data_descriptor_new(const char *name,
                         int size,
                         Eet_Descriptor_List_Next_Callback func_list_next,
@@ -2906,9 +2882,9 @@ eet_data_descriptor_new(const char *name,
  * moving to this api from the old above. this will break things when the
  * move happens - but be warned
  */
-EINA_DEPRECATED EAPI Eet_Data_Descriptor *
+EINA_DEPRECATED EET_API Eet_Data_Descriptor *
  eet_data_descriptor2_new(const Eet_Data_Descriptor_Class *eddc);
-EINA_DEPRECATED EAPI Eet_Data_Descriptor *
+EINA_DEPRECATED EET_API Eet_Data_Descriptor *
  eet_data_descriptor3_new(const Eet_Data_Descriptor_Class *eddc);
 
 /**
@@ -2936,7 +2912,7 @@ EINA_DEPRECATED EAPI Eet_Data_Descriptor *
  *
  * @since 1.2.3
  */
-EAPI Eet_Data_Descriptor *
+EET_API Eet_Data_Descriptor *
 eet_data_descriptor_stream_new(const Eet_Data_Descriptor_Class *eddc);
 
 /**
@@ -2986,7 +2962,7 @@ eet_data_descriptor_stream_new(const Eet_Data_Descriptor_Class *eddc);
  *
  * @since 1.2.3
  */
-EAPI Eet_Data_Descriptor *
+EET_API Eet_Data_Descriptor *
 eet_data_descriptor_file_new(const Eet_Data_Descriptor_Class *eddc);
 
 /**
@@ -3007,7 +2983,7 @@ eet_data_descriptor_file_new(const Eet_Data_Descriptor_Class *eddc);
  *
  * @since 1.2.3
  */
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_eina_stream_data_descriptor_class_set(Eet_Data_Descriptor_Class *eddc,
                                           unsigned int eddc_size,
                                           const char *name,
@@ -3048,7 +3024,7 @@ eet_eina_stream_data_descriptor_class_set(Eet_Data_Descriptor_Class *eddc,
  *
  * @since 1.2.3
  */
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_eina_file_data_descriptor_class_set(Eet_Data_Descriptor_Class *eddc,
                                         unsigned int eddc_size,
                                         const char *name,
@@ -3082,7 +3058,7 @@ eet_eina_file_data_descriptor_class_set(Eet_Data_Descriptor_Class *eddc,
  *
  * @since 1.0.0
  */
-EAPI void
+EET_API void
 eet_data_descriptor_free(Eet_Data_Descriptor *edd);
 
 /**
@@ -3093,7 +3069,7 @@ eet_data_descriptor_free(Eet_Data_Descriptor *edd);
  *
  * @since 1.8.0
  */
-EAPI const char *eet_data_descriptor_name_get(const Eet_Data_Descriptor *edd);
+EET_API const char *eet_data_descriptor_name_get(const Eet_Data_Descriptor *edd);
 
 /**
  * @ingroup Eet_Data_Group
@@ -3121,7 +3097,7 @@ EAPI const char *eet_data_descriptor_name_get(const Eet_Data_Descriptor *edd);
  *
  * @since 1.0.0
  */
-EAPI void
+EET_API void
 eet_data_descriptor_element_add(Eet_Data_Descriptor *edd,
                                 const char *name,
                                 int type,
@@ -3159,7 +3135,7 @@ eet_data_descriptor_element_add(Eet_Data_Descriptor *edd,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_read(Eet_File *ef,
               Eet_Data_Descriptor *edd,
               const char *name);
@@ -3183,7 +3159,7 @@ eet_data_read(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_write(Eet_File *ef,
                Eet_Data_Descriptor *edd,
                const char *name,
@@ -3192,11 +3168,11 @@ eet_data_write(Eet_File *ef,
 
 /**
  *  @typedef Eet_Data_Descriptor_Class
- * 
- * Callback protoype for Eet_Dump 
+ *
+ * Callback protoype for Eet_Dump
  *
  * @param data To passe to the callback
- * @param str The string to dump 
+ * @param str The string to dump
  *
  */
 typedef void (*Eet_Dump_Callback)(void *data, const char *str);
@@ -3248,7 +3224,7 @@ typedef void (*Eet_Dump_Callback)(void *data, const char *str);
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_text_dump(const void *data_in,
                    int size_in,
                    Eet_Dump_Callback dumpfunc,
@@ -3273,7 +3249,7 @@ eet_data_text_dump(const void *data_in,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_text_undump(const char *text,
                      int textlen,
                      int *size_ret) EINA_ARG_NONNULL(3);
@@ -3301,7 +3277,7 @@ eet_data_text_undump(const char *text,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_dump(Eet_File *ef,
               const char *name,
               Eet_Dump_Callback dumpfunc,
@@ -3329,7 +3305,7 @@ eet_data_dump(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_undump(Eet_File *ef,
                 const char *name,
                 const char *text,
@@ -3363,7 +3339,7 @@ eet_data_undump(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_descriptor_decode(Eet_Data_Descriptor *edd,
                            const void *data_in,
                            int size_in);
@@ -3397,7 +3373,7 @@ eet_data_descriptor_decode(Eet_Data_Descriptor *edd,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_descriptor_encode(Eet_Data_Descriptor *edd,
                            const void *data_in,
                            int *size_ret);
@@ -3931,7 +3907,7 @@ eet_data_descriptor_encode(Eet_Data_Descriptor *edd,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_read_cipher(Eet_File *ef,
                      Eet_Data_Descriptor *edd,
                      const char *name,
@@ -3967,7 +3943,7 @@ eet_data_read_cipher(Eet_File *ef,
  *
  * @since 1.10.0
  */
-EAPI void *
+EET_API void *
 eet_data_read_cipher_buffer(Eet_File            *ef,
                             Eet_Data_Descriptor *edd,
                             const char          *name,
@@ -3998,7 +3974,7 @@ eet_data_read_cipher_buffer(Eet_File            *ef,
  *
  * @since 1.5.0
  */
-EAPI void *
+EET_API void *
 eet_data_xattr_cipher_get(const char *filename,
                           const char *attribute,
                           Eet_Data_Descriptor *edd,
@@ -4021,7 +3997,7 @@ eet_data_xattr_cipher_get(const char *filename,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_write_cipher(Eet_File *ef,
                       Eet_Data_Descriptor *edd,
                       const char *name,
@@ -4046,7 +4022,7 @@ eet_data_write_cipher(Eet_File *ef,
  *
  * @since 1.5.0
  */
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_data_xattr_cipher_set(const char *filename,
                           const char *attribute,
                           Eet_Data_Descriptor *edd,
@@ -4102,7 +4078,7 @@ eet_data_xattr_cipher_set(const char *filename,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_text_dump_cipher(const void *data_in,
                           const char *cipher_key,
                           int size_in,
@@ -4130,7 +4106,7 @@ eet_data_text_dump_cipher(const void *data_in,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_text_undump_cipher(const char *text,
                             const char *cipher_key,
                             int textlen,
@@ -4161,7 +4137,7 @@ eet_data_text_undump_cipher(const char *text,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_dump_cipher(Eet_File *ef,
                      const char *name,
                      const char *cipher_key,
@@ -4192,7 +4168,7 @@ eet_data_dump_cipher(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI int
+EET_API int
 eet_data_undump_cipher(Eet_File *ef,
                        const char *name,
                        const char *cipher_key,
@@ -4229,7 +4205,7 @@ eet_data_undump_cipher(Eet_File *ef,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_descriptor_decode_cipher(Eet_Data_Descriptor *edd,
                                   const void *data_in,
                                   const char *cipher_key,
@@ -4266,7 +4242,7 @@ eet_data_descriptor_decode_cipher(Eet_Data_Descriptor *edd,
  *
  * @since 1.0.0
  */
-EAPI void *
+EET_API void *
 eet_data_descriptor_encode_cipher(Eet_Data_Descriptor *edd,
                                   const void *data_in,
                                   const char *cipher_key,
@@ -4326,7 +4302,7 @@ struct _Eet_Node_Data
  * @param c Character value.
  * @return A new character node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_char_new(const char *name,
                   char c);
 
@@ -4337,7 +4313,7 @@ eet_node_char_new(const char *name,
  * @param s Short value.
  * @return A new short node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_short_new(const char *name,
                    short s);
 
@@ -4348,7 +4324,7 @@ eet_node_short_new(const char *name,
  * @param i Integer value.
  * @return A new integer node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_int_new(const char *name,
                  int i);
 
@@ -4359,7 +4335,7 @@ eet_node_int_new(const char *name,
  * @param l Long long integer value.
  * @return A new long long integer node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_long_long_new(const char *name,
                        long long l);
 
@@ -4370,7 +4346,7 @@ eet_node_long_long_new(const char *name,
  * @param f Float value.
  * @return A new float node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_float_new(const char *name,
                    float f);
 
@@ -4381,7 +4357,7 @@ eet_node_float_new(const char *name,
  * @param d Double value.
  * @return A new double node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_double_new(const char *name,
                     double d);
 
@@ -4392,7 +4368,7 @@ eet_node_double_new(const char *name,
  * @param uc Unsigned char value.
  * @return A new unsigned char node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_unsigned_char_new(const char *name,
                            unsigned char uc);
 
@@ -4403,7 +4379,7 @@ eet_node_unsigned_char_new(const char *name,
  * @param us Unsigned short value.
  * @return A new unsigned short node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_unsigned_short_new(const char *name,
                             unsigned short us);
 
@@ -4414,7 +4390,7 @@ eet_node_unsigned_short_new(const char *name,
  * @param ui Unsigned integer value.
  * @return A new unsigned integer node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_unsigned_int_new(const char *name,
                           unsigned int ui);
 
@@ -4425,7 +4401,7 @@ eet_node_unsigned_int_new(const char *name,
  * @param l Unsigned long long integer value.
  * @return A new unsigned long long integer node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_unsigned_long_long_new(const char *name,
                                 unsigned long long l);
 
@@ -4436,7 +4412,7 @@ eet_node_unsigned_long_long_new(const char *name,
  * @param str String value.
  * @return A new string node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_string_new(const char *name,
                     const char *str);
 
@@ -4447,7 +4423,7 @@ eet_node_string_new(const char *name,
  * @param str String value.
  * @return A new inlined string node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_inlined_string_new(const char *name,
                             const char *str);
 
@@ -4457,7 +4433,7 @@ eet_node_inlined_string_new(const char *name,
  * @param name Name of the node.
  * @return A new empty node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_null_new(const char *name);
 
 /**
@@ -4467,7 +4443,7 @@ eet_node_null_new(const char *name);
  * @param nodes List of nodes.
  * @return A new list node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_list_new(const char *name,
                   Eina_List *nodes);
 
@@ -4479,7 +4455,7 @@ eet_node_list_new(const char *name,
  * @param nodes List of nodes.
  * @return A new array node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_array_new(const char *name,
                    int count,
                    Eina_List *nodes);
@@ -4491,7 +4467,7 @@ eet_node_array_new(const char *name,
  * @param nodes List of nodes.
  * @return A new variable array node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_var_array_new(const char *name,
                        Eina_List *nodes);
 
@@ -4507,7 +4483,7 @@ eet_node_var_array_new(const char *name,
  * @param node The node.
  * @return A new hash node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_hash_new(const char *name,
                   const char *key,
                   Eet_Node *node);
@@ -4519,7 +4495,7 @@ eet_node_hash_new(const char *name,
  * @param nodes List of nodes.
  * @return A new struct node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_struct_new(const char *name,
                     Eina_List *nodes);
 
@@ -4534,7 +4510,7 @@ eet_node_struct_new(const char *name,
  * @param child The child node.
  * @return A new struct child node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_struct_child_new(const char *parent,
                           Eet_Node *child);
 
@@ -4545,7 +4521,7 @@ eet_node_struct_child_new(const char *parent,
  * next child node and the parent.
  * @since 1.5
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_children_get(Eet_Node *node);
 
 /**
@@ -4555,7 +4531,7 @@ eet_node_children_get(Eet_Node *node);
  * next child node and the parent.
  * @since 1.5
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_next_get(Eet_Node *node);
 
 /**
@@ -4564,7 +4540,7 @@ eet_node_next_get(Eet_Node *node);
  * @return The parent node of @p node
  * @since 1.5
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_node_parent_get(Eet_Node *node);
 
 /**
@@ -4574,7 +4550,7 @@ eet_node_parent_get(Eet_Node *node);
  * @param name The name of new node.
  * @param child The child node.
  */
-EAPI void
+EET_API void
 eet_node_list_append(Eet_Node *parent,
                      const char *name,
                      Eet_Node *child);
@@ -4587,7 +4563,7 @@ eet_node_list_append(Eet_Node *parent,
  * @param name The name of new node.
  * @param child The child node.
  */
-EAPI void
+EET_API void
 eet_node_struct_append(Eet_Node *parent,
                        const char *name,
                        Eet_Node *child);
@@ -4601,7 +4577,7 @@ eet_node_struct_append(Eet_Node *parent,
  * @param key Key of the node.
  * @param child The child node.
  */
-EAPI void
+EET_API void
 eet_node_hash_add(Eet_Node *parent,
                   const char *name,
                   const char *key,
@@ -4617,7 +4593,7 @@ eet_node_hash_add(Eet_Node *parent,
  *        data is converted to text.
  * @param dumpdata The data to pass to the @p dumpfunc callback.
  */
-EAPI void
+EET_API void
 eet_node_dump(Eet_Node *n,
               int dumplevel,
               Eet_Dump_Callback dumpfunc,
@@ -4629,7 +4605,7 @@ eet_node_dump(Eet_Node *n,
  * @return The node's type (EET_T_$TYPE)
  * @since 1.5
  */
-EAPI int
+EET_API int
 eet_node_type_get(Eet_Node *node);
 
 /**
@@ -4638,7 +4614,7 @@ eet_node_type_get(Eet_Node *node);
  * @return The data contained in the node
  * @since 1.5
  */
-EAPI Eet_Node_Data *
+EET_API Eet_Node_Data *
 eet_node_value_get(Eet_Node *node);
 
 /**
@@ -4647,7 +4623,7 @@ eet_node_value_get(Eet_Node *node);
  * @brief Deletes the given node.
  * @param n The node.
  */
-EAPI void
+EET_API void
 eet_node_del(Eet_Node *n);
 
 /**
@@ -4658,7 +4634,7 @@ eet_node_del(Eet_Node *n);
  * @param cipher_key The key to use as cipher.
  * @param size_ret Number of bytes read from entry and returned.
  */
-EAPI void *
+EET_API void *
 eet_data_node_encode_cipher(Eet_Node *node,
                             const char *cipher_key,
                             int *size_ret);
@@ -4672,7 +4648,7 @@ eet_data_node_encode_cipher(Eet_Node *node,
  * @param size_in The size of the data pointed to in bytes.
  * @return The decoded node.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_data_node_decode_cipher(const void *data_in,
                             const char *cipher_key,
                             int size_in);
@@ -4686,7 +4662,7 @@ eet_data_node_decode_cipher(const void *data_in,
  * @param cipher_key The key to use as cipher.
  * @return A node to the decoded data structure.
  */
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_data_node_read_cipher(Eet_File *ef,
                           const char *name,
                           const char *cipher_key);
@@ -4702,7 +4678,7 @@ eet_data_node_read_cipher(Eet_File *ef,
  * @param compress Compression flags for storage.
  * @return bytes written on successful write, 0 on failure.
  */
-EAPI int
+EET_API int
 eet_data_node_write_cipher(Eet_File *ef,
                            const char *name,
                            const char *cipher_key,
@@ -4770,7 +4746,7 @@ struct _Eet_Node_Walk
    Eet_Node_Walk_Simple_Callback       simple;
 };
 
-EAPI void *
+EET_API void *
 eet_node_walk(void *parent,
               const char *name,
               Eet_Node *root,
@@ -4823,7 +4799,7 @@ typedef Eina_Bool Eet_Write_Cb (const void *data, size_t size, void *user_data);
  *
  * @since 1.2.4
  */
-EAPI Eet_Connection *
+EET_API Eet_Connection *
 eet_connection_new(Eet_Read_Cb *eet_read_cb,
                    Eet_Write_Cb *eet_write_cb,
                    const void *user_data);
@@ -4842,7 +4818,7 @@ eet_connection_new(Eet_Read_Cb *eet_read_cb,
  *
  * @since 1.2.4
  */
-EAPI int
+EET_API int
 eet_connection_received(Eet_Connection *conn,
                         const void *data,
                         size_t size);
@@ -4859,7 +4835,7 @@ eet_connection_received(Eet_Connection *conn,
  *
  * @since 1.7
  */
-EAPI Eina_Bool eet_connection_empty(Eet_Connection *conn);
+EET_API Eina_Bool eet_connection_empty(Eet_Connection *conn);
 
 /**
  * @ingroup Eet_Connection_Group
@@ -4878,7 +4854,7 @@ EAPI Eina_Bool eet_connection_empty(Eet_Connection *conn);
  *
  * @since 1.2.4
  */
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_connection_send(Eet_Connection *conn,
                     Eet_Data_Descriptor *edd,
                     const void *data_in,
@@ -4900,7 +4876,7 @@ eet_connection_send(Eet_Connection *conn,
  *
  * @since 1.2.4
  */
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_connection_node_send(Eet_Connection *conn,
                          Eet_Node *node,
                          const char *cipher_key);
@@ -4914,7 +4890,7 @@ eet_connection_node_send(Eet_Connection *conn,
  *
  * @since 1.2.4
  */
-EAPI void *
+EET_API void *
 eet_connection_close(Eet_Connection *conn,
                      Eina_Bool *on_going);
 
@@ -4922,8 +4898,5 @@ eet_connection_close(Eet_Connection *conn,
 #ifdef __cplusplus
 }
 #endif /* ifdef __cplusplus */
-
-#undef EAPI
-#define EAPI
 
 #endif /* ifndef _EET_H */

--- a/src/lib/eet/eet_api.h
+++ b/src/lib/eet/eet_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_CORE_API_H
+#define _EFL_CORE_API_H
+
+#ifdef EET_API
+#error EET_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EET_STATIC
+#  ifdef EET_BUILD
+#   define EET_API __declspec(dllexport)
+#  else
+#   define EET_API __declspec(dllimport)
+#  endif
+# else
+#  define EET_API
+# endif
+# define EET_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define EET_API __attribute__ ((visibility("default")))
+#   define EET_API_WEAK __attribute__ ((weak))
+#  else
+#   define EET_API
+#   define EET_API_WEAK
+#  endif
+# else
+#  define EET_API
+#  define EET_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/eet/eet_api.h
+++ b/src/lib/eet/eet_api.h
@@ -1,5 +1,5 @@
-#ifndef _EFL_CORE_API_H
-#define _EFL_CORE_API_H
+#ifndef _EFL_EET_API_H
+#define _EFL_EET_API_H
 
 #ifdef EET_API
 #error EET_API should not be already defined

--- a/src/lib/eet/eet_cipher.c
+++ b/src/lib/eet/eet_cipher.c
@@ -78,7 +78,7 @@ struct _Eet_Key
 #endif /* ifdef HAVE_SIGNATURE */
 };
 
-EAPI Eet_Key *
+EET_API Eet_Key *
 eet_identity_open(const char               *certificate_file,
                   const char               *private_key_file,
                   Eet_Key_Password_Callback cb)
@@ -248,7 +248,7 @@ on_error:
    return NULL;
 }
 
-EAPI void
+EET_API void
 eet_identity_close(Eet_Key *key)
 {
    if (!emile_cipher_init()) return ;
@@ -270,7 +270,7 @@ eet_identity_close(Eet_Key *key)
 #endif /* ifdef HAVE_SIGNATURE */
 }
 
-EAPI void
+EET_API void
 eet_identity_print(Eet_Key *key,
                    FILE    *out)
 {
@@ -837,7 +837,7 @@ eet_identity_check(const void   *data_base,
 #endif /* ifdef HAVE_SIGNATURE */
 }
 
-EAPI void
+EET_API void
 eet_identity_certificate_print(const unsigned char *certificate,
                                int                  der_length,
                                FILE                *out)

--- a/src/lib/eet/eet_connection.c
+++ b/src/lib/eet/eet_connection.c
@@ -27,7 +27,7 @@ struct _Eet_Connection
    void         *buffer;
 };
 
-EAPI Eet_Connection *
+EET_API Eet_Connection *
 eet_connection_new(Eet_Read_Cb  *eet_read_cb,
                    Eet_Write_Cb *eet_write_cb,
                    const void   *user_data)
@@ -44,7 +44,7 @@ eet_connection_new(Eet_Read_Cb  *eet_read_cb,
    return conn;
 }
 
-EAPI int
+EET_API int
 eet_connection_received(Eet_Connection *conn,
                         const void     *data,
                         size_t          size)
@@ -146,14 +146,14 @@ _eet_connection_raw_send(Eet_Connection *conn,
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_connection_empty(Eet_Connection *conn)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(conn, EINA_TRUE);
    return conn->size ? EINA_FALSE : EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_connection_send(Eet_Connection      *conn,
                     Eet_Data_Descriptor *edd,
                     const void          *data_in,
@@ -175,7 +175,7 @@ eet_connection_send(Eet_Connection      *conn,
    return ret;
 }
 
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_connection_node_send(Eet_Connection *conn,
                          Eet_Node       *node,
                          const char     *cipher_key)
@@ -194,7 +194,7 @@ eet_connection_node_send(Eet_Connection *conn,
    return ret;
 }
 
-EAPI void *
+EET_API void *
 eet_connection_close(Eet_Connection *conn,
                      Eina_Bool      *on_going)
 {

--- a/src/lib/eet/eet_data.c
+++ b/src/lib/eet/eet_data.c
@@ -1918,7 +1918,7 @@ _eet_eina_hash_free(void *hash)
 }
 
 /*---*/
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_eina_stream_data_descriptor_class_set(Eet_Data_Descriptor_Class *eddc,
      /* When we change the structure content in the future, we need to handle old structure type too */
                                           unsigned int               eddc_size,
@@ -1953,7 +1953,7 @@ eet_eina_stream_data_descriptor_class_set(Eet_Data_Descriptor_Class *eddc,
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_eina_file_data_descriptor_class_set(Eet_Data_Descriptor_Class *eddc,
      /* When we change the structure content in the future, we need to handle old structure type too */
                                         unsigned int               eddc_size,
@@ -2033,7 +2033,7 @@ _eet_data_descriptor_new(const Eet_Data_Descriptor_Class *eddc,
    return edd;
 }
 
-EAPI Eet_Data_Descriptor *
+EET_API Eet_Data_Descriptor *
 eet_data_descriptor_new(const char                          *name,
                         int                                  size,
                         Eet_Descriptor_List_Next_Callback    func_list_next,
@@ -2066,31 +2066,31 @@ eet_data_descriptor_new(const char                          *name,
    return _eet_data_descriptor_new(&eddc, 0);
 }
 
-EAPI Eet_Data_Descriptor *
+EET_API Eet_Data_Descriptor *
 eet_data_descriptor2_new(const Eet_Data_Descriptor_Class *eddc)
 {
    return _eet_data_descriptor_new(eddc, 1);
 }
 
-EAPI Eet_Data_Descriptor *
+EET_API Eet_Data_Descriptor *
 eet_data_descriptor3_new(const Eet_Data_Descriptor_Class *eddc)
 {
    return _eet_data_descriptor_new(eddc, 2);
 }
 
-EAPI Eet_Data_Descriptor *
+EET_API Eet_Data_Descriptor *
 eet_data_descriptor_stream_new(const Eet_Data_Descriptor_Class *eddc)
 {
    return _eet_data_descriptor_new(eddc, 1);
 }
 
-EAPI Eet_Data_Descriptor *
+EET_API Eet_Data_Descriptor *
 eet_data_descriptor_file_new(const Eet_Data_Descriptor_Class *eddc)
 {
    return _eet_data_descriptor_new(eddc, 2);
 }
 
-EAPI const char *
+EET_API const char *
 eet_data_descriptor_name_get(const Eet_Data_Descriptor *edd)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(edd, NULL);
@@ -2098,7 +2098,7 @@ eet_data_descriptor_name_get(const Eet_Data_Descriptor *edd)
 }
 
 
-EAPI void
+EET_API void
 eet_data_descriptor_free(Eet_Data_Descriptor *edd)
 {
    if (!edd)
@@ -2119,7 +2119,7 @@ eet_data_descriptor_free(Eet_Data_Descriptor *edd)
    free(edd);
 }
 
-EAPI void
+EET_API void
 eet_data_descriptor_element_add(Eet_Data_Descriptor *edd,
                                 const char          *name,
                                 int                  type,
@@ -2256,7 +2256,7 @@ eet_data_descriptor_element_add(Eet_Data_Descriptor *edd,
    ede->subtype = subtype;
 }
 
-EAPI void *
+EET_API void *
 eet_data_read_cipher(Eet_File            *ef,
                      Eet_Data_Descriptor *edd,
                      const char          *name,
@@ -2295,7 +2295,7 @@ eet_data_read_cipher(Eet_File            *ef,
    return data_dec;
 }
 
-EAPI void *
+EET_API void *
 eet_data_read_cipher_buffer(Eet_File            *ef,
                             Eet_Data_Descriptor *edd,
                             const char          *name,
@@ -2336,7 +2336,7 @@ eet_data_read_cipher_buffer(Eet_File            *ef,
    return data_dec;
 }
 
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_data_node_read_cipher(Eet_File   *ef,
                           const char *name,
                           const char *cipher_key)
@@ -2373,7 +2373,7 @@ eet_data_node_read_cipher(Eet_File   *ef,
    return result;
 }
 
-EAPI void *
+EET_API void *
 eet_data_read(Eet_File            *ef,
               Eet_Data_Descriptor *edd,
               const char          *name)
@@ -2381,7 +2381,7 @@ eet_data_read(Eet_File            *ef,
    return eet_data_read_cipher(ef, edd, name, NULL);
 }
 
-EAPI int
+EET_API int
 eet_data_write_cipher(Eet_File            *ef,
                       Eet_Data_Descriptor *edd,
                       const char          *name,
@@ -2410,7 +2410,7 @@ eet_data_write_cipher(Eet_File            *ef,
    return val;
 }
 
-EAPI int
+EET_API int
 eet_data_write(Eet_File            *ef,
                Eet_Data_Descriptor *edd,
                const char          *name,
@@ -4812,7 +4812,7 @@ eet_data_put_hash(Eet_Dictionary      *ed,
    edd->func.hash_foreach(l, eet_data_descriptor_encode_hash_cb, &fdata);
 }
 
-EAPI int
+EET_API int
 eet_data_dump_cipher(Eet_File         *ef,
                      const char       *name,
                      const char       *cipher_key,
@@ -4855,7 +4855,7 @@ eet_data_dump_cipher(Eet_File         *ef,
    return result ? 1 : 0;
 }
 
-EAPI int
+EET_API int
 eet_data_dump(Eet_File         *ef,
               const char       *name,
               Eet_Dump_Callback dumpfunc,
@@ -4864,7 +4864,7 @@ eet_data_dump(Eet_File         *ef,
    return eet_data_dump_cipher(ef, name, NULL, dumpfunc, dumpdata);
 }
 
-EAPI int
+EET_API int
 eet_data_text_dump_cipher(const void       *data_in,
                           const char       *cipher_key,
                           int               size_in,
@@ -4909,7 +4909,7 @@ eet_data_text_dump_cipher(const void       *data_in,
    return result ? 1 : 0;
 }
 
-EAPI int
+EET_API int
 eet_data_text_dump(const void       *data_in,
                    int               size_in,
                    Eet_Dump_Callback dumpfunc,
@@ -4918,7 +4918,7 @@ eet_data_text_dump(const void       *data_in,
    return eet_data_text_dump_cipher(data_in, NULL, size_in, dumpfunc, dumpdata);
 }
 
-EAPI void *
+EET_API void *
 eet_data_text_undump_cipher(const char *text,
                             const char *cipher_key,
                             int         textlen,
@@ -4951,7 +4951,7 @@ eet_data_text_undump_cipher(const char *text,
    return ret;
 }
 
-EAPI void *
+EET_API void *
 eet_data_text_undump(const char *text,
                      int         textlen,
                      int        *size_ret)
@@ -4959,7 +4959,7 @@ eet_data_text_undump(const char *text,
    return eet_data_text_undump_cipher(text, NULL, textlen, size_ret);
 }
 
-EAPI int
+EET_API int
 eet_data_undump_cipher(Eet_File   *ef,
                        const char *name,
                        const char *cipher_key,
@@ -4985,7 +4985,7 @@ eet_data_undump_cipher(Eet_File   *ef,
    return val;
 }
 
-EAPI int
+EET_API int
 eet_data_undump(Eet_File   *ef,
                 const char *name,
                 const char *text,
@@ -4995,7 +4995,7 @@ eet_data_undump(Eet_File   *ef,
    return eet_data_undump_cipher(ef, name, NULL, text, textlen, comp);
 }
 
-EAPI void *
+EET_API void *
 eet_data_descriptor_decode_cipher(Eet_Data_Descriptor *edd,
                                   const void          *data_in,
                                   const char          *cipher_key,
@@ -5033,7 +5033,7 @@ eet_data_descriptor_decode_cipher(Eet_Data_Descriptor *edd,
    return ret;
 }
 
-EAPI void *
+EET_API void *
 eet_data_descriptor_decode(Eet_Data_Descriptor *edd,
                            const void          *data_in,
                            int                  size_in)
@@ -5041,7 +5041,7 @@ eet_data_descriptor_decode(Eet_Data_Descriptor *edd,
    return eet_data_descriptor_decode_cipher(edd, data_in, NULL, size_in);
 }
 
-EAPI Eet_Node *
+EET_API Eet_Node *
 eet_data_node_decode_cipher(const void *data_in,
                             const char *cipher_key,
                             int         size_in)
@@ -5138,7 +5138,7 @@ _eet_data_descriptor_encode(Eet_Dictionary      *ed,
    return cdata;
 }
 
-EAPI int
+EET_API int
 eet_data_node_write_cipher(Eet_File   *ef,
                            const char *name,
                            const char *cipher_key,
@@ -5163,7 +5163,7 @@ eet_data_node_write_cipher(Eet_File   *ef,
    return val;
 }
 
-EAPI void *
+EET_API void *
 eet_data_node_encode_cipher(Eet_Node   *node,
                             const char *cipher_key,
                             int        *size_ret)
@@ -5200,7 +5200,7 @@ eet_data_node_encode_cipher(Eet_Node   *node,
    return ret;
 }
 
-EAPI void *
+EET_API void *
 eet_data_descriptor_encode_cipher(Eet_Data_Descriptor *edd,
                                   const void          *data_in,
                                   const char          *cipher_key,
@@ -5241,7 +5241,7 @@ eet_data_descriptor_encode_cipher(Eet_Data_Descriptor *edd,
    return ret;
 }
 
-EAPI void *
+EET_API void *
 eet_data_descriptor_encode(Eet_Data_Descriptor *edd,
                            const void          *data_in,
                            int                 *size_ret)
@@ -5249,7 +5249,7 @@ eet_data_descriptor_encode(Eet_Data_Descriptor *edd,
    return eet_data_descriptor_encode_cipher(edd, data_in, NULL, size_ret);
 }
 
-EAPI void *
+EET_API void *
 eet_data_xattr_cipher_get(const char          *filename,
                           const char          *attribute,
                           Eet_Data_Descriptor *edd,
@@ -5270,7 +5270,7 @@ eet_data_xattr_cipher_get(const char          *filename,
    return ret;
 }
 
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_data_xattr_cipher_set(const char          *filename,
                           const char          *attribute,
                           Eet_Data_Descriptor *edd,

--- a/src/lib/eet/eet_dictionary.c
+++ b/src/lib/eet/eet_dictionary.c
@@ -186,7 +186,7 @@ eet_dictionary_string_get_size(const Eet_Dictionary *ed,
    return length;
 }
 
-EAPI int
+EET_API int
 eet_dictionary_count(const Eet_Dictionary *ed)
 {
    int cnt;
@@ -489,7 +489,7 @@ eet_dictionary_string_get_fp(const Eet_Dictionary *ed,
    return ret;
 }
 
-EAPI int
+EET_API int
 eet_dictionary_string_check(Eet_Dictionary *ed,
                             const char     *string)
 {

--- a/src/lib/eet/eet_image.c
+++ b/src/lib/eet/eet_image.c
@@ -1318,7 +1318,7 @@ eet_data_image_jpeg_alpha_convert(int         *size,
    return d;
 }
 
-EAPI int
+EET_API int
 eet_data_image_write_cipher(Eet_File    *ef,
                             const char  *name,
                             const char  *cipher_key,
@@ -1346,7 +1346,7 @@ eet_data_image_write_cipher(Eet_File    *ef,
    return 0;
 }
 
-EAPI int
+EET_API int
 eet_data_image_write(Eet_File    *ef,
                      const char  *name,
                      const void  *data,
@@ -1369,7 +1369,7 @@ eet_data_image_write(Eet_File    *ef,
                                       lossy);
 }
 
-EAPI void *
+EET_API void *
 eet_data_image_read_cipher(Eet_File     *ef,
                            const char   *name,
                            const char   *cipher_key,
@@ -1404,7 +1404,7 @@ eet_data_image_read_cipher(Eet_File     *ef,
    return d;
 }
 
-EAPI void *
+EET_API void *
 eet_data_image_read(Eet_File     *ef,
                     const char   *name,
                     unsigned int *w,
@@ -1418,7 +1418,7 @@ eet_data_image_read(Eet_File     *ef,
                                      comp, quality, lossy);
 }
 
-EAPI int
+EET_API int
 eet_data_image_read_to_cspace_surface_cipher(Eet_File     *ef,
                                              const char   *name,
                                              const char   *cipher_key,
@@ -1460,7 +1460,7 @@ eet_data_image_read_to_cspace_surface_cipher(Eet_File     *ef,
    return res;
 }
 
-EAPI int
+EET_API int
 eet_data_image_read_to_surface_cipher(Eet_File     *ef,
                                       const char   *name,
                                       const char   *cipher_key,
@@ -1481,7 +1481,7 @@ eet_data_image_read_to_surface_cipher(Eet_File     *ef,
                                                        alpha, comp, quality, lossy);
 }
 
-EAPI int
+EET_API int
 eet_data_image_read_to_surface(Eet_File     *ef,
                                const char   *name,
                                unsigned int  src_x,
@@ -1502,7 +1502,7 @@ eet_data_image_read_to_surface(Eet_File     *ef,
                                                 lossy);
 }
 
-EAPI int
+EET_API int
 eet_data_image_header_read_cipher(Eet_File     *ef,
                                   const char   *name,
                                   const char   *cipher_key,
@@ -1537,7 +1537,7 @@ eet_data_image_header_read_cipher(Eet_File     *ef,
    return d;
 }
 
-EAPI int
+EET_API int
 eet_data_image_header_read(Eet_File     *ef,
                            const char   *name,
                            unsigned int *w,
@@ -1552,7 +1552,7 @@ eet_data_image_header_read(Eet_File     *ef,
                                             comp, quality, lossy);
 }
 
-EAPI void *
+EET_API void *
 eet_data_image_encode_cipher(const void  *data,
                              const char  *cipher_key,
                              unsigned int w,
@@ -1625,7 +1625,7 @@ eet_data_image_encode_cipher(const void  *data,
    return d;
 }
 
-EAPI void *
+EET_API void *
 eet_data_image_encode(const void  *data,
                       int         *size_ret,
                       unsigned int w,
@@ -1855,7 +1855,7 @@ eet_data_image_header_advance_decode_cipher(const void   *data,
    return r;
 }
 
-EAPI int
+EET_API int
 eet_data_image_header_decode_cipher(const void   *data,
                                     const char   *cipher_key,
                                     int           size,
@@ -1872,7 +1872,7 @@ eet_data_image_header_decode_cipher(const void   *data,
                                                       NULL);
 }
 
-EAPI int
+EET_API int
 eet_data_image_colorspace_get(Eet_File *ef,
                               const char *name,
                               const char *cipher_key,
@@ -1903,7 +1903,7 @@ eet_data_image_colorspace_get(Eet_File *ef,
    return d;
 }
 
-EAPI int
+EET_API int
 eet_data_image_header_decode(const void   *data,
                              int           size,
                              unsigned int *w,
@@ -2061,7 +2061,7 @@ _eet_data_image_decode_inside(const void   *data,
    return 1;
 }
 
-EAPI void *
+EET_API void *
 eet_data_image_decode_cipher(const void   *data,
                              const char   *cipher_key,
                              int           size,
@@ -2133,7 +2133,7 @@ eet_data_image_decode_cipher(const void   *data,
    return d;
 }
 
-EAPI void *
+EET_API void *
 eet_data_image_decode(const void   *data,
                       int           size,
                       unsigned int *w,
@@ -2147,7 +2147,7 @@ eet_data_image_decode(const void   *data,
                                        alpha, comp, quality, lossy);
 }
 
-EAPI int
+EET_API int
 eet_data_image_decode_to_cspace_surface_cipher(const void   *data,
                                                const char   *cipher_key,
                                                int           size,
@@ -2237,7 +2237,7 @@ eet_data_image_decode_to_cspace_surface_cipher(const void   *data,
    return 1;
 }
 
-EAPI int
+EET_API int
 eet_data_image_decode_to_surface_cipher(const void   *data,
                                         const char   *cipher_key,
                                         int           size,
@@ -2255,7 +2255,7 @@ eet_data_image_decode_to_surface_cipher(const void   *data,
    return eet_data_image_decode_to_cspace_surface_cipher(data, cipher_key, size, src_x, src_y, d, w, h, row_stride, EET_COLORSPACE_ARGB8888, alpha, comp, quality, lossy);
 }
 
-EAPI int
+EET_API int
 eet_data_image_decode_to_surface(const void   *data,
                                  int           size,
                                  unsigned int  src_x,

--- a/src/lib/eet/eet_lib.c
+++ b/src/lib/eet/eet_lib.c
@@ -27,7 +27,7 @@
 #endif
 
 static Eet_Version _version = { VMAJ, VMIN, VMIC, VREV };
-EAPI Eet_Version *eet_version = &_version;
+EET_API Eet_Version *eet_version = &_version;
 
 #ifdef HAVE_REALPATH
 # undef HAVE_REALPATH
@@ -540,7 +540,7 @@ sign_error:
    return error;
 }
 
-EAPI int
+EET_API int
 eet_init(void)
 {
    if (++eet_init_count != 1)
@@ -594,7 +594,7 @@ shutdown_eina:
    return --eet_init_count;
 }
 
-EAPI int
+EET_API int
 eet_shutdown(void)
 {
    if (eet_init_count <= 0)
@@ -651,7 +651,7 @@ eet_shutdown(void)
    return eet_init_count;
 }
 
-EAPI Eet_Error
+EET_API Eet_Error
 eet_sync(Eet_File *ef)
 {
    Eet_Error ret;
@@ -674,7 +674,7 @@ eet_sync(Eet_File *ef)
    return ret;
 }
 
-EAPI void
+EET_API void
 eet_clearcache(void)
 {
    int num = 0;
@@ -1387,7 +1387,7 @@ on_error:
    return EET_ERROR_NONE;
 }
 
-EAPI Eet_File *
+EET_API Eet_File *
 eet_memopen_read(const void *data,
                  size_t      size)
 {
@@ -1424,14 +1424,14 @@ eet_memopen_read(const void *data,
    return ef;
 }
 
-EAPI const char *
+EET_API const char *
 eet_file_get(Eet_File *ef)
 {
    if (eet_check_pointer(ef)) return NULL;
    return ef->path;
 }
 
-EAPI Eet_File *
+EET_API Eet_File *
 eet_mmap(const Eina_File *file)
 {
    Eet_File *ef = NULL;
@@ -1499,7 +1499,7 @@ eet_mmap(const Eina_File *file)
    return NULL;
 }
 
-EAPI Eet_File *
+EET_API Eet_File *
 eet_open(const char   *file,
          Eet_File_Mode mode)
 {
@@ -1669,7 +1669,7 @@ on_error:
    return NULL;
 }
 
-EAPI Eet_File_Mode
+EET_API Eet_File_Mode
 eet_mode_get(Eet_File *ef)
 {
    /* check to see its' an eet file pointer */
@@ -1798,7 +1798,7 @@ _base64_dec(const char *file, int *size_ret)
    return data;
 }
 
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_identity_verify(Eet_File   *ef,
                     const char *certificate_file)
 {
@@ -1829,7 +1829,7 @@ eet_identity_verify(Eet_File   *ef,
    return EINA_TRUE;
 }
 
-EAPI const void *
+EET_API const void *
 eet_identity_x509(Eet_File *ef,
                   int      *der_length)
 {
@@ -1845,7 +1845,7 @@ eet_identity_x509(Eet_File *ef,
    return ef->x509_der;
 }
 
-EAPI const void *
+EET_API const void *
 eet_identity_signature(Eet_File *ef,
                        int      *signature_length)
 {
@@ -1861,7 +1861,7 @@ eet_identity_signature(Eet_File *ef,
    return ef->signature;
 }
 
-EAPI const void *
+EET_API const void *
 eet_identity_sha1(Eet_File *ef,
                   int      *sha1_length)
 {
@@ -1879,7 +1879,7 @@ eet_identity_sha1(Eet_File *ef,
    return ef->sha1;
 }
 
-EAPI Eet_Error
+EET_API Eet_Error
 eet_identity_set(Eet_File *ef,
                  Eet_Key  *key)
 {
@@ -1899,13 +1899,13 @@ eet_identity_set(Eet_File *ef,
    return EET_ERROR_NONE;
 }
 
-EAPI Eet_Error
+EET_API Eet_Error
 eet_close(Eet_File *ef)
 {
    return eet_internal_close(ef, EINA_FALSE, EINA_FALSE);
 }
 
-EAPI void *
+EET_API void *
 eet_read_cipher(Eet_File   *ef,
                 const char *name,
                 int        *size_ret,
@@ -2006,7 +2006,7 @@ on_error:
    return NULL;
 }
 
-EAPI void *
+EET_API void *
 eet_read(Eet_File   *ef,
          const char *name,
          int        *size_ret)
@@ -2014,7 +2014,7 @@ eet_read(Eet_File   *ef,
    return eet_read_cipher(ef, name, size_ret, NULL);
 }
 
-EAPI const void *
+EET_API const void *
 eet_read_direct(Eet_File   *ef,
                 const char *name,
                 int        *size_ret)
@@ -2118,7 +2118,7 @@ on_error:
    return NULL;
 }
 
-EAPI const char *
+EET_API const char *
 eet_alias_get(Eet_File   *ef,
               const char *name)
 {
@@ -2220,7 +2220,7 @@ eet_define_data(Eet_File *ef, Eet_File_Node *efn, Eina_Binbuf *data, int origina
    efn->offset = ef->data_size + 1;
 }
 
-EAPI Eina_Bool
+EET_API Eina_Bool
 eet_alias(Eet_File   *ef,
           const char *name,
           const char *destination,
@@ -2342,7 +2342,7 @@ on_error:
    return success;
 }
 
-EAPI int
+EET_API int
 eet_write_cipher(Eet_File   *ef,
                  const char *name,
                  const void *data,
@@ -2492,7 +2492,7 @@ on_error:
    return 0;
 }
 
-EAPI int
+EET_API int
 eet_write(Eet_File   *ef,
           const char *name,
           const void *data,
@@ -2502,7 +2502,7 @@ eet_write(Eet_File   *ef,
    return eet_write_cipher(ef, name, data, size, comp, NULL);
 }
 
-EAPI int
+EET_API int
 eet_delete(Eet_File   *ef,
            const char *name)
 {
@@ -2564,7 +2564,7 @@ eet_delete(Eet_File   *ef,
    return exists_already;
 }
 
-EAPI Eet_Dictionary *
+EET_API Eet_Dictionary *
 eet_dictionary_get(Eet_File *ef)
 {
    if (eet_check_pointer(ef))
@@ -2573,7 +2573,7 @@ eet_dictionary_get(Eet_File *ef)
    return ef->ed;
 }
 
-EAPI char **
+EET_API char **
 eet_list(Eet_File   *ef,
          const char *glob,
          int        *count_ret)
@@ -2657,7 +2657,7 @@ on_error:
    return NULL;
 }
 
-EAPI int
+EET_API int
 eet_num_entries(Eet_File *ef)
 {
    int i, num, ret = 0;
@@ -2777,7 +2777,7 @@ _eet_entries_iterator_unlock(Eet_Entries_Iterator *it)
    return EINA_TRUE;
 }
 
-EAPI Eina_Iterator *
+EET_API Eina_Iterator *
 eet_list_entries(Eet_File *ef)
 {
    Eet_Entries_Iterator *it;

--- a/src/lib/eet/eet_node.c
+++ b/src/lib/eet/eet_node.c
@@ -62,7 +62,7 @@ _eet_node_append(Eet_Node  *n,
 }
 
 #define EET_NODE_NEW(Eet_type, Name, Value, Type)         \
-  EAPI Eet_Node *                                         \
+  EET_API Eet_Node *                                         \
   eet_node_ ## Name ## _new(const char *name, Type Value) \
   {                                                       \
      Eet_Node *n;                                         \
@@ -76,7 +76,7 @@ _eet_node_append(Eet_Node  *n,
   }
 
 #define EET_NODE_STR_NEW(Eet_type, Name, Value, Type)     \
-  EAPI Eet_Node *                                         \
+  EET_API Eet_Node *                                         \
   eet_node_ ## Name ## _new(const char *name, Type Value) \
   {                                                       \
      Eet_Node *n;                                         \

--- a/src/lib/eet/meson.build
+++ b/src/lib/eet/meson.build
@@ -21,7 +21,7 @@ eet_src = files([
 
 eet_lib = library('eet',
     eet_src, pub_eo_file_target,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DEET_BUILD'],
     dependencies: eet_deps + eet_pub_deps + eet_ext_deps,
     include_directories : config_dir,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.