### PR TITLE
[ecore_input] Use ECORE_INPUT_API instead of EAPI

### DIFF
--- a/src/lib/ecore_input/Ecore_Input.h
+++ b/src/lib/ecore_input/Ecore_Input.h
@@ -11,31 +11,7 @@
 
 #include <Eo.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_input_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,17 +23,17 @@ extern "C" {
  *
  *@{
  */
-   EAPI extern int ECORE_EVENT_KEY_DOWN;
-   EAPI extern int ECORE_EVENT_KEY_UP;
-   EAPI extern int ECORE_EVENT_MOUSE_BUTTON_DOWN;
-   EAPI extern int ECORE_EVENT_MOUSE_BUTTON_UP;
-   EAPI extern int ECORE_EVENT_MOUSE_MOVE;
-   EAPI extern int ECORE_EVENT_MOUSE_WHEEL;
-   EAPI extern int ECORE_EVENT_MOUSE_IN;
-   EAPI extern int ECORE_EVENT_MOUSE_OUT;
-   EAPI extern int ECORE_EVENT_AXIS_UPDATE; /**< @since 1.13 */
-   EAPI extern int ECORE_EVENT_MOUSE_BUTTON_CANCEL; /**< @since 1.15 */
-   EAPI extern int ECORE_EVENT_JOYSTICK; /**< @since 1.18 */
+   ECORE_INPUT_API extern int ECORE_EVENT_KEY_DOWN;
+   ECORE_INPUT_API extern int ECORE_EVENT_KEY_UP;
+   ECORE_INPUT_API extern int ECORE_EVENT_MOUSE_BUTTON_DOWN;
+   ECORE_INPUT_API extern int ECORE_EVENT_MOUSE_BUTTON_UP;
+   ECORE_INPUT_API extern int ECORE_EVENT_MOUSE_MOVE;
+   ECORE_INPUT_API extern int ECORE_EVENT_MOUSE_WHEEL;
+   ECORE_INPUT_API extern int ECORE_EVENT_MOUSE_IN;
+   ECORE_INPUT_API extern int ECORE_EVENT_MOUSE_OUT;
+   ECORE_INPUT_API extern int ECORE_EVENT_AXIS_UPDATE; /**< @since 1.13 */
+   ECORE_INPUT_API extern int ECORE_EVENT_MOUSE_BUTTON_CANCEL; /**< @since 1.15 */
+   ECORE_INPUT_API extern int ECORE_EVENT_JOYSTICK; /**< @since 1.18 */
 
 #define ECORE_EVENT_MODIFIER_SHIFT      0x0001
 #define ECORE_EVENT_MODIFIER_CTRL       0x0002
@@ -130,7 +106,7 @@ extern "C" {
     * An enum of Compose states.
     */
    typedef enum _Ecore_Compose_State
-     {   
+     {
         ECORE_COMPOSE_NONE,
         ECORE_COMPOSE_MIDDLE,
         ECORE_COMPOSE_DONE
@@ -202,10 +178,10 @@ extern "C" {
         Ecore_Window     window; /**< The main window where event happened */
         Ecore_Window     root_window; /**< The root window where event happened */
         Ecore_Window     event_window; /**< The child window where event happened */
-        
+
         unsigned int     timestamp; /**< Time when the event occurred */
         unsigned int     modifiers; /**< The combination of modifiers key (SHIFT,CTRL,ALT,..)*/
-        
+
         int              same_screen; /**< same screen flag */
 
         unsigned int     keycode; /**< Key scan code numeric value @since 1.10 */
@@ -231,14 +207,14 @@ extern "C" {
         unsigned int     double_click; /**< Double click event */
         unsigned int     triple_click; /**< Triple click event */
         int              same_screen; /**< Same screen flag */
-        
+
         int              x; /**< x coordinate relative to window where event happened */
         int              y; /**< y coordinate relative to window where event happened */
         struct {
            int           x;
            int           y;
         } root; /**< Coordinates relative to root window */
-        
+
         struct {
            int           device; /**< 0 if normal mouse, 1+ for other mouse-devices (eg multi-touch - other fingers) */
            double        radius, radius_x, radius_y; /**< radius of press point - radius_x and y if its an ellipse (radius is the average of the 2) */
@@ -262,14 +238,14 @@ extern "C" {
         Ecore_Window     window; /**< The main window where event happened */
         Ecore_Window     root_window; /**< The root window where event happened */
         Ecore_Window     event_window; /**< The child window where event happened */
-        
+
         unsigned int     timestamp; /**< Time when the event occurred */
         unsigned int     modifiers; /**< The combination of modifiers key (SHIFT,CTRL,ALT,..)*/
-        
+
         int              same_screen; /**< Same screen flag */
         int              direction; /**< Orientation of the wheel (horizontal/vertical) */
         int              z; /**< Value of the wheel event (+1/-1) */
-        
+
         int              x; /**< x coordinate relative to window where event happened */
         int              y; /**< y coordinate relative to window where event happened */
         struct {
@@ -289,19 +265,19 @@ extern "C" {
         Ecore_Window     window; /**< The main window where event happened */
         Ecore_Window     root_window; /**< The root window where event happened */
         Ecore_Window     event_window; /**< The child window where event happened */
-        
+
         unsigned int     timestamp; /**< Time when the event occurred */
         unsigned int     modifiers; /**< The combination of modifiers key (SHIFT,CTRL,ALT,..)*/
-        
+
         int              same_screen; /**< Same screen flag */
-        
+
         int              x; /**< x coordinate relative to window where event happened */
         int              y; /**< y coordinate relative to window where event happened */
         struct {
            int           x;
            int           y;
         } root; /**< Coordinates relative to root window */
-        
+
         struct {
            int           device; /**< 0 if normal mouse, 1+ for other mouse-devices (eg multi-touch - other fingers) */
            double        radius, radius_x, radius_y; /**< radius of press point - radius_x and y if its an ellipse (radius is the average of the 2) */
@@ -367,10 +343,10 @@ extern "C" {
      {
         Ecore_Window     window; /**< The main window where event happened */
         Ecore_Window     event_window; /**< The child window where event happened */
-        
+
         unsigned int     timestamp; /**< Time when the event occurred */
         unsigned int     modifiers; /**< The combination of modifiers key (SHIFT,CTRL,ALT,..)*/
-        
+
         int              x; /**< x coordinate relative to window where event happened */
         int              y; /**< y coordinate relative to window where event happened */
 
@@ -418,11 +394,11 @@ extern "C" {
    /**
     * Initializes the Ecore Event system.
     */
-   EAPI int                  ecore_event_init(void);
+   ECORE_INPUT_API int                  ecore_event_init(void);
    /**
     * Shutdowns the Ecore Event system.
     */
-   EAPI int                  ecore_event_shutdown(void);
+   ECORE_INPUT_API int                  ecore_event_shutdown(void);
 
    /**
     * Returns the Ecore modifier event integer associated to a
@@ -432,7 +408,7 @@ extern "C" {
     * @return A event_modifier integer that matches with the provided modifier
     * event.
     */
-   EAPI unsigned int         ecore_event_modifier_mask(Ecore_Event_Modifier modifier);
+   ECORE_INPUT_API unsigned int         ecore_event_modifier_mask(Ecore_Event_Modifier modifier);
 
    /**
     * Update a Ecore_Event_Modifiers array with "key" modifier.
@@ -444,7 +420,7 @@ extern "C" {
     * @return ECORE_NONE if the key does not match with an existing one, else
     * the corresponding Ecore_Event_Modifier.
     */
-   EAPI Ecore_Event_Modifier ecore_event_update_modifier(const char *key, Ecore_Event_Modifiers *modifiers, int inc);
+   ECORE_INPUT_API Ecore_Event_Modifier ecore_event_update_modifier(const char *key, Ecore_Event_Modifiers *modifiers, int inc);
 
    /**
     * Handles a sequence of key symbols to make a final compose string.
@@ -456,7 +432,7 @@ extern "C" {
     * @param seqstr_ret The final compose string.
     * @return The status of the composition.
     */
-   EAPI Ecore_Compose_State  ecore_compose_get(const Eina_List *seq, char **seqstr_ret);
+   ECORE_INPUT_API Ecore_Compose_State  ecore_compose_get(const Eina_List *seq, char **seqstr_ret);
 
    /**
     * Set deadzone of joystick event for an axis.
@@ -469,7 +445,7 @@ extern "C" {
     * @param event_axis_deadzone The joystick event axis deadzone.
     * @since 1.19
     */
-   EAPI void ecore_input_joystick_event_axis_deadzone_set(int event_axis_deadzone);
+   ECORE_INPUT_API void ecore_input_joystick_event_axis_deadzone_set(int event_axis_deadzone);
 
    /**
     * Get deadzone of joystick event for an axis.
@@ -477,7 +453,7 @@ extern "C" {
     * @return deadzone of joystick event for an axis.
     * @since 1.19
     */
-   EAPI int ecore_input_joystick_event_axis_deadzone_get(void);
+   ECORE_INPUT_API int ecore_input_joystick_event_axis_deadzone_get(void);
 
    /**
     * Get name of joystick
@@ -489,13 +465,10 @@ extern "C" {
     * @return name of joystick.
     * @since 1.20
     */
-   EAPI const char *ecore_input_joystick_name_get(int index);
+   ECORE_INPUT_API const char *ecore_input_joystick_name_get(int index);
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 /** @} */
 #endif

--- a/src/lib/ecore_input/ecore_input.c
+++ b/src/lib/ecore_input/ecore_input.c
@@ -14,21 +14,21 @@
 
 int _ecore_input_log_dom = -1;
 
-EAPI int ECORE_EVENT_KEY_DOWN = 0;
-EAPI int ECORE_EVENT_KEY_UP = 0;
-EAPI int ECORE_EVENT_MOUSE_BUTTON_DOWN = 0;
-EAPI int ECORE_EVENT_MOUSE_BUTTON_UP = 0;
-EAPI int ECORE_EVENT_MOUSE_MOVE = 0;
-EAPI int ECORE_EVENT_MOUSE_WHEEL = 0;
-EAPI int ECORE_EVENT_MOUSE_IN = 0;
-EAPI int ECORE_EVENT_MOUSE_OUT = 0;
-EAPI int ECORE_EVENT_AXIS_UPDATE = 0;
-EAPI int ECORE_EVENT_MOUSE_BUTTON_CANCEL = 0;
-EAPI int ECORE_EVENT_JOYSTICK = 0;
+ECORE_INPUT_API int ECORE_EVENT_KEY_DOWN = 0;
+ECORE_INPUT_API int ECORE_EVENT_KEY_UP = 0;
+ECORE_INPUT_API int ECORE_EVENT_MOUSE_BUTTON_DOWN = 0;
+ECORE_INPUT_API int ECORE_EVENT_MOUSE_BUTTON_UP = 0;
+ECORE_INPUT_API int ECORE_EVENT_MOUSE_MOVE = 0;
+ECORE_INPUT_API int ECORE_EVENT_MOUSE_WHEEL = 0;
+ECORE_INPUT_API int ECORE_EVENT_MOUSE_IN = 0;
+ECORE_INPUT_API int ECORE_EVENT_MOUSE_OUT = 0;
+ECORE_INPUT_API int ECORE_EVENT_AXIS_UPDATE = 0;
+ECORE_INPUT_API int ECORE_EVENT_MOUSE_BUTTON_CANCEL = 0;
+ECORE_INPUT_API int ECORE_EVENT_JOYSTICK = 0;
 
 static int _ecore_event_init_count = 0;
 
-EAPI int
+ECORE_INPUT_API int
 ecore_event_init(void)
 {
    if (++_ecore_event_init_count != 1)
@@ -64,7 +64,7 @@ ecore_event_init(void)
    return _ecore_event_init_count;
 }
 
-EAPI int
+ECORE_INPUT_API int
 ecore_event_shutdown(void)
 {
    if (--_ecore_event_init_count != 0)
@@ -110,7 +110,7 @@ static const Ecore_Event_Modifier_Match matchs[] = {
   { "Scroll_Lock", ECORE_SCROLL, ECORE_EVENT_MODIFIER_SCROLL }
 };
 
-EAPI unsigned int
+ECORE_INPUT_API unsigned int
 ecore_event_modifier_mask(Ecore_Event_Modifier modifier)
 {
    size_t i;
@@ -122,7 +122,7 @@ ecore_event_modifier_mask(Ecore_Event_Modifier modifier)
    return 0;
 }
 
-EAPI Ecore_Event_Modifier
+ECORE_INPUT_API Ecore_Event_Modifier
 ecore_event_update_modifier(const char *key, Ecore_Event_Modifiers *modifiers, int inc)
 {
    size_t i;

--- a/src/lib/ecore_input/ecore_input_api.h
+++ b/src/lib/ecore_input/ecore_input_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_INPUT_API_H
+#define _EFL_ECORE_INPUT_API_H
+
+#ifdef ECORE_INPUT_API
+#error ECORE_INPUT_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_STATIC
+#  ifdef ECORE_INPUT_BUILD
+#   define ECORE_INPUT_API __declspec(dllexport)
+#  else
+#   define ECORE_INPUT_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_INPUT_API
+# endif
+# define ECORE_INPUT_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_INPUT_API __attribute__ ((visibility("default")))
+#   define ECORE_INPUT_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_INPUT_API
+#   define ECORE_INPUT_API_WEAK
+#  endif
+# else
+#  define ECORE_INPUT_API
+#  define ECORE_INPUT_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_input/ecore_input_api.h
+++ b/src/lib/ecore_input/ecore_input_api.h
@@ -6,7 +6,7 @@
 #endif
 
 #ifdef _WIN32
-# ifndef EFL_STATIC
+# ifndef ECORE_INPUT_STATIC
 #  ifdef ECORE_INPUT_BUILD
 #   define ECORE_INPUT_API __declspec(dllexport)
 #  else

--- a/src/lib/ecore_input/ecore_input_compose.c
+++ b/src/lib/ecore_input/ecore_input_compose.c
@@ -16,7 +16,7 @@
 // isolate compose tree into its own file - hand crafted into static const c
 #include "ecore_input_compose.h"
 
-EAPI Ecore_Compose_State
+ECORE_INPUT_API Ecore_Compose_State
 ecore_compose_get(const Eina_List *seq, char **seqstr_ret)
 {
    const char *p, *pend;

--- a/src/lib/ecore_input/ecore_input_joystick.c
+++ b/src/lib/ecore_input/ecore_input_joystick.c
@@ -611,7 +611,7 @@ ecore_input_joystick_shutdown(void)
    return _ecore_input_joystick_init_count;
 }
 
-EAPI void
+ECORE_INPUT_API void
 ecore_input_joystick_event_axis_deadzone_set(int event_axis_deadzone)
 {
    event_axis_deadzone = abs(event_axis_deadzone);
@@ -620,13 +620,13 @@ ecore_input_joystick_event_axis_deadzone_set(int event_axis_deadzone)
    _event_axis_deadzone = event_axis_deadzone;
 }
 
-EAPI int
+ECORE_INPUT_API int
 ecore_input_joystick_event_axis_deadzone_get(void)
 {
    return _event_axis_deadzone;
 }
 
-EAPI const char *
+ECORE_INPUT_API const char *
 ecore_input_joystick_name_get(int index)
 {
 #if defined(HAVE_EEZE) && defined(JSIOCGNAME)

--- a/src/lib/ecore_input/meson.build
+++ b/src/lib/ecore_input/meson.build
@@ -20,7 +20,7 @@ endif
 
 ecore_input_lib = library('ecore_input',
     ecore_input_src, pub_eo_file_target,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_INPUT_BUILD'],
     dependencies: ecore_input_pub_deps + ecore_input_deps + ecore_input_ext_deps,
     include_directories : config_dir,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.