### PR TITLE
[emile] Use EMILE_API instead of EAPI

### DIFF
--- a/src/lib/emile/Emile.h
+++ b/src/lib/emile/Emile.h
@@ -21,31 +21,7 @@
 
 #include <Eina.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <emile_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -87,7 +63,7 @@ extern "C" {
  *
  * @since 1.14
  */
-EAPI int emile_init(void);
+EMILE_API int emile_init(void);
 
 /**
  * Shut down the Emile library
@@ -100,7 +76,7 @@ EAPI int emile_init(void);
  * @return The new init count.
  * @since 1.14
  */
-EAPI int emile_shutdown(void);
+EMILE_API int emile_shutdown(void);
 
 /**
  * @}
@@ -114,8 +90,5 @@ EAPI int emile_shutdown(void);
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/emile/emile_api.h
+++ b/src/lib/emile/emile_api.h
@@ -6,7 +6,7 @@
 #endif
 
 #ifdef _WIN32
-# ifndef EFL_STATIC
+# ifndef EMILE_STATIC
 #  ifdef EMILE_BUILD
 #   define EMILE_API __declspec(dllexport)
 #  else

--- a/src/lib/emile/emile_api.h
+++ b/src/lib/emile/emile_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_EMILE_API_H
+#define _EFL_EMILE_API_H
+
+#ifdef EMILE_API
+#error EMILE_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_STATIC
+#  ifdef EMILE_BUILD
+#   define EMILE_API __declspec(dllexport)
+#  else
+#   define EMILE_API __declspec(dllimport)
+#  endif
+# else
+#  define EMILE_API
+# endif
+# define EMILE_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define EMILE_API __attribute__ ((visibility("default")))
+#   define EMILE_API_WEAK __attribute__ ((weak))
+#  else
+#   define EMILE_API
+#   define EMILE_API_WEAK
+#  endif
+# else
+#  define EMILE_API
+#  define EMILE_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/emile/emile_base64.c
+++ b/src/lib/emile/emile_base64.c
@@ -182,25 +182,25 @@ emile_base64_decode_common(const Eina_Strbuf *in, Eina_Bool is_base64url_decode)
 *                                   API                                      *
 *============================================================================*/
 
-EAPI Eina_Strbuf *
+EMILE_API Eina_Strbuf *
 emile_base64_encode(const Eina_Binbuf *in)
 {
    return emile_base64_encode_common(in, EINA_FALSE);
 }
 
-EAPI Eina_Strbuf *
+EMILE_API Eina_Strbuf *
 emile_base64url_encode(const Eina_Binbuf *in)
 {
    return emile_base64_encode_common(in, EINA_TRUE);
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_base64_decode(const Eina_Strbuf *in)
 {
    return emile_base64_decode_common(in, EINA_FALSE);
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_base64url_decode(const Eina_Strbuf *in)
 {
    return emile_base64_decode_common(in, EINA_TRUE);

--- a/src/lib/emile/emile_base64.h
+++ b/src/lib/emile/emile_base64.h
@@ -19,7 +19,7 @@
  *
  * @since 1.17.0
  */
-EAPI Eina_Strbuf *emile_base64_encode(const Eina_Binbuf *in);
+EMILE_API Eina_Strbuf *emile_base64_encode(const Eina_Binbuf *in);
 
 /**
  * @brief base64 url and filename safe encoding function.
@@ -33,7 +33,7 @@ EAPI Eina_Strbuf *emile_base64_encode(const Eina_Binbuf *in);
  *
  * @since 1.17.0
  */
-EAPI Eina_Strbuf *emile_base64url_encode(const Eina_Binbuf *in);
+EMILE_API Eina_Strbuf *emile_base64url_encode(const Eina_Binbuf *in);
 
 /**
  * @brief base64 decoding function.
@@ -45,7 +45,7 @@ EAPI Eina_Strbuf *emile_base64url_encode(const Eina_Binbuf *in);
  *
  * @since 1.17.0
  */
-EAPI Eina_Binbuf* emile_base64_decode(const Eina_Strbuf *in);
+EMILE_API Eina_Binbuf* emile_base64_decode(const Eina_Strbuf *in);
 
 /**
  * @brief decoding function for base64 url and filename safe encoding.
@@ -57,7 +57,7 @@ EAPI Eina_Binbuf* emile_base64_decode(const Eina_Strbuf *in);
  *
  * @since 1.17.0
  */
-EAPI Eina_Binbuf* emile_base64url_decode(const Eina_Strbuf *in);
+EMILE_API Eina_Binbuf* emile_base64url_decode(const Eina_Strbuf *in);
 
 /**
  * @}

--- a/src/lib/emile/emile_cipher.c
+++ b/src/lib/emile/emile_cipher.c
@@ -13,7 +13,7 @@ Eina_Bool _emile_cipher_init(void)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_binbuf_hmac_sha1(const char *key EINA_UNUSED,
                        unsigned int key_len EINA_UNUSED,
                        const Eina_Binbuf *data EINA_UNUSED,
@@ -22,13 +22,13 @@ emile_binbuf_hmac_sha1(const char *key EINA_UNUSED,
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_binbuf_sha1(const Eina_Binbuf * data, unsigned char digest[20])
 {
    return EINA_FALSE;
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_binbuf_cipher(Emile_Cipher_Algorithm algo EINA_UNUSED,
                     const Eina_Binbuf *data EINA_UNUSED,
                     const char *key EINA_UNUSED,
@@ -37,7 +37,7 @@ emile_binbuf_cipher(Emile_Cipher_Algorithm algo EINA_UNUSED,
    return NULL;
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_binbuf_decipher(Emile_Cipher_Algorithm algo EINA_UNUSED,
                       const Eina_Binbuf *data EINA_UNUSED,
                       const char *key EINA_UNUSED,
@@ -46,66 +46,66 @@ emile_binbuf_decipher(Emile_Cipher_Algorithm algo EINA_UNUSED,
    return NULL;
 }
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_server_listen(Emile_Cipher_Type t EINA_UNUSED)
 {
    return NULL;
 }
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_client_connect(Emile_SSL *server EINA_UNUSED, int fd EINA_UNUSED)
 {
    return NULL;
 }
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_server_connect(Emile_Cipher_Type t EINA_UNUSED)
 {
    return NULL;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_free(Emile_SSL *emile EINA_UNUSED)
 {
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_cafile_add(Emile_SSL *emile EINA_UNUSED,
                         const char *file EINA_UNUSED)
 {
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_cert_add(Emile_SSL *emile EINA_UNUSED,
                       const char *file EINA_UNUSED)
 {
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_privkey_add(Emile_SSL *emile EINA_UNUSED,
                          const char *file EINA_UNUSED)
 {
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_crl_add(Emile_SSL *emile EINA_UNUSED,
                      const char *file EINA_UNUSED)
 {
    return EINA_FALSE;
 }
 
-EAPI int
+EMILE_API int
 emile_cipher_read(Emile_SSL *emile EINA_UNUSED,
                   Eina_Binbuf *buffer EINA_UNUSED)
 {
    return EINA_FALSE;
 }
 
-EAPI int
+EMILE_API int
 emile_cipher_write(Emile_SSL *emile EINA_UNUSED,
                    const Eina_Binbuf *buffer EINA_UNUSED)
 {
@@ -113,44 +113,44 @@ emile_cipher_write(Emile_SSL *emile EINA_UNUSED,
 }
 
 
-EAPI const char *
+EMILE_API const char *
 emile_cipher_error_get(const Emile_SSL *emile EINA_UNUSED)
 {
    return NULL;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_name_set(Emile_SSL *emile EINA_UNUSED,
                              const char *name EINA_UNUSED)
 {
    return EINA_FALSE;
 }
 
-EAPI const char *
+EMILE_API const char *
 emile_cipher_verify_name_get(const Emile_SSL *emile EINA_UNUSED)
 {
    return NULL;
 }
 
-EAPI void
+EMILE_API void
 emile_cipher_verify_set(Emile_SSL *emile EINA_UNUSED,
                         Eina_Bool verify EINA_UNUSED)
 {
 }
 
-EAPI void
+EMILE_API void
 emile_cipher_verify_basic_set(Emile_SSL *emile EINA_UNUSED,
                               Eina_Bool verify_basic EINA_UNUSED)
 {
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_get(const Emile_SSL *emile EINA_UNUSED)
 {
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_basic_get(const Emile_SSL *emile EINA_UNUSED)
 {
    return EINA_FALSE;

--- a/src/lib/emile/emile_cipher.h
+++ b/src/lib/emile/emile_cipher.h
@@ -46,14 +46,14 @@ typedef enum _Emile_Cipher_Algorithm
  *
  * @since 1.14
  */
-EAPI Eina_Bool emile_cipher_init(void);
+EMILE_API Eina_Bool emile_cipher_init(void);
 /**
  * Get the name of the current used backend.
  *
  * @return the name of the current cipher backend.
  * @since 1.14
  */
-EAPI Emile_Cipher_Backend emile_cipher_module_get(void);
+EMILE_API Emile_Cipher_Backend emile_cipher_module_get(void);
 
 /**
  * Cipher a buffer with a defined algorithm and key.
@@ -66,7 +66,7 @@ EAPI Emile_Cipher_Backend emile_cipher_module_get(void);
  *
  * @since 1.14
  */
-EAPI Eina_Binbuf *emile_binbuf_cipher(Emile_Cipher_Algorithm algo, const Eina_Binbuf * in, const char *key, unsigned int length);
+EMILE_API Eina_Binbuf *emile_binbuf_cipher(Emile_Cipher_Algorithm algo, const Eina_Binbuf * in, const char *key, unsigned int length);
 
 /**
  * Decipher a buffer with a defined algorithm and key.
@@ -83,7 +83,7 @@ EAPI Eina_Binbuf *emile_binbuf_cipher(Emile_Cipher_Algorithm algo, const Eina_Bi
  *
  * @since 1.14
  */
-EAPI Eina_Binbuf *emile_binbuf_decipher(Emile_Cipher_Algorithm algo, const Eina_Binbuf * in, const char *key, unsigned int length);
+EMILE_API Eina_Binbuf *emile_binbuf_decipher(Emile_Cipher_Algorithm algo, const Eina_Binbuf * in, const char *key, unsigned int length);
 
 #ifdef EFL_BETA_API_SUPPORT
 
@@ -102,29 +102,29 @@ typedef enum
   EMILE_WANT_WRITE = 3
 } Emile_Want_Type;
 
-EAPI Eina_Bool emile_binbuf_hmac_sha1(const char *key, unsigned int key_len, const Eina_Binbuf * data, unsigned char digest[20]);
+EMILE_API Eina_Bool emile_binbuf_hmac_sha1(const char *key, unsigned int key_len, const Eina_Binbuf * data, unsigned char digest[20]);
 
-EAPI Eina_Bool emile_binbuf_sha1(const Eina_Binbuf * data, unsigned char digest[20]);
+EMILE_API Eina_Bool emile_binbuf_sha1(const Eina_Binbuf * data, unsigned char digest[20]);
 
 
-EAPI Emile_SSL *emile_cipher_server_listen(Emile_Cipher_Type t);
-EAPI Emile_SSL *emile_cipher_client_connect(Emile_SSL * server, int fd);
-EAPI Emile_SSL *emile_cipher_server_connect(Emile_Cipher_Type t);
-EAPI Eina_Bool emile_cipher_free(Emile_SSL * emile);
+EMILE_API Emile_SSL *emile_cipher_server_listen(Emile_Cipher_Type t);
+EMILE_API Emile_SSL *emile_cipher_client_connect(Emile_SSL * server, int fd);
+EMILE_API Emile_SSL *emile_cipher_server_connect(Emile_Cipher_Type t);
+EMILE_API Eina_Bool emile_cipher_free(Emile_SSL * emile);
 
-EAPI Eina_Bool emile_cipher_cafile_add(Emile_SSL * emile, const char *file);
-EAPI Eina_Bool emile_cipher_cert_add(Emile_SSL * emile, const char *file);
-EAPI Eina_Bool emile_cipher_privkey_add(Emile_SSL * emile, const char *file);
-EAPI Eina_Bool emile_cipher_crl_add(Emile_SSL * emile, const char *file);
-EAPI int emile_cipher_read(Emile_SSL * emile, Eina_Binbuf * buffer);
-EAPI int emile_cipher_write(Emile_SSL * emile, const Eina_Binbuf * buffer);
-EAPI const char *emile_cipher_error_get(const Emile_SSL * emile);
-EAPI Eina_Bool emile_cipher_verify_name_set(Emile_SSL * emile, const char *name);
-EAPI const char *emile_cipher_verify_name_get(const Emile_SSL * emile);
-EAPI void emile_cipher_verify_set(Emile_SSL * emile, Eina_Bool verify);
-EAPI void emile_cipher_verify_basic_set(Emile_SSL * emile, Eina_Bool verify_basic);
-EAPI Eina_Bool emile_cipher_verify_get(const Emile_SSL * emile);
-EAPI Eina_Bool emile_cipher_verify_basic_get(const Emile_SSL * emile);
+EMILE_API Eina_Bool emile_cipher_cafile_add(Emile_SSL * emile, const char *file);
+EMILE_API Eina_Bool emile_cipher_cert_add(Emile_SSL * emile, const char *file);
+EMILE_API Eina_Bool emile_cipher_privkey_add(Emile_SSL * emile, const char *file);
+EMILE_API Eina_Bool emile_cipher_crl_add(Emile_SSL * emile, const char *file);
+EMILE_API int emile_cipher_read(Emile_SSL * emile, Eina_Binbuf * buffer);
+EMILE_API int emile_cipher_write(Emile_SSL * emile, const Eina_Binbuf * buffer);
+EMILE_API const char *emile_cipher_error_get(const Emile_SSL * emile);
+EMILE_API Eina_Bool emile_cipher_verify_name_set(Emile_SSL * emile, const char *name);
+EMILE_API const char *emile_cipher_verify_name_get(const Emile_SSL * emile);
+EMILE_API void emile_cipher_verify_set(Emile_SSL * emile, Eina_Bool verify);
+EMILE_API void emile_cipher_verify_basic_set(Emile_SSL * emile, Eina_Bool verify_basic);
+EMILE_API Eina_Bool emile_cipher_verify_get(const Emile_SSL * emile);
+EMILE_API Eina_Bool emile_cipher_verify_basic_get(const Emile_SSL * emile);
 
 #endif
 

--- a/src/lib/emile/emile_cipher_gnutls.c
+++ b/src/lib/emile/emile_cipher_gnutls.c
@@ -120,7 +120,7 @@ emile_hmac_sha1(const void    *key,
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_binbuf_hmac_sha1(const char *key,
                        unsigned int key_len,
                        const Eina_Binbuf *data,
@@ -161,14 +161,14 @@ emile_sha1(const void    *data,
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_binbuf_sha1(const Eina_Binbuf * data, unsigned char digest[20])
 {
    Eina_Slice slice = eina_binbuf_slice_get(data);
    return emile_sha1(slice.mem, slice.len, digest);
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_binbuf_cipher(Emile_Cipher_Algorithm algo,
                     const Eina_Binbuf *data,
                     const char *key,
@@ -271,7 +271,7 @@ on_error:
    return NULL;
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_binbuf_decipher(Emile_Cipher_Algorithm algo,
                       const Eina_Binbuf *data,
                       const char *key,
@@ -368,7 +368,7 @@ on_error:
 // FIXME: handshaking and fun
 
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_server_listen(Emile_Cipher_Type t)
 {
    Emile_SSL *r;
@@ -397,13 +397,13 @@ emile_cipher_server_listen(Emile_Cipher_Type t)
    return NULL;
 }
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_client_connect(Emile_SSL *server EINA_UNUSED, int fd EINA_UNUSED)
 {
    return NULL;
 }
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_server_connect(Emile_Cipher_Type t)
 {
    const char *priority = "NORMAL:%VERIFY_ALLOW_X509_V1_CA_CRT";
@@ -455,13 +455,13 @@ emile_cipher_server_connect(Emile_Cipher_Type t)
    return NULL;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_free(Emile_SSL *emile EINA_UNUSED)
 {
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_cafile_add(Emile_SSL *emile, const char *file)
 {
    Eina_File_Direct_Info *info;
@@ -500,13 +500,13 @@ emile_cipher_cafile_add(Emile_SSL *emile, const char *file)
    return !count ? EINA_FALSE : EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_cert_add(Emile_SSL *emile, const char *file)
 {
    return eina_stringshare_replace(&emile->cert_file, file);
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_privkey_add(Emile_SSL *emile, const char *file)
 {
    int ret;
@@ -521,7 +521,7 @@ emile_cipher_privkey_add(Emile_SSL *emile, const char *file)
    return ret ? EINA_FALSE : EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_crl_add(Emile_SSL *emile, const char *file)
 {
    int ret;
@@ -533,7 +533,7 @@ emile_cipher_crl_add(Emile_SSL *emile, const char *file)
    return ret ? EINA_FALSE : EINA_TRUE;
 }
 
-EAPI int
+EMILE_API int
 emile_cipher_read(Emile_SSL *emile, Eina_Binbuf *buffer)
 {
    int num;
@@ -554,49 +554,49 @@ emile_cipher_read(Emile_SSL *emile, Eina_Binbuf *buffer)
    return num;
 }
 
-EAPI int
+EMILE_API int
 emile_cipher_write(Emile_SSL *emile EINA_UNUSED, const Eina_Binbuf *buffer EINA_UNUSED)
 {
    return 0;
 }
 
-EAPI const char *
+EMILE_API const char *
 emile_cipher_error_get(const Emile_SSL *emile)
 {
    return emile->last_error;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_name_set(Emile_SSL *emile, const char *name)
 {
    return eina_stringshare_replace(&emile->name, name);
 }
 
-EAPI const char *
+EMILE_API const char *
 emile_cipher_verify_name_get(const Emile_SSL *emile)
 {
    return emile->name;
 }
 
-EAPI void
+EMILE_API void
 emile_cipher_verify_set(Emile_SSL *emile, Eina_Bool verify)
 {
    emile->verify = verify;
 }
 
-EAPI void
+EMILE_API void
 emile_cipher_verify_basic_set(Emile_SSL *emile, Eina_Bool verify_basic)
 {
    emile->verify_basic = verify_basic;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_get(const Emile_SSL *emile)
 {
    return emile->verify;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_basic_get(const Emile_SSL *emile)
 {
    return emile->verify_basic;

--- a/src/lib/emile/emile_cipher_openssl.c
+++ b/src/lib/emile/emile_cipher_openssl.c
@@ -55,7 +55,7 @@ _emile_cipher_init(void)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_binbuf_hmac_sha1(const char *key,
                        unsigned int key_len,
                        const Eina_Binbuf *data,
@@ -68,7 +68,7 @@ emile_binbuf_hmac_sha1(const char *key,
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_binbuf_sha1(const Eina_Binbuf * data, unsigned char digest[20])
 {
    const EVP_MD *md = EVP_sha1();
@@ -96,7 +96,7 @@ emile_binbuf_sha1(const Eina_Binbuf * data, unsigned char digest[20])
    return EINA_TRUE;
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_binbuf_cipher(Emile_Cipher_Algorithm algo,
                     const Eina_Binbuf *data,
                     const char *key,
@@ -210,7 +210,7 @@ on_error:
 }
 
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_binbuf_decipher(Emile_Cipher_Algorithm algo,
                       const Eina_Binbuf *data,
                       const char *key,
@@ -303,7 +303,7 @@ on_error:
    return NULL;
 }
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_server_listen(Emile_Cipher_Type t)
 {
    Emile_SSL *r;
@@ -722,7 +722,7 @@ _emile_cipher_client_handshake(Emile_SSL *client)
    return ;
 }
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_client_connect(Emile_SSL *server, int fd)
 {
    Emile_SSL *r;
@@ -752,7 +752,7 @@ emile_cipher_client_connect(Emile_SSL *server, int fd)
    return NULL;
 }
 
-EAPI Emile_SSL *
+EMILE_API Emile_SSL *
 emile_cipher_server_connect(Emile_Cipher_Type t)
 {
    Emile_SSL *r;
@@ -796,7 +796,7 @@ emile_cipher_server_connect(Emile_Cipher_Type t)
    return NULL;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_free(Emile_SSL *emile)
 {
    if (!emile) return EINA_FALSE;
@@ -824,7 +824,7 @@ emile_cipher_free(Emile_SSL *emile)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_cafile_add(Emile_SSL *emile, const char *file)
 {
    struct stat st;
@@ -853,7 +853,7 @@ emile_cipher_cafile_add(Emile_SSL *emile, const char *file)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_cert_add(Emile_SSL *emile, const char *file)
 {
    Eina_File *f;
@@ -897,7 +897,7 @@ emile_cipher_cert_add(Emile_SSL *emile, const char *file)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_privkey_add(Emile_SSL *emile, const char *file)
 {
    Eina_File *f;
@@ -948,7 +948,7 @@ emile_cipher_privkey_add(Emile_SSL *emile, const char *file)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_crl_add(Emile_SSL *emile, const char *file)
 {
    X509_LOOKUP *lu;
@@ -983,7 +983,7 @@ emile_cipher_crl_add(Emile_SSL *emile, const char *file)
    return EINA_FALSE;
 }
 
-EAPI int
+EMILE_API int
 emile_cipher_read(Emile_SSL *emile, Eina_Binbuf *buffer)
 {
    int err;
@@ -1026,7 +1026,7 @@ emile_cipher_read(Emile_SSL *emile, Eina_Binbuf *buffer)
    return num < 0 ? 0 : num;
 }
 
-EAPI int
+EMILE_API int
 emile_cipher_write(Emile_SSL *emile, const Eina_Binbuf *buffer)
 {
    int num;
@@ -1069,43 +1069,43 @@ emile_cipher_write(Emile_SSL *emile, const Eina_Binbuf *buffer)
    return num < 0 ? 0 : num;
 }
 
-EAPI const char *
+EMILE_API const char *
 emile_cipher_error_get(const Emile_SSL *emile)
 {
    return emile->last_error;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_name_set(Emile_SSL *emile, const char *name)
 {
    return eina_stringshare_replace(&emile->verify_name, name);
 }
 
-EAPI const char *
+EMILE_API const char *
 emile_cipher_verify_name_get(const Emile_SSL *emile)
 {
    return emile->verify_name;
 }
 
-EAPI void
+EMILE_API void
 emile_cipher_verify_set(Emile_SSL *emile, Eina_Bool verify)
 {
    emile->verify = verify;
 }
 
-EAPI void
+EMILE_API void
 emile_cipher_verify_basic_set(Emile_SSL *emile, Eina_Bool verify_basic)
 {
    emile->verify_basic = verify_basic;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_get(const Emile_SSL *emile)
 {
    return emile->verify;
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_verify_basic_get(const Emile_SSL *emile)
 {
    return emile->verify_basic;

--- a/src/lib/emile/emile_compress.c
+++ b/src/lib/emile/emile_compress.c
@@ -33,7 +33,7 @@ _emile_compress_buffer_size(const Eina_Binbuf *data, Emile_Compressor_Type t)
      }
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_compress(const Eina_Binbuf *data,
                Emile_Compressor_Type t,
                Emile_Compressor_Level l)
@@ -93,7 +93,7 @@ emile_compress(const Eina_Binbuf *data,
    return eina_binbuf_manage_new(compact, length, EINA_FALSE);
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_expand(const Eina_Binbuf *in, Eina_Binbuf *out, Emile_Compressor_Type t)
 {
    if (!in || !out)
@@ -131,7 +131,7 @@ emile_expand(const Eina_Binbuf *in, Eina_Binbuf *out, Emile_Compressor_Type t)
    return EINA_TRUE;
 }
 
-EAPI Eina_Binbuf *
+EMILE_API Eina_Binbuf *
 emile_decompress(const Eina_Binbuf *data,
                  Emile_Compressor_Type t,
                  unsigned int dest_length)

--- a/src/lib/emile/emile_compress.h
+++ b/src/lib/emile/emile_compress.h
@@ -51,7 +51,7 @@ typedef enum
  *
  * @since 1.14
  */
-EAPI Eina_Binbuf *emile_compress(const Eina_Binbuf * in, Emile_Compressor_Type t, Emile_Compressor_Level level);
+EMILE_API Eina_Binbuf *emile_compress(const Eina_Binbuf * in, Emile_Compressor_Type t, Emile_Compressor_Level level);
 /**
  * @brief Uncompress a buffer into a newly allocated buffer.
  *
@@ -67,7 +67,7 @@ EAPI Eina_Binbuf *emile_compress(const Eina_Binbuf * in, Emile_Compressor_Type t
  * @note That if dest_length doesn't match the expanded data, it will
  * just fail and return @c NULL.
  */
-EAPI Eina_Binbuf *emile_decompress(const Eina_Binbuf * in, Emile_Compressor_Type t, unsigned int dest_length);
+EMILE_API Eina_Binbuf *emile_decompress(const Eina_Binbuf * in, Emile_Compressor_Type t, unsigned int dest_length);
 
 /**
  * @brief Uncompress a buffer into an existing buffer.
@@ -83,7 +83,7 @@ EAPI Eina_Binbuf *emile_decompress(const Eina_Binbuf * in, Emile_Compressor_Type
  * expanded data or it will fail. In case of failure, random garbage
  * could fill the out buffer.
  */
-EAPI Eina_Bool emile_expand(const Eina_Binbuf * in, Eina_Binbuf * out, Emile_Compressor_Type t);
+EMILE_API Eina_Bool emile_expand(const Eina_Binbuf * in, Eina_Binbuf * out, Emile_Compressor_Type t);
 /**
  * @}
  */

--- a/src/lib/emile/emile_image.c
+++ b/src/lib/emile/emile_image.c
@@ -2385,7 +2385,7 @@ _emile_image_bind(Emile_Image *ei,
 
 /* Public API to manipulate Emile_Image */
 
-EAPI Emile_Image *
+EMILE_API Emile_Image *
 emile_image_tgv_memory_open(Eina_Binbuf *source,
                             Emile_Image_Load_Opts *opts,
                             Emile_Image_Animated *animated,
@@ -2404,7 +2404,7 @@ emile_image_tgv_memory_open(Eina_Binbuf *source,
    return _emile_image_bind(ei, opts, animated, error);
 }
 
-EAPI Emile_Image *
+EMILE_API Emile_Image *
 emile_image_tgv_file_open(Eina_File *source,
                           Emile_Image_Load_Opts *opts,
                           Emile_Image_Animated *animated,
@@ -2423,7 +2423,7 @@ emile_image_tgv_file_open(Eina_File *source,
    return _emile_image_bind(ei, opts, animated, error);
 }
 
-EAPI Emile_Image *
+EMILE_API Emile_Image *
 emile_image_jpeg_memory_open(Eina_Binbuf *source,
                              Emile_Image_Load_Opts *opts,
                              Emile_Image_Animated *animated,
@@ -2442,7 +2442,7 @@ emile_image_jpeg_memory_open(Eina_Binbuf *source,
    return _emile_image_bind(ei, opts, animated, error);
 }
 
-EAPI Emile_Image *
+EMILE_API Emile_Image *
 emile_image_jpeg_file_open(Eina_File *source,
                            Emile_Image_Load_Opts *opts,
                            Emile_Image_Animated *animated,
@@ -2461,7 +2461,7 @@ emile_image_jpeg_file_open(Eina_File *source,
    return _emile_image_bind(ei, opts, animated, error);
 }
 
-EAPI void
+EMILE_API void
 emile_image_callback_set(Emile_Image *image, Emile_Action_Cb callback, Emile_Action action, const void *data)
 {
    if (!image) return ;
@@ -2472,7 +2472,7 @@ emile_image_callback_set(Emile_Image *image, Emile_Action_Cb callback, Emile_Act
    image->cancelled = callback;
 }
 
-EAPI void
+EMILE_API void
 emile_image_close(Emile_Image *image)
 {
    if (!image)
@@ -2485,7 +2485,7 @@ emile_image_close(Emile_Image *image)
    free(image);
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_image_head(Emile_Image *image,
                  Emile_Image_Property *prop,
                  unsigned int property_size,
@@ -2498,7 +2498,7 @@ emile_image_head(Emile_Image *image,
    return image->head(image, prop, property_size, error);
 }
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_image_data(Emile_Image *image,
                  Emile_Image_Property *prop,
                  unsigned int property_size,
@@ -2512,7 +2512,7 @@ emile_image_data(Emile_Image *image,
    return image->data(image, prop, property_size, pixels, error);
 }
 
-EAPI const char *
+EMILE_API const char *
 emile_load_error_str(Emile_Image *source EINA_UNUSED,
                      Emile_Image_Load_Error error)
 {

--- a/src/lib/emile/emile_image.h
+++ b/src/lib/emile/emile_image.h
@@ -246,7 +246,7 @@ struct _Emile_Image_Load_Opts
  *
  * @since 1.14
  */
-EAPI Emile_Image *emile_image_tgv_memory_open(Eina_Binbuf * source, Emile_Image_Load_Opts * opts, Emile_Image_Animated * animated, Emile_Image_Load_Error * error);
+EMILE_API Emile_Image *emile_image_tgv_memory_open(Eina_Binbuf * source, Emile_Image_Load_Opts * opts, Emile_Image_Animated * animated, Emile_Image_Load_Error * error);
 
 /**
  * Open a TGV image from a file.
@@ -259,7 +259,7 @@ EAPI Emile_Image *emile_image_tgv_memory_open(Eina_Binbuf * source, Emile_Image_
  *
  * @since 1.14
  */
-EAPI Emile_Image *emile_image_tgv_file_open(Eina_File * source, Emile_Image_Load_Opts * opts, Emile_Image_Animated * animated, Emile_Image_Load_Error * error);
+EMILE_API Emile_Image *emile_image_tgv_file_open(Eina_File * source, Emile_Image_Load_Opts * opts, Emile_Image_Animated * animated, Emile_Image_Load_Error * error);
 
 
 /**
@@ -273,7 +273,7 @@ EAPI Emile_Image *emile_image_tgv_file_open(Eina_File * source, Emile_Image_Load
  *
  * @since 1.14
  */
-EAPI Emile_Image *emile_image_jpeg_memory_open(Eina_Binbuf * source, Emile_Image_Load_Opts * opts, Emile_Image_Animated * animated, Emile_Image_Load_Error * error);
+EMILE_API Emile_Image *emile_image_jpeg_memory_open(Eina_Binbuf * source, Emile_Image_Load_Opts * opts, Emile_Image_Animated * animated, Emile_Image_Load_Error * error);
 
 /**
  * Open a JPEG image from file.
@@ -286,7 +286,7 @@ EAPI Emile_Image *emile_image_jpeg_memory_open(Eina_Binbuf * source, Emile_Image
  *
  * @since 1.14
  */
-EAPI Emile_Image *emile_image_jpeg_file_open(Eina_File * source, Emile_Image_Load_Opts * opts, Emile_Image_Animated * animated, Emile_Image_Load_Error * error);
+EMILE_API Emile_Image *emile_image_jpeg_file_open(Eina_File * source, Emile_Image_Load_Opts * opts, Emile_Image_Animated * animated, Emile_Image_Load_Error * error);
 
 /**
  * Read the header of an image to fill Emile_Image_Property.
@@ -299,7 +299,7 @@ EAPI Emile_Image *emile_image_jpeg_file_open(Eina_File * source, Emile_Image_Loa
  *
  * @since 1.14
  */
-EAPI Eina_Bool emile_image_head(Emile_Image * image, Emile_Image_Property * prop, unsigned int property_size, Emile_Image_Load_Error * error);
+EMILE_API Eina_Bool emile_image_head(Emile_Image * image, Emile_Image_Property * prop, unsigned int property_size, Emile_Image_Load_Error * error);
 
 /**
  * Read the pixels from an image file.
@@ -313,7 +313,7 @@ EAPI Eina_Bool emile_image_head(Emile_Image * image, Emile_Image_Property * prop
  *
  * @since 1.14
  */
-EAPI Eina_Bool emile_image_data(Emile_Image * image, Emile_Image_Property * prop, unsigned int property_size, void *pixels, Emile_Image_Load_Error * error);
+EMILE_API Eina_Bool emile_image_data(Emile_Image * image, Emile_Image_Property * prop, unsigned int property_size, void *pixels, Emile_Image_Load_Error * error);
 
 /**
  * Register a callback for emile to ask what to do during the processing of an image
@@ -323,7 +323,7 @@ EAPI Eina_Bool emile_image_data(Emile_Image * image, Emile_Image_Property * prop
  * @param action The action this callback is triggered on.
  * @since 1.19
  */
-EAPI void emile_image_callback_set(Emile_Image *image, Emile_Action_Cb callback, Emile_Action action, const void *data);
+EMILE_API void emile_image_callback_set(Emile_Image *image, Emile_Action_Cb callback, Emile_Action action, const void *data);
 
 /**
  * Close an opened image handler.
@@ -332,7 +332,7 @@ EAPI void emile_image_callback_set(Emile_Image *image, Emile_Action_Cb callback,
  *
  * @since 1.14
  */
-EAPI void emile_image_close(Emile_Image * source);
+EMILE_API void emile_image_close(Emile_Image * source);
 
 /**
  * Convert an error code related to an image handler into a meaningful string.
@@ -343,7 +343,7 @@ EAPI void emile_image_close(Emile_Image * source);
  *
  * @since 1.14
  */
-EAPI const char *emile_load_error_str(Emile_Image * source, Emile_Image_Load_Error error);
+EMILE_API const char *emile_load_error_str(Emile_Image * source, Emile_Image_Load_Error error);
 
 /**
  * @}

--- a/src/lib/emile/emile_main.c
+++ b/src/lib/emile/emile_main.c
@@ -23,7 +23,7 @@ static Eina_Bool _emile_cipher_inited = EINA_FALSE;
 static unsigned int _emile_init_count = 0;
 int _emile_log_dom_global = -1;
 
-EAPI Eina_Bool
+EMILE_API Eina_Bool
 emile_cipher_init(void)
 {
    if (_emile_cipher_inited)
@@ -37,7 +37,7 @@ emile_cipher_init(void)
    return EINA_TRUE;
 }
 
-EAPI Emile_Cipher_Backend
+EMILE_API Emile_Cipher_Backend
 emile_cipher_module_get(void)
 {
 #ifdef HAVE_GNUTLS
@@ -51,7 +51,7 @@ emile_cipher_module_get(void)
 #endif
 }
 
-EAPI int
+EMILE_API int
 emile_init(void)
 {
    if (++_emile_init_count != 1)
@@ -77,7 +77,7 @@ shutdown_eina:
    return --_emile_init_count;
 }
 
-EAPI int
+EMILE_API int
 emile_shutdown(void)
 {
    if (--_emile_init_count != 0)

--- a/src/lib/emile/meson.build
+++ b/src/lib/emile/meson.build
@@ -32,7 +32,7 @@ endif
 
 emile_lib = library('emile',
     emile_src,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DEMILE_BUILD'],
     include_directories: config_dir,
     dependencies: emile_pub_deps + emile_deps + emile_ext_deps,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.