### PR TITLE
[eeze] Use EEZE_API instead of EAPI

### DIFF
--- a/src/lib/eeze/Eeze.h
+++ b/src/lib/eeze/Eeze.h
@@ -75,19 +75,7 @@
 #include <Eina.h>
 #include <Efl_Config.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef __GNUC__
-# if __GNUC__ >= 4
-#  define EAPI __attribute__ ((visibility("default")))
-# else
-#  define EAPI
-# endif
-#else
-# define EAPI
-#endif
+#include <eeze_api.h>
 
 /**
  * @file Eeze.h
@@ -309,7 +297,7 @@ typedef struct Eeze_Udev_Watch Eeze_Udev_Watch;
         int revision; /** < git revision (0 if a proper release or the git revision number Eeze is built from) */
      } Eeze_Version;
 
-   EAPI extern Eeze_Version *eeze_version;
+   EEZE_API extern Eeze_Version *eeze_version;
 
 /**
  * @addtogroup Eeze_Watch
@@ -328,7 +316,7 @@ typedef void(*Eeze_Udev_Watch_Cb)(const char *, Eeze_Udev_Event, void *, Eeze_Ud
  *
  * @ingroup Eeze_Main
  */
-EAPI int             eeze_init(void);
+EEZE_API int             eeze_init(void);
 
 /**
  * Shut down the eeze library.
@@ -339,7 +327,7 @@ EAPI int             eeze_init(void);
  *
  * @ingroup Eeze_Main
  */
-EAPI int             eeze_shutdown(void);
+EEZE_API int             eeze_shutdown(void);
 
 /**
  * @return the main udev context used by the library
@@ -348,7 +336,7 @@ EAPI int             eeze_shutdown(void);
  * @warning DO NOT CLOSE THIS CONTEXT.
  * @since 1.10
  */
-EAPI void           *eeze_udev_get(void);
+EEZE_API void           *eeze_udev_get(void);
 
 
    /**
@@ -368,7 +356,7 @@ EAPI void           *eeze_udev_get(void);
  * @param syspath The syspath of the device to find matches for
  * @return All devices which are the same as the one passed
  */
-EAPI Eina_List       *eeze_udev_find_similar_from_syspath(const char *syspath);
+EEZE_API Eina_List       *eeze_udev_find_similar_from_syspath(const char *syspath);
 
 /**
  * Updates a list of all syspaths that are (or should be) the same
@@ -383,7 +371,7 @@ EAPI Eina_List       *eeze_udev_find_similar_from_syspath(const char *syspath);
  *
  * @note This is an expensive call, do not use it unless you must.
  */
-EAPI Eina_List       *eeze_udev_find_unlisted_similar(Eina_List *list);
+EEZE_API Eina_List       *eeze_udev_find_unlisted_similar(Eina_List *list);
 
 /**
  * Find a list of devices by a sysattr (and, optionally, a value of that sysattr).
@@ -395,7 +383,7 @@ EAPI Eina_List       *eeze_udev_find_unlisted_similar(Eina_List *list);
  *
  * @ingroup Eeze_Find
  */
-EAPI Eina_List       *eeze_udev_find_by_sysattr(const char *sysattr, const char *value);
+EEZE_API Eina_List       *eeze_udev_find_by_sysattr(const char *sysattr, const char *value);
 
 /**
  * Find devices using an #Eeze_Udev_Type and/or a name.
@@ -406,7 +394,7 @@ EAPI Eina_List       *eeze_udev_find_by_sysattr(const char *sysattr, const char 
  *
  * Return a list of syspaths (/sys/$syspath) for matching udev devices.
  */
-EAPI Eina_List       *eeze_udev_find_by_type(Eeze_Udev_Type type, const char *name);
+EEZE_API Eina_List       *eeze_udev_find_by_type(Eeze_Udev_Type type, const char *name);
 
 /**
  * A more advanced find, allows finds using udev properties.
@@ -419,7 +407,7 @@ EAPI Eina_List       *eeze_udev_find_by_type(Eeze_Udev_Type type, const char *na
  * Return a list of syspaths (/sys/$syspath) for matching udev devices.
  * Requires at least one filter.
  */
-EAPI Eina_List       *eeze_udev_find_by_filter(const char *subsystem, const char *type, const char *name);
+EEZE_API Eina_List       *eeze_udev_find_by_filter(const char *subsystem, const char *type, const char *name);
 
 /**
  * A more advanced find, allows finds using udev subsystem and sysname
@@ -432,8 +420,8 @@ EAPI Eina_List       *eeze_udev_find_by_filter(const char *subsystem, const char
  *
  * @since 1.13
 
- EAPI */
-EAPI Eina_List       *eeze_udev_find_by_subsystem_sysname(const char *subsystem, const char *sysname);
+ EEZE_API */
+EEZE_API Eina_List       *eeze_udev_find_by_subsystem_sysname(const char *subsystem, const char *sysname);
 
    /**
     * @}
@@ -458,7 +446,7 @@ EAPI Eina_List       *eeze_udev_find_by_subsystem_sysname(const char *subsystem,
  *
  * Takes "/dev/path" and returns the corresponding /sys/ path (without the "/sys/")
  */
-EAPI const char      *eeze_udev_devpath_get_syspath(const char *devpath);
+EEZE_API const char      *eeze_udev_devpath_get_syspath(const char *devpath);
 
 /**
  * Find the root device of a device from its syspath.
@@ -468,7 +456,7 @@ EAPI const char      *eeze_udev_devpath_get_syspath(const char *devpath);
  *
  * Return a stringshared syspath (/sys/$syspath) for the parent device.
  */
-EAPI const char      *eeze_udev_syspath_get_parent(const char *syspath);
+EEZE_API const char      *eeze_udev_syspath_get_parent(const char *syspath);
 
 /**
  * Find the parent device of a device from its syspath with a filter applied.
@@ -481,7 +469,7 @@ EAPI const char      *eeze_udev_syspath_get_parent(const char *syspath);
  * Return a stringshared syspath (/sys/$syspath) for the parent device if one exists which matches the filter.
  * @since 1.10
  */
-EAPI Eina_Stringshare *eeze_udev_syspath_get_parent_filtered(const char *syspath, const char *subsystem, const char *devtype);
+EEZE_API Eina_Stringshare *eeze_udev_syspath_get_parent_filtered(const char *syspath, const char *subsystem, const char *devtype);
 
 /**
  * Returns a list of all parent device syspaths for @p syspath.
@@ -489,7 +477,7 @@ EAPI Eina_Stringshare *eeze_udev_syspath_get_parent_filtered(const char *syspath
  * @param syspath The device to find parents of
  * @return A stringshared list of the parent devices of @p syspath
  */
-EAPI Eina_List       *eeze_udev_syspath_get_parents(const char *syspath);
+EEZE_API Eina_List       *eeze_udev_syspath_get_parents(const char *syspath);
 
 /**
  * Get the /dev/ path from the /sys/ path.
@@ -499,7 +487,7 @@ EAPI Eina_List       *eeze_udev_syspath_get_parents(const char *syspath);
  *
  * Takes /sys/$PATH and turns it into the corresponding "/dev/x/y".
  */
-EAPI const char      *eeze_udev_syspath_get_devpath(const char *syspath);
+EEZE_API const char      *eeze_udev_syspath_get_devpath(const char *syspath);
 
 /**
  * Get the /dev/ name from the /sys/ path.
@@ -509,7 +497,7 @@ EAPI const char      *eeze_udev_syspath_get_devpath(const char *syspath);
  *
  * Takes /sys/$PATH and turns it into the corresponding /dev/x/"y".
  */
-EAPI const char      *eeze_udev_syspath_get_devname(const char *syspath);
+EEZE_API const char      *eeze_udev_syspath_get_devname(const char *syspath);
 
 /**
  * Get the subsystem of a device from the /sys/ path.
@@ -520,7 +508,7 @@ EAPI const char      *eeze_udev_syspath_get_devname(const char *syspath);
  * Takes /sys/$PATH and returns the corresponding device subsystem,
  * such as "input" for keyboards/mice.
  */
-EAPI const char      *eeze_udev_syspath_get_subsystem(const char *syspath);
+EEZE_API const char      *eeze_udev_syspath_get_subsystem(const char *syspath);
 
 /**
  * Check the property value of a device from the /sys/ path against a provided value.
@@ -531,7 +519,7 @@ EAPI const char      *eeze_udev_syspath_get_subsystem(const char *syspath);
  * @return @c EINA_TRUE if the property matches the supplied value
  * @since 1.10
  */
-EAPI Eina_Bool eeze_udev_syspath_check_property(const char *syspath, const char *property, const char *value);
+EEZE_API Eina_Bool eeze_udev_syspath_check_property(const char *syspath, const char *property, const char *value);
 
 /**
  * Get the property value of a device from the /sys/ path.
@@ -540,7 +528,7 @@ EAPI Eina_Bool eeze_udev_syspath_check_property(const char *syspath, const char 
  * @param property The property to get; full list of these is a FIXME
  * @return A stringshared char* with the property or @c NULL on failure
  */
-EAPI const char      *eeze_udev_syspath_get_property(const char *syspath, const char *property);
+EEZE_API const char      *eeze_udev_syspath_get_property(const char *syspath, const char *property);
 
 /**
  * Get the sysattr value of a device from the /sys/ path.
@@ -549,7 +537,7 @@ EAPI const char      *eeze_udev_syspath_get_property(const char *syspath, const 
  * @param sysattr The sysattr to get; full list of these is a FIXME
  * @return A stringshared char* with the sysattr or @c NULL on failure
  */
-EAPI const char      *eeze_udev_syspath_get_sysattr(const char *syspath, const char *sysattr);
+EEZE_API const char      *eeze_udev_syspath_get_sysattr(const char *syspath, const char *sysattr);
 
 /**
  * Check the sysattr value of a device from the /sys/ path against a provided value.
@@ -560,7 +548,7 @@ EAPI const char      *eeze_udev_syspath_get_sysattr(const char *syspath, const c
  * @return @c EINA_TRUE if the sysattr matches the supplied value
  * @since 1.10
  */
-EAPI Eina_Bool eeze_udev_syspath_check_sysattr(const char *syspath, const char *sysattr, const char *value);
+EEZE_API Eina_Bool eeze_udev_syspath_check_sysattr(const char *syspath, const char *sysattr, const char *value);
 
 /**
  * Set the sysattr value of a device from the /sys/ path.
@@ -571,7 +559,7 @@ EAPI Eina_Bool eeze_udev_syspath_check_sysattr(const char *syspath, const char *
  * @return @c EINA_TRUE if the sysattr value is set
  * @since 1.12
  */
-EAPI Eina_Bool eeze_udev_syspath_set_sysattr(const char *syspath, const char *sysattr, double value);
+EEZE_API Eina_Bool eeze_udev_syspath_set_sysattr(const char *syspath, const char *sysattr, double value);
 
 /**
  * Get the sysattr list of a device from the /sys/ path.
@@ -580,7 +568,7 @@ EAPI Eina_Bool eeze_udev_syspath_set_sysattr(const char *syspath, const char *sy
  * @return Eina_list containing list of sysattr for a device or @c NULL on failure
  * @since 1.12
  */
-EAPI Eina_List *eeze_udev_syspath_get_sysattr_list(const char *syspath);
+EEZE_API Eina_List *eeze_udev_syspath_get_sysattr_list(const char *syspath);
 
 /**
  * Checks whether the device is a mouse.
@@ -588,7 +576,7 @@ EAPI Eina_List *eeze_udev_syspath_get_sysattr_list(const char *syspath);
  * @param syspath The /sys/ path with or without the /sys/
  * @return If true, the device is a mouse
  */
-EAPI Eina_Bool        eeze_udev_syspath_is_mouse(const char *syspath);
+EEZE_API Eina_Bool        eeze_udev_syspath_is_mouse(const char *syspath);
 
 /**
  * Checks whether the device is a keyboard.
@@ -596,7 +584,7 @@ EAPI Eina_Bool        eeze_udev_syspath_is_mouse(const char *syspath);
  * @param syspath The /sys/ path with or without the /sys/
  * @return If true, the device is a keyboard
  */
-EAPI Eina_Bool        eeze_udev_syspath_is_kbd(const char *syspath);
+EEZE_API Eina_Bool        eeze_udev_syspath_is_kbd(const char *syspath);
 
 /**
  * Checks whether the device is a touchpad.
@@ -604,7 +592,7 @@ EAPI Eina_Bool        eeze_udev_syspath_is_kbd(const char *syspath);
  * @param syspath The /sys/ path with or without the /sys/
  * @return If true, the device is a touchpad
  */
-EAPI Eina_Bool        eeze_udev_syspath_is_touchpad(const char *syspath);
+EEZE_API Eina_Bool        eeze_udev_syspath_is_touchpad(const char *syspath);
 
 /**
  * Checks whether the device is a joystick.
@@ -613,17 +601,17 @@ EAPI Eina_Bool        eeze_udev_syspath_is_touchpad(const char *syspath);
  * @return If true, the device is a joystick
  * @since 1.7
  */
-EAPI Eina_Bool        eeze_udev_syspath_is_joystick(const char *syspath);
+EEZE_API Eina_Bool        eeze_udev_syspath_is_joystick(const char *syspath);
 
 /**
  * Get the sysnum value of a device from the /sys/ path.
  *
  * @param syspath The /sys/ path with or without the /sys/
  * @return A integer with the sysnum or -1 on failure
- * 
+ *
  * @since 1.12
  */
-EAPI int              eeze_udev_syspath_get_sysnum(const char *syspath);
+EEZE_API int              eeze_udev_syspath_get_sysnum(const char *syspath);
 
    /**
     * @}
@@ -649,7 +637,7 @@ EAPI int              eeze_udev_syspath_get_sysnum(const char *syspath);
  *
  * @return If the sysattr (with value) is found, returns TRUE.  Else, false.
  */
-EAPI Eina_Bool        eeze_udev_walk_check_sysattr(const char *syspath, const char *sysattr, const char *value);
+EEZE_API Eina_Bool        eeze_udev_walk_check_sysattr(const char *syspath, const char *sysattr, const char *value);
 
 /**
  * Walks up the device chain starting at @p syspath,
@@ -660,7 +648,7 @@ EAPI Eina_Bool        eeze_udev_walk_check_sysattr(const char *syspath, const ch
  *
  * @return The stringshared value of @p sysattr if found, or @c NULL
  */
-EAPI const char      *eeze_udev_walk_get_sysattr(const char *syspath, const char *sysattr);
+EEZE_API const char      *eeze_udev_walk_get_sysattr(const char *syspath, const char *sysattr);
    /**
     * @}
     */
@@ -694,7 +682,7 @@ EAPI const char      *eeze_udev_walk_get_sysattr(const char *syspath, const char
  * syspath of the device will be sent to function @p func, along with the bitmask of the event type which can be detected through
  * binary &.
  */
-EAPI Eeze_Udev_Watch *eeze_udev_watch_add(Eeze_Udev_Type type, int event, Eeze_Udev_Watch_Cb cb, void *user_data);
+EEZE_API Eeze_Udev_Watch *eeze_udev_watch_add(Eeze_Udev_Type type, int event, Eeze_Udev_Watch_Cb cb, void *user_data);
 
 /**
  * Deletes a watch.
@@ -704,7 +692,7 @@ EAPI Eeze_Udev_Watch *eeze_udev_watch_add(Eeze_Udev_Type type, int event, Eeze_U
  *
  * Deletes a watch, closing file descriptors and freeing related udev memory.
  */
-EAPI void            *eeze_udev_watch_del(Eeze_Udev_Watch *watch);
+EEZE_API void            *eeze_udev_watch_del(Eeze_Udev_Watch *watch);
    /**
     * @}
     */
@@ -712,8 +700,5 @@ EAPI void            *eeze_udev_watch_del(Eeze_Udev_Watch *watch);
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/eeze/Eeze_Disk.h
+++ b/src/lib/eeze/Eeze_Disk.h
@@ -4,19 +4,7 @@
 #include <Eina.h>
 #include <Ecore.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef __GNUC__
-# if __GNUC__ >= 4
-#  define EAPI __attribute__ ((visibility("default")))
-# else
-#  define EAPI
-# endif
-#else
-# define EAPI
-#endif
+#include <eeze_api.h>
 
 /**
  * @file Eeze_Disk.h
@@ -72,10 +60,10 @@ typedef enum
 } Eeze_Mount_Opts;
 
 
-EAPI extern int EEZE_EVENT_DISK_MOUNT;
-EAPI extern int EEZE_EVENT_DISK_UNMOUNT;
-EAPI extern int EEZE_EVENT_DISK_EJECT;
-EAPI extern int EEZE_EVENT_DISK_ERROR;
+EEZE_API extern int EEZE_EVENT_DISK_MOUNT;
+EEZE_API extern int EEZE_EVENT_DISK_UNMOUNT;
+EEZE_API extern int EEZE_EVENT_DISK_EJECT;
+EEZE_API extern int EEZE_EVENT_DISK_ERROR;
 
 typedef struct _Eeze_Event_Disk Eeze_Event_Disk_Mount;
 typedef struct _Eeze_Event_Disk Eeze_Event_Disk_Unmount;
@@ -115,7 +103,7 @@ struct _Eeze_Event_Disk_Error
  * if your application successfully runs/compiles with this function then you have eeze_disk.
  * @since 1.1
  */
-EAPI void           eeze_disk_function(void);
+EEZE_API void           eeze_disk_function(void);
 
 /**
  * @brief Return whether mount support is available in eeze
@@ -124,7 +112,7 @@ EAPI void           eeze_disk_function(void);
  * binary available.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_can_mount(void);
+EEZE_API Eina_Bool      eeze_disk_can_mount(void);
 
 /**
  * @brief Return whether unmount support is available in eeze
@@ -133,7 +121,7 @@ EAPI Eina_Bool      eeze_disk_can_mount(void);
  * binary available.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_can_unmount(void);
+EEZE_API Eina_Bool      eeze_disk_can_unmount(void);
 
 /**
  * @brief Return whether eject support is available in eeze
@@ -142,7 +130,7 @@ EAPI Eina_Bool      eeze_disk_can_unmount(void);
  * binary available.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_can_eject(void);
+EEZE_API Eina_Bool      eeze_disk_can_eject(void);
 
 /**
  * @brief Create a new disk object from a /sys/ path or /dev/ path
@@ -154,7 +142,7 @@ EAPI Eina_Bool      eeze_disk_can_eject(void);
  * is not retrieved in this call.
  * @since 1.1
  */
-EAPI Eeze_Disk     *eeze_disk_new(const char *path);
+EEZE_API Eeze_Disk     *eeze_disk_new(const char *path);
 
 /**
  * @brief Create a new disk object from a mount point
@@ -167,7 +155,7 @@ EAPI Eeze_Disk     *eeze_disk_new(const char *path);
  * in /etc/fstab.
  * @since 1.1
  */
-EAPI Eeze_Disk     *eeze_disk_new_from_mount(const char *mount_point);
+EEZE_API Eeze_Disk     *eeze_disk_new_from_mount(const char *mount_point);
 
 /**
  * @brief Frees a disk object
@@ -176,7 +164,7 @@ EAPI Eeze_Disk     *eeze_disk_new_from_mount(const char *mount_point);
  * This call frees an #Eeze_Disk.  Once freed, the disk can no longer be used.
  * @since 1.1
  */
-EAPI void           eeze_disk_free(Eeze_Disk *disk);
+EEZE_API void           eeze_disk_free(Eeze_Disk *disk);
 
 /**
  * @brief Retrieve all disk information
@@ -187,7 +175,7 @@ EAPI void           eeze_disk_free(Eeze_Disk *disk);
  * meaning that subsequent calls will return immediately without performing any work.
  * @since 1.1
  */
-EAPI void           eeze_disk_scan(Eeze_Disk *disk);
+EEZE_API void           eeze_disk_scan(Eeze_Disk *disk);
 
 /**
  * @brief Associate data with a disk
@@ -198,7 +186,7 @@ EAPI void           eeze_disk_scan(Eeze_Disk *disk);
  * @see eeze_disk_data_get
  * @since 1.1
  */
-EAPI void           eeze_disk_data_set(Eeze_Disk *disk, void *data);
+EEZE_API void           eeze_disk_data_set(Eeze_Disk *disk, void *data);
 
 /**
  * @brief Retrieve data previously associated with a disk
@@ -210,7 +198,7 @@ EAPI void           eeze_disk_data_set(Eeze_Disk *disk, void *data);
  * @see eeze_disk_data_set
  * @since 1.1
  */
-EAPI void          *eeze_disk_data_get(Eeze_Disk *disk);
+EEZE_API void          *eeze_disk_data_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the /sys/ path of a disk
@@ -220,7 +208,7 @@ EAPI void          *eeze_disk_data_get(Eeze_Disk *disk);
  * This retrieves the /sys/ path that udev associates with @p disk.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_syspath_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_syspath_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the /dev/ path of a disk
@@ -230,7 +218,7 @@ EAPI const char    *eeze_disk_syspath_get(Eeze_Disk *disk);
  * This retrieves the /dev/ path that udev has created a device node at for @p disk.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_devpath_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_devpath_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the filesystem of the disk (if known)
@@ -240,7 +228,7 @@ EAPI const char    *eeze_disk_devpath_get(Eeze_Disk *disk);
  * This retrieves the filesystem that the disk is using, or @c NULL if unknown.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_fstype_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_fstype_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the manufacturing vendor of the disk
@@ -250,7 +238,7 @@ EAPI const char    *eeze_disk_fstype_get(Eeze_Disk *disk);
  * This retrieves the vendor which manufactured the disk, or @c NULL if unknown.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_vendor_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_vendor_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the model of the disk
@@ -260,7 +248,7 @@ EAPI const char    *eeze_disk_vendor_get(Eeze_Disk *disk);
  * This retrieves the model of the disk, or @c NULL if unknown.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_model_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_model_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the serial number of the disk
@@ -270,7 +258,7 @@ EAPI const char    *eeze_disk_model_get(Eeze_Disk *disk);
  * This retrieves the serial number the disk, or @c NULL if unknown.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_serial_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_serial_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the UUID of the disk
@@ -282,7 +270,7 @@ EAPI const char    *eeze_disk_serial_get(Eeze_Disk *disk);
  * be used to store persistent information about a disk.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_uuid_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_uuid_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the label of the disk
@@ -292,7 +280,7 @@ EAPI const char    *eeze_disk_uuid_get(Eeze_Disk *disk);
  * This retrieves the label (name) of the disk, or @c NULL if unknown.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_label_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_label_get(Eeze_Disk *disk);
 
 /**
  * @brief Return the #Eeze_Disk_Type of the disk
@@ -303,7 +291,7 @@ EAPI const char    *eeze_disk_label_get(Eeze_Disk *disk);
  * the bus that the disk is connected through.
  * @since 1.1
  */
-EAPI Eeze_Disk_Type eeze_disk_type_get(Eeze_Disk *disk);
+EEZE_API Eeze_Disk_Type eeze_disk_type_get(Eeze_Disk *disk);
 
 /**
  * @brief Return whether the disk is removable
@@ -311,7 +299,7 @@ EAPI Eeze_Disk_Type eeze_disk_type_get(Eeze_Disk *disk);
  * @return @c EINA_TRUE if removable, @c EINA_FALSE otherwise.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_removable_get(Eeze_Disk *disk);
+EEZE_API Eina_Bool      eeze_disk_removable_get(Eeze_Disk *disk);
 
 
 /**
@@ -323,7 +311,7 @@ EAPI Eina_Bool      eeze_disk_removable_get(Eeze_Disk *disk);
  * @c EINA_FALSE otherwise.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_mounted_get(Eeze_Disk *disk);
+EEZE_API Eina_Bool      eeze_disk_mounted_get(Eeze_Disk *disk);
 
 /**
  * @brief Get the previously set mount wrapper for a disk
@@ -333,7 +321,7 @@ EAPI Eina_Bool      eeze_disk_mounted_get(Eeze_Disk *disk);
  * This returns the wrapper previously set with eeze_disk_mount_wrapper_set
  * @since 1.1
  */
-EAPI const char    *eeze_disk_mount_wrapper_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_mount_wrapper_get(Eeze_Disk *disk);
 
 /**
  * @brief Set a wrapper to run mount commands with
@@ -346,7 +334,7 @@ EAPI const char    *eeze_disk_mount_wrapper_get(Eeze_Disk *disk);
  * Note that this function will call stat() on @p wrapper if not @c NULL to test for existence.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_mount_wrapper_set(Eeze_Disk *disk, const char *wrapper);
+EEZE_API Eina_Bool      eeze_disk_mount_wrapper_set(Eeze_Disk *disk, const char *wrapper);
 
 /**
  * @brief Begin a mount operation on the disk
@@ -362,7 +350,7 @@ EAPI Eina_Bool      eeze_disk_mount_wrapper_set(Eeze_Disk *disk, const char *wra
  * NOTE: The return value of this function does not in any way reflect the mount state of a disk.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_mount(Eeze_Disk *disk);
+EEZE_API Eina_Bool      eeze_disk_mount(Eeze_Disk *disk);
 
 /**
  * @brief Begin an unmount operation on the disk
@@ -378,7 +366,7 @@ EAPI Eina_Bool      eeze_disk_mount(Eeze_Disk *disk);
  * NOTE: The return value of this function does not in any way reflect the mount state of a disk.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_unmount(Eeze_Disk *disk);
+EEZE_API Eina_Bool      eeze_disk_unmount(Eeze_Disk *disk);
 
 /**
  * @brief Begin an eject operation on the disk
@@ -394,7 +382,7 @@ EAPI Eina_Bool      eeze_disk_unmount(Eeze_Disk *disk);
  * NOTE: The return value of this function does not in any way reflect the mount state of a disk.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_eject(Eeze_Disk *disk);
+EEZE_API Eina_Bool      eeze_disk_eject(Eeze_Disk *disk);
 /**
  * @brief Cancel a pending operation on the disk
  * @param disk The disk
@@ -403,7 +391,7 @@ EAPI Eina_Bool      eeze_disk_eject(Eeze_Disk *disk);
  * started with eeze_disk_mount or eeze_disk_unmount.
  * @since 1.1
  */
-EAPI void           eeze_disk_cancel(Eeze_Disk *disk);
+EEZE_API void           eeze_disk_cancel(Eeze_Disk *disk);
 
 /**
  * @brief Return the mount point of a disk
@@ -414,7 +402,7 @@ EAPI void           eeze_disk_cancel(Eeze_Disk *disk);
  * Note that to determine whether the disk is actually mounted, eeze_disk_mounted_get should be used.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_mount_point_get(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_mount_point_get(Eeze_Disk *disk);
 
 /**
  * @brief Set the mount point of a disk
@@ -427,7 +415,7 @@ EAPI const char    *eeze_disk_mount_point_get(Eeze_Disk *disk);
  * Also note that this function cannot be used while the disk is mounted to avoid losing the current mount point.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_mount_point_set(Eeze_Disk *disk, const char *mount_point);
+EEZE_API Eina_Bool      eeze_disk_mount_point_set(Eeze_Disk *disk, const char *mount_point);
 
 /**
  * @brief Set the mount options using flags
@@ -438,7 +426,7 @@ EAPI Eina_Bool      eeze_disk_mount_point_set(Eeze_Disk *disk, const char *mount
  * This function replaces the current mount opts of a disk with the ones in @p opts.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_mountopts_set(Eeze_Disk *disk, unsigned long opts);
+EEZE_API Eina_Bool      eeze_disk_mountopts_set(Eeze_Disk *disk, unsigned long opts);
 
 /**
  * @brief Get the flags of a disk's current mount options
@@ -448,7 +436,7 @@ EAPI Eina_Bool      eeze_disk_mountopts_set(Eeze_Disk *disk, unsigned long opts)
  * This function returns the current mount opts of a disk.
  * @since 1.1
  */
-EAPI unsigned long  eeze_disk_mountopts_get(Eeze_Disk *disk);
+EEZE_API unsigned long  eeze_disk_mountopts_get(Eeze_Disk *disk);
 
 
 /**
@@ -462,7 +450,7 @@ EAPI unsigned long  eeze_disk_mountopts_get(Eeze_Disk *disk);
  * @see eeze_mount_mtab_scan, eeze_mount_fstab_scan
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_mount_tabs_watch(void);
+EEZE_API Eina_Bool      eeze_mount_tabs_watch(void);
 
 /**
  * @brief Stop watching /etc/fstab and /etc/mtab
@@ -470,7 +458,7 @@ EAPI Eina_Bool      eeze_mount_tabs_watch(void);
  * This function stops watching fstab and mtab.  Data obtained previously will be saved.
  * @since 1.1
  */
-EAPI void           eeze_mount_tabs_unwatch(void);
+EEZE_API void           eeze_mount_tabs_unwatch(void);
 
 /**
  * @brief Scan /etc/mtab a single time
@@ -485,7 +473,7 @@ EAPI void           eeze_mount_tabs_unwatch(void);
  * @see eeze_mount_tabs_watch, eeze_mount_fstab_scan
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_mount_mtab_scan(void);
+EEZE_API Eina_Bool      eeze_mount_mtab_scan(void);
 
 /**
  * @brief Scan /etc/fstab a single time
@@ -500,7 +488,7 @@ EAPI Eina_Bool      eeze_mount_mtab_scan(void);
  * @see eeze_mount_tabs_watch, eeze_mount_mtab_scan
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_mount_fstab_scan(void);
+EEZE_API Eina_Bool      eeze_mount_fstab_scan(void);
 
 /**
  * @brief Get the property value of a disk
@@ -511,7 +499,7 @@ EAPI Eina_Bool      eeze_mount_fstab_scan(void);
  * @since 1.1
  */
 
-EAPI const char    *eeze_disk_udev_get_property(Eeze_Disk *disk, const char *property);
+EEZE_API const char    *eeze_disk_udev_get_property(Eeze_Disk *disk, const char *property);
 
 /**
  * @brief Get the sysattr value of a disk.
@@ -522,7 +510,7 @@ EAPI const char    *eeze_disk_udev_get_property(Eeze_Disk *disk, const char *pro
  * @since 1.1
  */
 
-EAPI const char    *eeze_disk_udev_get_sysattr(Eeze_Disk *disk, const char *sysattr);
+EEZE_API const char    *eeze_disk_udev_get_sysattr(Eeze_Disk *disk, const char *sysattr);
 
 /**
  * Find the root device of a disk.
@@ -533,7 +521,7 @@ EAPI const char    *eeze_disk_udev_get_sysattr(Eeze_Disk *disk, const char *sysa
  * Return a stringshared syspath (/sys/$syspath) for the parent device.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_udev_get_parent(Eeze_Disk *disk);
+EEZE_API const char    *eeze_disk_udev_get_parent(Eeze_Disk *disk);
 
 /**
  * Walks up the device chain using the device from @p disk,
@@ -547,7 +535,7 @@ EAPI const char    *eeze_disk_udev_get_parent(Eeze_Disk *disk);
  * @c EINA_FALSE otherwise.
  * @since 1.1
  */
-EAPI Eina_Bool      eeze_disk_udev_walk_check_sysattr(Eeze_Disk *disk, const char *sysattr, const char *value);
+EEZE_API Eina_Bool      eeze_disk_udev_walk_check_sysattr(Eeze_Disk *disk, const char *sysattr, const char *value);
 
 /**
  * @brief Walks up the device chain of @p disk
@@ -559,7 +547,7 @@ EAPI Eina_Bool      eeze_disk_udev_walk_check_sysattr(Eeze_Disk *disk, const cha
  * @return The stringshared value of @p sysattr if found, or @c NULL.
  * @since 1.1
  */
-EAPI const char    *eeze_disk_udev_walk_get_sysattr(Eeze_Disk *disk, const char *sysattr);
+EEZE_API const char    *eeze_disk_udev_walk_get_sysattr(Eeze_Disk *disk, const char *sysattr);
 
 #ifdef __cplusplus
 }

--- a/src/lib/eeze/Eeze_Net.h
+++ b/src/lib/eeze/Eeze_Net.h
@@ -4,19 +4,7 @@
 #include <Eina.h>
 #include <Ecore.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef __GNUC__
-# if __GNUC__ >= 4
-#  define EAPI __attribute__ ((visibility("default")))
-# else
-#  define EAPI
-# endif
-#else
-# define EAPI
-#endif
+#include <eeze_api.h>
 
 /**
  * @file Eeze_Net.h
@@ -47,22 +35,19 @@ typedef enum
 extern "C" {
 #endif
 
-EAPI Eeze_Net   *eeze_net_new(const char *name);
-EAPI void        eeze_net_free(Eeze_Net *net);
-EAPI const char *eeze_net_mac_get(Eeze_Net *net);
-EAPI int         eeze_net_idx_get(Eeze_Net *net);
-EAPI Eina_Bool   eeze_net_scan(Eeze_Net *net);
-EAPI const char *eeze_net_addr_get(Eeze_Net *net, Eeze_Net_Addr_Type type);
-EAPI const char *eeze_net_attribute_get(Eeze_Net *net, const char *attr);
-EAPI const char *eeze_net_syspath_get(Eeze_Net *net);
-EAPI Eina_List  *eeze_net_list(void);
+EEZE_API Eeze_Net   *eeze_net_new(const char *name);
+EEZE_API void        eeze_net_free(Eeze_Net *net);
+EEZE_API const char *eeze_net_mac_get(Eeze_Net *net);
+EEZE_API int         eeze_net_idx_get(Eeze_Net *net);
+EEZE_API Eina_Bool   eeze_net_scan(Eeze_Net *net);
+EEZE_API const char *eeze_net_addr_get(Eeze_Net *net, Eeze_Net_Addr_Type type);
+EEZE_API const char *eeze_net_attribute_get(Eeze_Net *net, const char *attr);
+EEZE_API const char *eeze_net_syspath_get(Eeze_Net *net);
+EEZE_API Eina_List  *eeze_net_list(void);
 
 #ifdef __cplusplus
 }
 #endif
 /** @} */
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/eeze/Eeze_Sensor.h
+++ b/src/lib/eeze/Eeze_Sensor.h
@@ -1,21 +1,9 @@
 #ifndef EEZE_SENSOR_H
 #define EEZE_SENSOR_H
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef __GNUC__
-# if __GNUC__ >= 4
-#  define EAPI __attribute__ ((visibility("default")))
-# else
-#  define EAPI
-# endif
-#else
-# define EAPI
-#endif
-
 #include <Eina.h>
+
+#include <eeze_api.h>
 
 /**
  * @file Eeze_Sensor.h
@@ -103,27 +91,27 @@ typedef enum
  * @since 1.8
  * @{
  */
-EAPI extern int EEZE_SENSOR_EVENT_ACCELEROMETER;
-EAPI extern int EEZE_SENSOR_EVENT_GRAVITY;
-EAPI extern int EEZE_SENSOR_EVENT_LINEAR_ACCELERATION;
-EAPI extern int EEZE_SENSOR_EVENT_DEVICE_ORIENTATION;
-EAPI extern int EEZE_SENSOR_EVENT_MAGNETIC;
-EAPI extern int EEZE_SENSOR_EVENT_ORIENTATION;
-EAPI extern int EEZE_SENSOR_EVENT_GYROSCOPE;
-EAPI extern int EEZE_SENSOR_EVENT_LIGHT;
-EAPI extern int EEZE_SENSOR_EVENT_PROXIMITY;
-EAPI extern int EEZE_SENSOR_EVENT_SNAP;
-EAPI extern int EEZE_SENSOR_EVENT_SHAKE;
-EAPI extern int EEZE_SENSOR_EVENT_DOUBLETAP;
-EAPI extern int EEZE_SENSOR_EVENT_PANNING;
-EAPI extern int EEZE_SENSOR_EVENT_PANNING_BROWSE;
-EAPI extern int EEZE_SENSOR_EVENT_TILT;
-EAPI extern int EEZE_SENSOR_EVENT_FACEDOWN;
-EAPI extern int EEZE_SENSOR_EVENT_DIRECT_CALL;
-EAPI extern int EEZE_SENSOR_EVENT_SMART_ALERT;
-EAPI extern int EEZE_SENSOR_EVENT_NO_MOVE;
-EAPI extern int EEZE_SENSOR_EVENT_BAROMETER;
-EAPI extern int EEZE_SENSOR_EVENT_TEMPERATURE;
+EEZE_API extern int EEZE_SENSOR_EVENT_ACCELEROMETER;
+EEZE_API extern int EEZE_SENSOR_EVENT_GRAVITY;
+EEZE_API extern int EEZE_SENSOR_EVENT_LINEAR_ACCELERATION;
+EEZE_API extern int EEZE_SENSOR_EVENT_DEVICE_ORIENTATION;
+EEZE_API extern int EEZE_SENSOR_EVENT_MAGNETIC;
+EEZE_API extern int EEZE_SENSOR_EVENT_ORIENTATION;
+EEZE_API extern int EEZE_SENSOR_EVENT_GYROSCOPE;
+EEZE_API extern int EEZE_SENSOR_EVENT_LIGHT;
+EEZE_API extern int EEZE_SENSOR_EVENT_PROXIMITY;
+EEZE_API extern int EEZE_SENSOR_EVENT_SNAP;
+EEZE_API extern int EEZE_SENSOR_EVENT_SHAKE;
+EEZE_API extern int EEZE_SENSOR_EVENT_DOUBLETAP;
+EEZE_API extern int EEZE_SENSOR_EVENT_PANNING;
+EEZE_API extern int EEZE_SENSOR_EVENT_PANNING_BROWSE;
+EEZE_API extern int EEZE_SENSOR_EVENT_TILT;
+EEZE_API extern int EEZE_SENSOR_EVENT_FACEDOWN;
+EEZE_API extern int EEZE_SENSOR_EVENT_DIRECT_CALL;
+EEZE_API extern int EEZE_SENSOR_EVENT_SMART_ALERT;
+EEZE_API extern int EEZE_SENSOR_EVENT_NO_MOVE;
+EEZE_API extern int EEZE_SENSOR_EVENT_BAROMETER;
+EEZE_API extern int EEZE_SENSOR_EVENT_TEMPERATURE;
 /**@}*/
 
 /**
@@ -175,7 +163,7 @@ extern "C" {
  *
  * @since 1.8
  */
-EAPI Eeze_Sensor_Obj *eeze_sensor_new(Eeze_Sensor_Type type);
+EEZE_API Eeze_Sensor_Obj *eeze_sensor_new(Eeze_Sensor_Type type);
 
 /**
  * @brief Free a sensor object.
@@ -186,7 +174,7 @@ EAPI Eeze_Sensor_Obj *eeze_sensor_new(Eeze_Sensor_Type type);
  *
  * @since 1.8
  */
-EAPI void eeze_sensor_free(Eeze_Sensor_Obj *sens);
+EEZE_API void eeze_sensor_free(Eeze_Sensor_Obj *sens);
 
 /**
  * @brief Get accuracy from sensor object.
@@ -204,7 +192,7 @@ EAPI void eeze_sensor_free(Eeze_Sensor_Obj *sens);
  *
  * @since 1.8
  */
-EAPI Eina_Bool eeze_sensor_accuracy_get(Eeze_Sensor_Obj *sens, int *accuracy);
+EEZE_API Eina_Bool eeze_sensor_accuracy_get(Eeze_Sensor_Obj *sens, int *accuracy);
 
 /**
  * @brief Get data from all three data properties
@@ -220,7 +208,7 @@ EAPI Eina_Bool eeze_sensor_accuracy_get(Eeze_Sensor_Obj *sens, int *accuracy);
  *
  * @since 1.8
  */
-EAPI Eina_Bool eeze_sensor_xyz_get(Eeze_Sensor_Obj *sens, float *x, float *y, float *z);
+EEZE_API Eina_Bool eeze_sensor_xyz_get(Eeze_Sensor_Obj *sens, float *x, float *y, float *z);
 
 /**
  * @brief Get data from first two data properties
@@ -234,7 +222,7 @@ EAPI Eina_Bool eeze_sensor_xyz_get(Eeze_Sensor_Obj *sens, float *x, float *y, fl
  *
  * @since 1.8
  */
-EAPI Eina_Bool eeze_sensor_xy_get(Eeze_Sensor_Obj *sens, float *x, float *y);
+EEZE_API Eina_Bool eeze_sensor_xy_get(Eeze_Sensor_Obj *sens, float *x, float *y);
 
 /**
  * @brief Get the data from  first data property
@@ -247,7 +235,7 @@ EAPI Eina_Bool eeze_sensor_xy_get(Eeze_Sensor_Obj *sens, float *x, float *y);
  *
  * @since 1.8
  */
-EAPI Eina_Bool eeze_sensor_x_get(Eeze_Sensor_Obj *sens, float *x);
+EEZE_API Eina_Bool eeze_sensor_x_get(Eeze_Sensor_Obj *sens, float *x);
 
 /**
  * @brief Get timestamp from sensor object.
@@ -261,7 +249,7 @@ EAPI Eina_Bool eeze_sensor_x_get(Eeze_Sensor_Obj *sens, float *x);
  *
  * @since 1.8
  */
-EAPI Eina_Bool eeze_sensor_timestamp_get(Eeze_Sensor_Obj *sens, double *timestamp);
+EEZE_API Eina_Bool eeze_sensor_timestamp_get(Eeze_Sensor_Obj *sens, double *timestamp);
 
 /**
  * @brief Read out sensor data
@@ -278,7 +266,7 @@ EAPI Eina_Bool eeze_sensor_timestamp_get(Eeze_Sensor_Obj *sens, double *timestam
  *
  * @since 1.8
  */
-EAPI Eina_Bool eeze_sensor_read(Eeze_Sensor_Obj *sens);
+EEZE_API Eina_Bool eeze_sensor_read(Eeze_Sensor_Obj *sens);
 
 /**
  * @brief Asynchronous read out sensor data
@@ -303,7 +291,7 @@ EAPI Eina_Bool eeze_sensor_read(Eeze_Sensor_Obj *sens);
  *
  * @since 1.8
  */
-EAPI Eina_Bool       eeze_sensor_async_read(Eeze_Sensor_Obj *sens, void *user_data);
+EEZE_API Eina_Bool       eeze_sensor_async_read(Eeze_Sensor_Obj *sens, void *user_data);
 
 #ifdef __cplusplus
 }

--- a/src/lib/eeze/eeze_api.h
+++ b/src/lib/eeze/eeze_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_EEZE_API_H
+#define _EFL_EEZE_API_H
+
+#ifdef EEZE_API
+#error EEZE_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_STATIC
+#  ifdef EEZE_BUILD
+#   define EEZE_API __declspec(dllexport)
+#  else
+#   define EEZE_API __declspec(dllimport)
+#  endif
+# else
+#  define EEZE_API
+# endif
+# define EEZE_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define EEZE_API __attribute__ ((visibility("default")))
+#   define EEZE_API_WEAK __attribute__ ((weak))
+#  else
+#   define EEZE_API
+#   define EEZE_API_WEAK
+#  endif
+# else
+#  define EEZE_API
+#  define EEZE_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/eeze/eeze_api.h
+++ b/src/lib/eeze/eeze_api.h
@@ -6,7 +6,7 @@
 #endif
 
 #ifdef _WIN32
-# ifndef EFL_STATIC
+# ifndef EEZE_STATIC
 #  ifdef EEZE_BUILD
 #   define EEZE_API __declspec(dllexport)
 #  else

--- a/src/lib/eeze/eeze_disk.c
+++ b/src/lib/eeze/eeze_disk.c
@@ -143,12 +143,12 @@ disk_fail:
    return EINA_FALSE;
 }
 
-EAPI void
+EEZE_API void
 eeze_disk_function(void)
 {
 }
 
-EAPI Eeze_Disk *
+EEZE_API Eeze_Disk *
 eeze_disk_new(const char *path)
 {
    Eeze_Disk *disk;
@@ -198,7 +198,7 @@ eeze_disk_new(const char *path)
    return disk;
 }
 
-EAPI Eeze_Disk *
+EEZE_API Eeze_Disk *
 eeze_disk_new_from_mount(const char *mount_point)
 {
    Eeze_Disk *disk = NULL;
@@ -266,7 +266,7 @@ error:
    return NULL;
 }
 
-EAPI void
+EEZE_API void
 eeze_disk_free(Eeze_Disk *disk)
 {
    extern Eina_List *eeze_events;
@@ -285,7 +285,7 @@ eeze_disk_free(Eeze_Disk *disk)
    free(disk);
 }
 
-EAPI void
+EEZE_API void
 eeze_disk_scan(Eeze_Disk *disk)
 {
    const char *test;
@@ -322,7 +322,7 @@ eeze_disk_scan(Eeze_Disk *disk)
    disk->cache.filled = EINA_TRUE;
 }
 
-EAPI void
+EEZE_API void
 eeze_disk_data_set(Eeze_Disk *disk, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(disk);
@@ -330,7 +330,7 @@ eeze_disk_data_set(Eeze_Disk *disk, void *data)
    disk->data = data;
 }
 
-EAPI void *
+EEZE_API void *
 eeze_disk_data_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -338,7 +338,7 @@ eeze_disk_data_get(Eeze_Disk *disk)
    return disk->data;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_syspath_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -346,7 +346,7 @@ eeze_disk_syspath_get(Eeze_Disk *disk)
    return disk->syspath;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_devpath_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -357,7 +357,7 @@ eeze_disk_devpath_get(Eeze_Disk *disk)
    return disk->devpath;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_fstype_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -365,7 +365,7 @@ eeze_disk_fstype_get(Eeze_Disk *disk)
    return disk->fstype;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_vendor_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -378,7 +378,7 @@ eeze_disk_vendor_get(Eeze_Disk *disk)
    return disk->cache.vendor;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_model_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -391,7 +391,7 @@ eeze_disk_model_get(Eeze_Disk *disk)
    return disk->cache.model;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_serial_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -402,7 +402,7 @@ eeze_disk_serial_get(Eeze_Disk *disk)
    return disk->cache.serial;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_uuid_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -413,7 +413,7 @@ eeze_disk_uuid_get(Eeze_Disk *disk)
    return disk->cache.uuid;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_label_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
@@ -424,7 +424,7 @@ eeze_disk_label_get(Eeze_Disk *disk)
    return disk->cache.label;
 }
 
-EAPI Eeze_Disk_Type
+EEZE_API Eeze_Disk_Type
 eeze_disk_type_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, EEZE_DISK_TYPE_UNKNOWN);
@@ -435,7 +435,7 @@ eeze_disk_type_get(Eeze_Disk *disk)
    return disk->cache.type;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_removable_get(Eeze_Disk *disk)
 {
    const char *test;
@@ -456,7 +456,7 @@ eeze_disk_removable_get(Eeze_Disk *disk)
    return disk->cache.removable;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_can_mount(void)
 {
    if (sizeof(EEZE_MOUNT_BIN) == sizeof(""))
@@ -464,7 +464,7 @@ eeze_disk_can_mount(void)
    return access(EEZE_MOUNT_BIN, X_OK | R_OK) == 0;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_can_unmount(void)
 {
    if (sizeof(EEZE_UNMOUNT_BIN) == sizeof(""))
@@ -472,7 +472,7 @@ eeze_disk_can_unmount(void)
    return access(EEZE_UNMOUNT_BIN, X_OK | R_OK) == 0;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_can_eject(void)
 {
    if (sizeof(EEZE_EJECT_BIN) == sizeof(""))

--- a/src/lib/eeze/eeze_disk_dummy.c
+++ b/src/lib/eeze/eeze_disk_dummy.c
@@ -55,25 +55,25 @@ eeze_disk_libmount_mp_lookup_by_devpath(const char *devpath EINA_UNUSED)
    return NULL;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_tabs_watch(void)
 {
    ERR("Dummy backend no watching code provided !");
    return EINA_FALSE;
 }
 
-EAPI void
+EEZE_API void
 eeze_mount_tabs_unwatch(void)
 {
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_mtab_scan(void)
 {
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_fstab_scan(void)
 {
    return EINA_FALSE;

--- a/src/lib/eeze/eeze_disk_libmount.c
+++ b/src/lib/eeze/eeze_disk_libmount.c
@@ -380,7 +380,7 @@ eeze_disk_libmount_mp_lookup_by_devpath(const char *devpath)
  *
  */
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_tabs_watch(void)
 {
    libmnt_table *bak;
@@ -427,7 +427,7 @@ error:
    return EINA_FALSE;
 }
 
-EAPI void
+EEZE_API void
 eeze_mount_tabs_unwatch(void)
 {
    if (!_watching)
@@ -440,7 +440,7 @@ eeze_mount_tabs_unwatch(void)
    _watching = EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_mtab_scan(void)
 {
    libmnt_table *bak;
@@ -469,7 +469,7 @@ error:
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_fstab_scan(void)
 {
    libmnt_table *bak;

--- a/src/lib/eeze/eeze_disk_libmount_new.c
+++ b/src/lib/eeze/eeze_disk_libmount_new.c
@@ -411,7 +411,7 @@ eeze_disk_libmount_mp_lookup_by_devpath(const char *devpath)
  *
  */
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_tabs_watch(void)
 {
    libmnt_table *bak;
@@ -461,7 +461,7 @@ error:
    return EINA_FALSE;
 }
 
-EAPI void
+EEZE_API void
 eeze_mount_tabs_unwatch(void)
 {
    if (!_watching)
@@ -475,7 +475,7 @@ eeze_mount_tabs_unwatch(void)
    _watching = EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_mtab_scan(void)
 {
    libmnt_table *bak;
@@ -501,7 +501,7 @@ error:
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_fstab_scan(void)
 {
    libmnt_table *bak;

--- a/src/lib/eeze/eeze_disk_libmount_old.c
+++ b/src/lib/eeze/eeze_disk_libmount_old.c
@@ -306,7 +306,7 @@ eeze_disk_libmount_mp_lookup_by_devpath(const char *devpath)
  * API
  *
  */
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_tabs_watch(void)
 {
    mnt_tab *bak;
@@ -347,7 +347,7 @@ error:
    return EINA_FALSE;
 }
 
-EAPI void
+EEZE_API void
 eeze_mount_tabs_unwatch(void)
 {
    if (!_watching)
@@ -357,7 +357,7 @@ eeze_mount_tabs_unwatch(void)
    ecore_file_monitor_del(_fstab_mon);
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_mtab_scan(void)
 {
    mnt_tab *bak;
@@ -380,7 +380,7 @@ error:
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_mount_fstab_scan(void)
 {
    mnt_tab *bak;

--- a/src/lib/eeze/eeze_disk_mount.c
+++ b/src/lib/eeze/eeze_disk_mount.c
@@ -16,10 +16,10 @@
 
 #define EEZE_MOUNT_DEFAULT_OPTS "noexec,nosuid,utf8"
 
-EAPI int EEZE_EVENT_DISK_MOUNT = 0;
-EAPI int EEZE_EVENT_DISK_UNMOUNT = 0;
-EAPI int EEZE_EVENT_DISK_EJECT = 0;
-EAPI int EEZE_EVENT_DISK_ERROR = 0;
+EEZE_API int EEZE_EVENT_DISK_MOUNT = 0;
+EEZE_API int EEZE_EVENT_DISK_UNMOUNT = 0;
+EEZE_API int EEZE_EVENT_DISK_EJECT = 0;
+EEZE_API int EEZE_EVENT_DISK_ERROR = 0;
 static Ecore_Event_Handler *_mount_handler = NULL;
 Eina_List *eeze_events = NULL;
 
@@ -201,7 +201,7 @@ eeze_mount_shutdown(void)
  *
  */
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_mounted_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, EINA_FALSE);
@@ -209,7 +209,7 @@ eeze_disk_mounted_get(Eeze_Disk *disk)
    return eeze_disk_libmount_mounted_get(disk);
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_mountopts_set(Eeze_Disk *disk, unsigned long opts)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, EINA_FALSE);
@@ -221,14 +221,14 @@ eeze_disk_mountopts_set(Eeze_Disk *disk, unsigned long opts)
    return EINA_TRUE;
 }
 
-EAPI unsigned long
+EEZE_API unsigned long
 eeze_disk_mountopts_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, 0);
    return disk->mount_opts;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_mount_wrapper_set(Eeze_Disk *disk, const char *wrapper)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, EINA_FALSE);
@@ -243,14 +243,14 @@ eeze_disk_mount_wrapper_set(Eeze_Disk *disk, const char *wrapper)
    return EINA_TRUE;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_mount_wrapper_get(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, NULL);
    return disk->mount_wrapper;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_mount(Eeze_Disk *disk)
 {
    struct stat st;
@@ -354,7 +354,7 @@ eeze_disk_mount(Eeze_Disk *disk)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_unmount(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, EINA_FALSE);
@@ -384,7 +384,7 @@ eeze_disk_unmount(Eeze_Disk *disk)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_eject(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, EINA_FALSE);
@@ -415,7 +415,7 @@ eeze_disk_eject(Eeze_Disk *disk)
    return EINA_TRUE;
 }
 
-EAPI void
+EEZE_API void
 eeze_disk_cancel(Eeze_Disk *disk)
 {
    EINA_SAFETY_ON_NULL_RETURN(disk);
@@ -425,7 +425,7 @@ eeze_disk_cancel(Eeze_Disk *disk)
    disk->mounter = NULL;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_mount_point_get(Eeze_Disk *disk)
 {
    const char *mp;
@@ -455,7 +455,7 @@ eeze_disk_mount_point_get(Eeze_Disk *disk)
    return NULL;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_mount_point_set(Eeze_Disk *disk, const char *mount_point)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(disk, EINA_FALSE);

--- a/src/lib/eeze/eeze_disk_udev.c
+++ b/src/lib/eeze/eeze_disk_udev.c
@@ -9,7 +9,7 @@
 #include "eeze_udev_private.h"
 #include "eeze_disk_private.h"
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_udev_get_property(Eeze_Disk *disk, const char *property)
 {
    const char *ret;
@@ -21,7 +21,7 @@ eeze_disk_udev_get_property(Eeze_Disk *disk, const char *property)
    return eina_stringshare_add(ret);
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_udev_get_sysattr(Eeze_Disk *disk, const char *sysattr)
 {
    const char *ret;
@@ -33,7 +33,7 @@ eeze_disk_udev_get_sysattr(Eeze_Disk *disk, const char *sysattr)
    return eina_stringshare_add(ret);
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_udev_get_parent(Eeze_Disk *disk)
 {
    _udev_device *parent;
@@ -43,7 +43,7 @@ eeze_disk_udev_get_parent(Eeze_Disk *disk)
    return eina_stringshare_add(udev_device_get_syspath(parent));
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_disk_udev_walk_check_sysattr(Eeze_Disk *disk,
                                   const char *sysattr,
                                   const char *value)
@@ -69,7 +69,7 @@ eeze_disk_udev_walk_check_sysattr(Eeze_Disk *disk,
    return EINA_FALSE;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_disk_udev_walk_get_sysattr(Eeze_Disk *disk,
                                   const char *sysattr)
 {

--- a/src/lib/eeze/eeze_main.c
+++ b/src/lib/eeze/eeze_main.c
@@ -19,9 +19,9 @@ int _eeze_sensor_log_dom = -1;
 int _eeze_init_count = 0;
 
 static Eeze_Version _version = { VMAJ, VMIN, VMIC, VREV };
-EAPI Eeze_Version *eeze_version = &_version;
+EEZE_API Eeze_Version *eeze_version = &_version;
 
-EAPI int
+EEZE_API int
 eeze_init(void)
 {
    if (++_eeze_init_count != 1)
@@ -98,7 +98,7 @@ eina_fail:
    return --_eeze_init_count;
 }
 
-EAPI int
+EEZE_API int
 eeze_shutdown(void)
 {
    if (_eeze_init_count <= 0)
@@ -126,7 +126,7 @@ eeze_shutdown(void)
    return _eeze_init_count;
 }
 
-EAPI void *
+EEZE_API void *
 eeze_udev_get(void)
 {
    return udev;

--- a/src/lib/eeze/eeze_sensor.c
+++ b/src/lib/eeze/eeze_sensor.c
@@ -11,27 +11,27 @@
 #include "eeze_sensor_private.h"
 #include "../../static_libs/buildsystem/buildsystem.h"
 
-EAPI int EEZE_SENSOR_EVENT_ACCELEROMETER;
-EAPI int EEZE_SENSOR_EVENT_GRAVITY;
-EAPI int EEZE_SENSOR_EVENT_LINEAR_ACCELERATION;
-EAPI int EEZE_SENSOR_EVENT_DEVICE_ORIENTATION;
-EAPI int EEZE_SENSOR_EVENT_MAGNETIC;
-EAPI int EEZE_SENSOR_EVENT_ORIENTATION;
-EAPI int EEZE_SENSOR_EVENT_GYROSCOPE;
-EAPI int EEZE_SENSOR_EVENT_LIGHT;
-EAPI int EEZE_SENSOR_EVENT_PROXIMITY;
-EAPI int EEZE_SENSOR_EVENT_SNAP;
-EAPI int EEZE_SENSOR_EVENT_SHAKE;
-EAPI int EEZE_SENSOR_EVENT_DOUBLETAP;
-EAPI int EEZE_SENSOR_EVENT_PANNING;
-EAPI int EEZE_SENSOR_EVENT_PANNING_BROWSE;
-EAPI int EEZE_SENSOR_EVENT_TILT;
-EAPI int EEZE_SENSOR_EVENT_FACEDOWN;
-EAPI int EEZE_SENSOR_EVENT_DIRECT_CALL;
-EAPI int EEZE_SENSOR_EVENT_SMART_ALERT;
-EAPI int EEZE_SENSOR_EVENT_NO_MOVE;
-EAPI int EEZE_SENSOR_EVENT_BAROMETER;
-EAPI int EEZE_SENSOR_EVENT_TEMPERATURE;
+EEZE_API int EEZE_SENSOR_EVENT_ACCELEROMETER;
+EEZE_API int EEZE_SENSOR_EVENT_GRAVITY;
+EEZE_API int EEZE_SENSOR_EVENT_LINEAR_ACCELERATION;
+EEZE_API int EEZE_SENSOR_EVENT_DEVICE_ORIENTATION;
+EEZE_API int EEZE_SENSOR_EVENT_MAGNETIC;
+EEZE_API int EEZE_SENSOR_EVENT_ORIENTATION;
+EEZE_API int EEZE_SENSOR_EVENT_GYROSCOPE;
+EEZE_API int EEZE_SENSOR_EVENT_LIGHT;
+EEZE_API int EEZE_SENSOR_EVENT_PROXIMITY;
+EEZE_API int EEZE_SENSOR_EVENT_SNAP;
+EEZE_API int EEZE_SENSOR_EVENT_SHAKE;
+EEZE_API int EEZE_SENSOR_EVENT_DOUBLETAP;
+EEZE_API int EEZE_SENSOR_EVENT_PANNING;
+EEZE_API int EEZE_SENSOR_EVENT_PANNING_BROWSE;
+EEZE_API int EEZE_SENSOR_EVENT_TILT;
+EEZE_API int EEZE_SENSOR_EVENT_FACEDOWN;
+EEZE_API int EEZE_SENSOR_EVENT_DIRECT_CALL;
+EEZE_API int EEZE_SENSOR_EVENT_SMART_ALERT;
+EEZE_API int EEZE_SENSOR_EVENT_NO_MOVE;
+EEZE_API int EEZE_SENSOR_EVENT_BAROMETER;
+EEZE_API int EEZE_SENSOR_EVENT_TEMPERATURE;
 
 static Eeze_Sensor *g_handle;
 static Eina_Prefix *pfx;
@@ -68,7 +68,7 @@ _highest_priority_module_get(void)
 /* Utility function to take the given sensor type and get the matching sensor
  * object from the highest priority module.
  */
-EAPI Eeze_Sensor_Obj *
+EEZE_API Eeze_Sensor_Obj *
 eeze_sensor_obj_get(Eeze_Sensor_Type sensor_type)
 {
    Eina_List *l;
@@ -154,7 +154,7 @@ eeze_sensor_modules_unload(void)
  * been loaded in initialized. They stay in the hash function until they
  * unregister themself.
  */
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_module_register(const char *name, Eeze_Sensor_Module *mod)
 {
    Eeze_Sensor_Module *module = NULL;
@@ -174,7 +174,7 @@ eeze_sensor_module_register(const char *name, Eeze_Sensor_Module *mod)
 /* This function is offered to the modules to unregsiter itself. When requested
  * we remove them safely from the hash.
  */
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_module_unregister(const char *name)
 {
    DBG("Unregister module %s", name);
@@ -197,7 +197,7 @@ eeze_sensor_module_unregister(const char *name)
  * Make sure to use the eeze_sensor_free function to remove this sensor object
  * when it is no longer needed.
  */
-EAPI Eeze_Sensor_Obj *
+EEZE_API Eeze_Sensor_Obj *
 eeze_sensor_new(Eeze_Sensor_Type type)
 {
    Eeze_Sensor_Obj *sens;
@@ -234,7 +234,7 @@ eeze_sensor_new(Eeze_Sensor_Type type)
 }
 
 /* Free sensor object created with eeze_sensor_new */
-EAPI void
+EEZE_API void
 eeze_sensor_free(Eeze_Sensor_Obj *sens)
 {
    if (!sens) return;
@@ -245,7 +245,7 @@ eeze_sensor_free(Eeze_Sensor_Obj *sens)
  * sensor read. It is way faster this way but also means that the timestamp
  * should be checked to ensure recent data if needed.
  */
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_accuracy_get(Eeze_Sensor_Obj *sens, int *accuracy)
 {
    if (!sens) return EINA_FALSE;
@@ -254,7 +254,7 @@ eeze_sensor_accuracy_get(Eeze_Sensor_Obj *sens, int *accuracy)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_xyz_get(Eeze_Sensor_Obj *sens, float *x, float *y, float *z)
 {
    if (!sens) return EINA_FALSE;
@@ -265,7 +265,7 @@ eeze_sensor_xyz_get(Eeze_Sensor_Obj *sens, float *x, float *y, float *z)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_xy_get(Eeze_Sensor_Obj *sens, float *x, float *y)
 {
    if (!sens) return EINA_FALSE;
@@ -275,7 +275,7 @@ eeze_sensor_xy_get(Eeze_Sensor_Obj *sens, float *x, float *y)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_x_get(Eeze_Sensor_Obj *sens, float *x)
 {
    if (!sens) return EINA_FALSE;
@@ -284,7 +284,7 @@ eeze_sensor_x_get(Eeze_Sensor_Obj *sens, float *x)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_timestamp_get(Eeze_Sensor_Obj *sens, double *timestamp)
 {
    if (!sens) return EINA_FALSE;
@@ -296,7 +296,7 @@ eeze_sensor_timestamp_get(Eeze_Sensor_Obj *sens, double *timestamp)
 /* Synchronous read. Blocked until the data was readout from the hardware
  * sensor
  */
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_read(Eeze_Sensor_Obj *sens)
 {
    Eeze_Sensor_Module *module = NULL;
@@ -315,7 +315,7 @@ eeze_sensor_read(Eeze_Sensor_Obj *sens)
 /* Asynchronous read. Schedule a new read out that will update the cached values
  * as soon as it arrives.
  */
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_sensor_async_read(Eeze_Sensor_Obj *sens, void *user_data)
 {
    Eeze_Sensor_Module *module = NULL;

--- a/src/lib/eeze/eeze_sensor_private.h
+++ b/src/lib/eeze/eeze_sensor_private.h
@@ -74,7 +74,7 @@ typedef struct _Eeze_Sensor_Module
  *
  * @since 1.8
  */
-EAPI Eina_Bool eeze_sensor_module_register(const char *name, Eeze_Sensor_Module *mod);
+EEZE_API Eina_Bool eeze_sensor_module_register(const char *name, Eeze_Sensor_Module *mod);
 
 /**
  * @brief Unregister a module from eeze_sensor core.
@@ -85,7 +85,7 @@ EAPI Eina_Bool eeze_sensor_module_register(const char *name, Eeze_Sensor_Module 
  *
  * @since 1.8
  */
-EAPI Eina_Bool eeze_sensor_module_unregister(const char *name);
+EEZE_API Eina_Bool eeze_sensor_module_unregister(const char *name);
 
 /**
  * @brief Fetch the sensor object by type from the sensor object list
@@ -94,7 +94,7 @@ EAPI Eina_Bool eeze_sensor_module_unregister(const char *name);
  *
  * @since 1.8
  */
-EAPI Eeze_Sensor_Obj    *eeze_sensor_obj_get(Eeze_Sensor_Type type);
+EEZE_API Eeze_Sensor_Obj    *eeze_sensor_obj_get(Eeze_Sensor_Type type);
 
 /**
  * @brief Initialize the Eeze sensor subsystem.

--- a/src/lib/eeze/eeze_udev_find.c
+++ b/src/lib/eeze/eeze_udev_find.c
@@ -10,7 +10,7 @@
 #include <Eeze.h>
 #include "eeze_udev_private.h"
 
-EAPI Eina_List *
+EEZE_API Eina_List *
 eeze_udev_find_similar_from_syspath(const char *syspath)
 {
    _udev_device *device;
@@ -75,7 +75,7 @@ eeze_udev_find_similar_from_syspath(const char *syspath)
    return ret;
 }
 
-EAPI Eina_List *
+EEZE_API Eina_List *
 eeze_udev_find_unlisted_similar(Eina_List *list)
 {
    _udev_device *device;
@@ -143,7 +143,7 @@ eeze_udev_find_unlisted_similar(Eina_List *list)
    return list;
 }
 
-EAPI Eina_List *
+EEZE_API Eina_List *
 eeze_udev_find_by_type(Eeze_Udev_Type etype,
                        const char    *name)
 {
@@ -321,7 +321,7 @@ out:
    return ret;
 }
 
-EAPI Eina_List *
+EEZE_API Eina_List *
 eeze_udev_find_by_filter(const char *subsystem,
                          const char *type,
                          const char *name)
@@ -359,7 +359,7 @@ eeze_udev_find_by_filter(const char *subsystem,
    return ret;
 }
 
-EAPI Eina_List *
+EEZE_API Eina_List *
 eeze_udev_find_by_sysattr(const char *sysattr,
                           const char *value)
 {
@@ -388,7 +388,7 @@ eeze_udev_find_by_sysattr(const char *sysattr,
    return ret;
 }
 
-EAPI Eina_List *
+EEZE_API Eina_List *
 eeze_udev_find_by_subsystem_sysname(const char *subsystem, const char *sysname)
 {
    _udev_enumerate *en;

--- a/src/lib/eeze/eeze_udev_syspath.c
+++ b/src/lib/eeze/eeze_udev_syspath.c
@@ -5,7 +5,7 @@
 #include <Eeze.h>
 #include "eeze_udev_private.h"
 
-EAPI Eina_Stringshare *
+EEZE_API Eina_Stringshare *
 eeze_udev_syspath_get_parent_filtered(const char *syspath, const char *subsystem, const char *devtype)
 {
    _udev_device *device, *parent;
@@ -22,7 +22,7 @@ eeze_udev_syspath_get_parent_filtered(const char *syspath, const char *subsystem
    return ret;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_udev_syspath_get_parent(const char *syspath)
 {
    _udev_device *device, *parent;
@@ -39,7 +39,7 @@ eeze_udev_syspath_get_parent(const char *syspath)
    return ret;
 }
 
-EAPI Eina_List *
+EEZE_API Eina_List *
 eeze_udev_syspath_get_parents(const char *syspath)
 {
    _udev_device *child, *parent, *device;
@@ -65,7 +65,7 @@ eeze_udev_syspath_get_parents(const char *syspath)
    return devlist;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_udev_syspath_get_devpath(const char *syspath)
 {
    _udev_device *device;
@@ -85,7 +85,7 @@ eeze_udev_syspath_get_devpath(const char *syspath)
    return name;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_udev_syspath_get_devname(const char *syspath)
 {
    _udev_device *device;
@@ -105,7 +105,7 @@ eeze_udev_syspath_get_devname(const char *syspath)
    return name;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_udev_syspath_get_subsystem(const char *syspath)
 {
    _udev_device *device;
@@ -121,7 +121,7 @@ eeze_udev_syspath_get_subsystem(const char *syspath)
    return subsystem;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_udev_syspath_check_property(const char *syspath, const char *property, const char *value)
 {
    _udev_device *device;
@@ -140,7 +140,7 @@ eeze_udev_syspath_check_property(const char *syspath, const char *property, cons
    return ret;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_udev_syspath_get_property(const char *syspath,
                                const char *property)
 {
@@ -160,7 +160,7 @@ eeze_udev_syspath_get_property(const char *syspath,
    return value;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_udev_syspath_check_sysattr(const char *syspath, const char *sysattr, const char *value)
 {
    _udev_device *device;
@@ -180,7 +180,7 @@ eeze_udev_syspath_check_sysattr(const char *syspath, const char *sysattr, const 
    return ret;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_udev_syspath_get_sysattr(const char *syspath,
                               const char *sysattr)
 {
@@ -200,7 +200,7 @@ eeze_udev_syspath_get_sysattr(const char *syspath,
    return value;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_udev_syspath_set_sysattr(const char *syspath,
                               const char *sysattr,
                               double value)
@@ -230,7 +230,7 @@ eeze_udev_syspath_set_sysattr(const char *syspath,
   return ret;
 }
 
-EAPI Eina_List *
+EEZE_API Eina_List *
 eeze_udev_syspath_get_sysattr_list(const char *syspath)
 {
    _udev_device *device;
@@ -254,7 +254,7 @@ eeze_udev_syspath_get_sysattr_list(const char *syspath)
    return syslist;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_udev_syspath_is_mouse(const char *syspath)
 {
    _udev_device *device = NULL;
@@ -276,7 +276,7 @@ eeze_udev_syspath_is_mouse(const char *syspath)
    return mouse;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_udev_syspath_is_kbd(const char *syspath)
 {
    _udev_device *device = NULL;
@@ -298,7 +298,7 @@ eeze_udev_syspath_is_kbd(const char *syspath)
    return kbd;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_udev_syspath_is_touchpad(const char *syspath)
 {
    _udev_device *device = NULL;
@@ -320,7 +320,7 @@ eeze_udev_syspath_is_touchpad(const char *syspath)
    return touchpad;
 }
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_udev_syspath_is_joystick(const char *syspath)
 {
    _udev_device *device = NULL;
@@ -342,7 +342,7 @@ eeze_udev_syspath_is_joystick(const char *syspath)
    return joystick;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_udev_devpath_get_syspath(const char *devpath)
 {
    _udev_enumerate *en;
@@ -369,7 +369,7 @@ eeze_udev_devpath_get_syspath(const char *devpath)
    return ret;
 }
 
-EAPI int 
+EEZE_API int 
 eeze_udev_syspath_get_sysnum(const char *syspath)
 {
    _udev_device *device;

--- a/src/lib/eeze/eeze_udev_walk.c
+++ b/src/lib/eeze/eeze_udev_walk.c
@@ -5,7 +5,7 @@
 #include <Eeze.h>
 #include "eeze_udev_private.h"
 
-EAPI Eina_Bool
+EEZE_API Eina_Bool
 eeze_udev_walk_check_sysattr(const char *syspath,
                              const char *sysattr,
                              const char *value)
@@ -36,7 +36,7 @@ eeze_udev_walk_check_sysattr(const char *syspath,
    return ret;
 }
 
-EAPI const char *
+EEZE_API const char *
 eeze_udev_walk_get_sysattr(const char *syspath,
                            const char *sysattr)
 {

--- a/src/lib/eeze/eeze_udev_watch.c
+++ b/src/lib/eeze/eeze_udev_watch.c
@@ -376,7 +376,7 @@ _eeze_udev_watch_reset()
      }
 }
 
-EAPI Eeze_Udev_Watch *
+EEZE_API Eeze_Udev_Watch *
 eeze_udev_watch_add(Eeze_Udev_Type     type,
                     int                event,
                     Eeze_Udev_Watch_Cb cb,
@@ -402,7 +402,7 @@ error:
    return NULL;
 }
 
-EAPI void *
+EEZE_API void *
 eeze_udev_watch_del(Eeze_Udev_Watch *watch)
 {
    void *ret = NULL;

--- a/src/lib/eeze/meson.build
+++ b/src/lib/eeze/meson.build
@@ -91,7 +91,7 @@ eeze_lib = library('eeze',
     dependencies: eeze_deps + eeze_pub_deps + eeze_deps + eeze_ext_deps,
     include_directories : config_dir,
     install: true,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DEEZE_BUILD'],
     version : meson.project_version()
 )
 


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.