### PR TITLE
[efreet] Use EFREET_API instead of EAPI

### DIFF
--- a/src/lib/efreet/Efreet.h
+++ b/src/lib/efreet/Efreet.h
@@ -74,37 +74,7 @@
 #include <Eina.h>
 #include <Efl_Config.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef EFL_BUILD
-# define EFREET_DEPRECATED_API
-#else
-# define EFREET_DEPRECATED_API EINA_DEPRECATED
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <efreet_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -123,9 +93,9 @@ extern "C" {
         int micro; /** < micro (bugfix, internal improvements, no new features version) */
         int revision; /** < git revision (0 if a proper release or the git revision number Efreet is built from) */
      } Efreet_Version;
-   
-   EAPI extern Efreet_Version *efreet_version;
-   
+
+   EFREET_API extern Efreet_Version *efreet_version;
+
 #include "efreet_base.h"
 #include "efreet_ini.h"
 #include "efreet_icon.h"
@@ -138,7 +108,7 @@ extern "C" {
  * @return Value > @c 0 if the initialization was successful, @c 0 otherwise.
  * @brief Initializes the Efreet system
  */
-EAPI int efreet_init(void);
+EFREET_API int efreet_init(void);
 
 /**
  * @return The number of times the init function has been called minus the
@@ -146,32 +116,29 @@ EAPI int efreet_init(void);
  * @brief Shuts down Efreet if a balanced number of init/shutdown calls have
  * been made
  */
-EAPI int efreet_shutdown(void);
+EFREET_API int efreet_shutdown(void);
 
 /**
  * @brief Resets language dependent variables and resets language dependent
  * caches This must be called whenever the locale is changed.
  * @since 1.7
  */
-EAPI void efreet_lang_reset(void);
+EFREET_API void efreet_lang_reset(void);
 
 /**
  * @brief Disables connecting to efreet cache for this process.
  * @since 1.21
  */
-EAPI void efreet_cache_disable(void);
+EFREET_API void efreet_cache_disable(void);
 
 /**
  * @brief Enables connecting to efreet cache for this process.
  * @since 1.21
  */
-EAPI void efreet_cache_enable(void);
+EFREET_API void efreet_cache_enable(void);
 
 #include <Efreet_Mime.h>
 #include <Efreet_Trash.h>
-
-#undef EAPI
-#define EAPI
 
 #ifdef __cplusplus
 }

--- a/src/lib/efreet/Efreet_Mime.h
+++ b/src/lib/efreet/Efreet_Mime.h
@@ -16,6 +16,10 @@
 
 #include <efreet_api.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @return @c 1 on success or @c 0 on failure.
  * @brief Initializes the efreet mime settings

--- a/src/lib/efreet/Efreet_Mime.h
+++ b/src/lib/efreet/Efreet_Mime.h
@@ -14,42 +14,13 @@
  * @{
  */
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+#include <efreet_api.h>
 
 /**
  * @return @c 1 on success or @c 0 on failure.
  * @brief Initializes the efreet mime settings
  */
-EAPI int         efreet_mime_init(void);
+EFREET_API int         efreet_mime_init(void);
 
 /**
  * @return The number of times the init function has been called minus the
@@ -57,7 +28,7 @@ EAPI int         efreet_mime_init(void);
  * @brief Shuts down Efreet mime settings system if a balanced number of
  * init/shutdown calls have been made
  */
-EAPI int         efreet_mime_shutdown(void);
+EFREET_API int         efreet_mime_shutdown(void);
 
 /**
  * @param file The file to find the mime type
@@ -65,35 +36,35 @@ EAPI int         efreet_mime_shutdown(void);
  * @brief Retrieve the mime type of a file
  * @note The return value of this function is not guaranteed to be stringshared.
  */
-EAPI const char *efreet_mime_type_get(const char *file);
+EFREET_API const char *efreet_mime_type_get(const char *file);
 
 /**
  * @param file The file to check the mime type
  * @return Mime type as a string.
  * @brief Retrieve the mime type of a file using magic
  */
-EAPI const char *efreet_mime_magic_type_get(const char *file);
+EFREET_API const char *efreet_mime_magic_type_get(const char *file);
 
 /**
  * @param file The file to check the mime type
  * @return Mime type as a string.
  * @brief Retrieve the mime type of a file using globs
  */
-EAPI const char *efreet_mime_globs_type_get(const char *file);
+EFREET_API const char *efreet_mime_globs_type_get(const char *file);
 
 /**
  * @param file The file to check the mime type
  * @return Mime type as a string.
  * @brief Retrieve the special mime type of a file
  */
-EAPI const char *efreet_mime_special_type_get(const char *file);
+EFREET_API const char *efreet_mime_special_type_get(const char *file);
 
 /**
  * @param file The file to check the mime type
  * @return Mime type as a string.
  * @brief Retrieve the fallback mime type of a file.
  */
-EAPI const char *efreet_mime_fallback_type_get(const char *file);
+EFREET_API const char *efreet_mime_fallback_type_get(const char *file);
 
 
 /**
@@ -103,13 +74,13 @@ EAPI const char *efreet_mime_fallback_type_get(const char *file);
  * @return Mime type icon path as a string.
  * @brief Retrieve the mime type icon for a file.
  */
-EAPI const char *efreet_mime_type_icon_get(const char *mime, const char *theme,
+EFREET_API const char *efreet_mime_type_icon_get(const char *mime, const char *theme,
                                            unsigned int size);
 
 /**
  * @brief Clear mime icons mapping cache
  */
-EAPI void efreet_mime_type_cache_clear(void);
+EFREET_API void efreet_mime_type_cache_clear(void);
 
 /**
  * @brief Flush mime icons mapping cache
@@ -117,7 +88,7 @@ EAPI void efreet_mime_type_cache_clear(void);
  * Flush timeout is defined at compile time by
  * EFREET_MIME_ICONS_FLUSH_TIMEOUT
  */
-EAPI void efreet_mime_type_cache_flush(void);
+EFREET_API void efreet_mime_type_cache_flush(void);
 
 /**
  * @}
@@ -126,8 +97,5 @@ EAPI void efreet_mime_type_cache_flush(void);
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/efreet/Efreet_Mime.h
+++ b/src/lib/efreet/Efreet_Mime.h
@@ -20,6 +20,7 @@
 extern "C" {
 #endif
 
+
 /**
  * @return @c 1 on success or @c 0 on failure.
  * @brief Initializes the efreet mime settings

--- a/src/lib/efreet/Efreet_Trash.h
+++ b/src/lib/efreet/Efreet_Trash.h
@@ -1,31 +1,7 @@
 #ifndef EFREET_TRASH_H
 #define EFREET_TRASH_H
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <efreet_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,20 +22,20 @@ extern "C" {
  * @return @c 1 on success or @c 0 on failure.
  * @brief Initializes the efreet trash system
  */
-EAPI int         efreet_trash_init(void);
+EFREET_API int         efreet_trash_init(void);
 
 /**
  * @return No value.
  * @brief Cleans up the efreet trash system
  */
-EAPI int         efreet_trash_shutdown(void);
+EFREET_API int         efreet_trash_shutdown(void);
 
 /**
  * @return The XDG Trash local directory or @c NULL on errors.
  * Return value must be freed with eina_stringshare_del.
  * @brief Retrieves the XDG Trash local directory
  */
-EAPI const char *efreet_trash_dir_get(const char *for_file);
+EFREET_API const char *efreet_trash_dir_get(const char *for_file);
 
 /**
  * @param uri The local uri to move in the trash
@@ -67,31 +43,31 @@ EAPI const char *efreet_trash_dir_get(const char *for_file);
  * will be deleted permanently
  * @return @c 1 on success, @c 0 on failure or @c -1 in case the uri is not on
  * the same filesystem and force_delete is not set.
- * @brief This function try to move the given uri to the trash. Files on 
+ * @brief This function try to move the given uri to the trash. Files on
  * different filesystem can't be moved to trash. If force_delete
  * is @c 0 than non-local files will be ignored and @c -1 is returned, if you set
  * force_delete to @c 1 non-local files will be deleted without asking.
  */
-EAPI int         efreet_trash_delete_uri(Efreet_Uri *uri, int force_delete);
+EFREET_API int         efreet_trash_delete_uri(Efreet_Uri *uri, int force_delete);
 
 /**
  * @return A list of strings with filename (remember to free the list
  * when you don't need anymore).
  * @brief List all the files and directory currently inside the trash.
  */
-EAPI Eina_List  *efreet_trash_ls(void);
+EFREET_API Eina_List  *efreet_trash_ls(void);
 
 /**
  * @return @c 1 if the trash is empty or @c 0 if some file are in.
  * @brief Check if the trash is currently empty
  */
-EAPI int         efreet_trash_is_empty(void);
+EFREET_API int         efreet_trash_is_empty(void);
 
 /**
  * @return @c 1 on success or @c 0 on failure.
  * @brief Delete all the files inside the trash.
  */
-EAPI int         efreet_trash_empty_trash(void);
+EFREET_API int         efreet_trash_empty_trash(void);
 
 /**
  * @}
@@ -100,8 +76,5 @@ EAPI int         efreet_trash_empty_trash(void);
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/efreet/efreet.c
+++ b/src/lib/efreet/efreet.c
@@ -18,9 +18,9 @@
 #include "efreet_xml.h"
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI int efreet_cache_update = 1;
+EFREET_API int efreet_cache_update = 1;
 
 static int _efreet_init_count = 0;
 static int efreet_parsed_locale = 0;
@@ -36,7 +36,7 @@ static uid_t ruid;
 static uid_t rgid;
 #endif
 
-EAPI int
+EFREET_API int
 efreet_init(void)
 {
 #ifndef _WIN32
@@ -137,7 +137,7 @@ shutdown_eina:
    return --_efreet_init_count;
 }
 
-EAPI int
+EFREET_API int
 efreet_shutdown(void)
 {
    if (_efreet_init_count <= 0)
@@ -173,7 +173,7 @@ efreet_shutdown(void)
    return _efreet_init_count;
 }
 
-EAPI void
+EFREET_API void
 efreet_lang_reset(void)
 {
    IF_RELEASE(efreet_lang);
@@ -231,7 +231,7 @@ efreet_lang_modifier_get(void)
    return efreet_lang_modifier;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_language_get(void)
 {
    if (efreet_parsed_locale) return efreet_language;
@@ -372,7 +372,7 @@ efreet_array_cat(char *buffer, size_t size, const char *strs[])
 }
 
 #ifndef _WIN32
-EAPI void
+EFREET_API void
 efreet_fsetowner(int fd)
 {
    struct stat st;
@@ -384,14 +384,14 @@ efreet_fsetowner(int fd)
    if (fchown(fd, ruid, rgid) != 0) return;
 }
 #else
-EAPI void
+EFREET_API void
 efreet_fsetowner(int fd EINA_UNUSED)
 {
 }
 #endif
 
 #ifndef _WIN32
-EAPI void
+EFREET_API void
 efreet_setowner(const char *path)
 {
    EINA_SAFETY_ON_NULL_RETURN(path);
@@ -404,7 +404,7 @@ efreet_setowner(const char *path)
    close(fd);
 }
 #else
-EAPI void
+EFREET_API void
 efreet_setowner(const char *path EINA_UNUSED)
 {
 }

--- a/src/lib/efreet/efreet_api.h
+++ b/src/lib/efreet/efreet_api.h
@@ -1,0 +1,40 @@
+#ifndef _EFL_EFREET_API_H
+#define _EFL_EFREET_API_H
+
+#ifdef EFREET_API
+#error EFREET_API should not be already defined
+#endif
+
+#ifdef EFL_BUILD
+# define EFREET_DEPRECATED_API
+#else
+# define EFREET_DEPRECATED_API EINA_DEPRECATED
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_STATIC
+#  ifdef EFREET_BUILD
+#   define EFREET_API __declspec(dllexport)
+#  else
+#   define EFREET_API __declspec(dllimport)
+#  endif
+# else
+#  define EFREET_API
+# endif
+# define EFREET_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define EFREET_API __attribute__ ((visibility("default")))
+#   define EFREET_API_WEAK __attribute__ ((weak))
+#  else
+#   define EFREET_API
+#   define EFREET_API_WEAK
+#  endif
+# else
+#  define EFREET_API
+#  define EFREET_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/efreet/efreet_api.h
+++ b/src/lib/efreet/efreet_api.h
@@ -12,7 +12,7 @@
 #endif
 
 #ifdef _WIN32
-# ifndef EFL_STATIC
+# ifndef EFREET_STATIC
 #  ifdef EFREET_BUILD
 #   define EFREET_API __declspec(dllexport)
 #  else

--- a/src/lib/efreet/efreet_base.c
+++ b/src/lib/efreet/efreet_base.c
@@ -26,7 +26,7 @@ static int _efreet_base_log_dom = -1;
 #include "efreet_private.h"
 
 static Efreet_Version _version = { VMAJ, VMIN, VMIC, VREV };
-EAPI Efreet_Version *efreet_version = &_version;
+EFREET_API Efreet_Version *efreet_version = &_version;
 
 #ifdef _WIN32
 # define EFREET_PATH_SEP ';'
@@ -120,7 +120,7 @@ efreet_home_dir_get(void)
     return efreet_home_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_desktop_dir_get(void)
 {
     if (xdg_desktop_dir) return xdg_desktop_dir;
@@ -128,7 +128,7 @@ efreet_desktop_dir_get(void)
     return xdg_desktop_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_download_dir_get(void)
 {
     if (xdg_download_dir) return xdg_download_dir;
@@ -136,7 +136,7 @@ efreet_download_dir_get(void)
     return xdg_download_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_templates_dir_get(void)
 {
     if (xdg_templates_dir) return xdg_templates_dir;
@@ -145,7 +145,7 @@ efreet_templates_dir_get(void)
     return xdg_templates_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_public_share_dir_get(void)
 {
     if (xdg_publicshare_dir) return xdg_publicshare_dir;
@@ -154,7 +154,7 @@ efreet_public_share_dir_get(void)
     return xdg_publicshare_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_documents_dir_get(void)
 {
     if (xdg_documents_dir) return xdg_documents_dir;
@@ -163,7 +163,7 @@ efreet_documents_dir_get(void)
     return xdg_documents_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_music_dir_get(void)
 {
     if (xdg_music_dir) return xdg_music_dir;
@@ -171,7 +171,7 @@ efreet_music_dir_get(void)
     return xdg_music_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_pictures_dir_get(void)
 {
     if (xdg_pictures_dir) return xdg_pictures_dir;
@@ -179,7 +179,7 @@ efreet_pictures_dir_get(void)
     return xdg_pictures_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_videos_dir_get(void)
 {
     if (xdg_videos_dir) return xdg_videos_dir;
@@ -187,43 +187,43 @@ efreet_videos_dir_get(void)
     return xdg_videos_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_data_home_get(void)
 {
     return xdg_data_home;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_data_dirs_get(void)
 {
     return xdg_data_dirs;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_config_home_get(void)
 {
     return xdg_config_home;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_config_dirs_get(void)
 {
     return xdg_config_dirs;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_cache_home_get(void)
 {
     return xdg_cache_home;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_runtime_dir_get(void)
 {
     return xdg_runtime_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_hostname_get(void)
 {
     return hostname;
@@ -238,9 +238,9 @@ efreet_hostname_get(void)
  * @brief Creates the list of directories based on the user
  * dir, system dirs and given suffix.
  *
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_default_dirs_get(const char *user_dir, Eina_List *system_dirs,
                                                     const char *suffix)
 {

--- a/src/lib/efreet/efreet_base.h
+++ b/src/lib/efreet/efreet_base.h
@@ -22,7 +22,7 @@
  * This is where user-specific data files should be written
  * ($XDG_DATA_HOME or $HOME/.local/share).
  */
-EAPI const char *efreet_data_home_get(void);
+EFREET_API const char *efreet_data_home_get(void);
 
 /**
  * @return Returns the Eina_List of preference ordered extra data directories
@@ -35,7 +35,7 @@ EAPI const char *efreet_data_home_get(void);
  * list then the next call to efreet_data_dirs_get() will return your
  * modified values. DO NOT free this list.
  */
-EAPI Eina_List *efreet_data_dirs_get(void);
+EFREET_API Eina_List *efreet_data_dirs_get(void);
 
 
 /**
@@ -45,7 +45,7 @@ EAPI Eina_List *efreet_data_dirs_get(void);
  * This is where user-specific configuration files should be
  * written ($XDG_CONFIG_HOME or $HOME/.config).
  */
-EAPI const char *efreet_config_home_get(void);
+EFREET_API const char *efreet_config_home_get(void);
 
 /**
  * @return Returns the XDG Desktop directory
@@ -57,7 +57,7 @@ EAPI const char *efreet_config_home_get(void);
  *
  * @since 1.3
  */
-EAPI const char *efreet_desktop_dir_get(void);
+EFREET_API const char *efreet_desktop_dir_get(void);
 
 /**
  * @return Returns the XDG Download directory
@@ -77,7 +77,7 @@ EAPI const char *efreet_desktop_dir_get(void);
  *
  * @since 1.8
  */
-EAPI const char *efreet_download_dir_get(void);
+EFREET_API const char *efreet_download_dir_get(void);
 
 /**
  * @return Returns the XDG Templates directory
@@ -94,7 +94,7 @@ EAPI const char *efreet_download_dir_get(void);
  *
  * @since 1.8
  */
-EAPI const char *efreet_templates_dir_get(void);
+EFREET_API const char *efreet_templates_dir_get(void);
 
 /**
  * @return Returns the XDG Public Share directory
@@ -108,7 +108,7 @@ EAPI const char *efreet_templates_dir_get(void);
  *
  * @since 1.8
  */
-EAPI const char *efreet_public_share_dir_get(void);
+EFREET_API const char *efreet_public_share_dir_get(void);
 
 /**
  * @return Returns the XDG Documents directory
@@ -125,7 +125,7 @@ EAPI const char *efreet_public_share_dir_get(void);
  *
  * @since 1.8
  */
-EAPI const char *efreet_documents_dir_get(void);
+EFREET_API const char *efreet_documents_dir_get(void);
 
 /**
  * @return Returns the XDG Music directory
@@ -142,7 +142,7 @@ EAPI const char *efreet_documents_dir_get(void);
  *
  * @since 1.8
  */
-EAPI const char *efreet_music_dir_get(void);
+EFREET_API const char *efreet_music_dir_get(void);
 
 /**
  * @return Returns the XDG Pictures directory
@@ -159,7 +159,7 @@ EAPI const char *efreet_music_dir_get(void);
  *
  * @since 1.8
  */
-EAPI const char *efreet_pictures_dir_get(void);
+EFREET_API const char *efreet_pictures_dir_get(void);
 
 /**
  * @return Returns the XDG Videos directory
@@ -176,7 +176,7 @@ EAPI const char *efreet_pictures_dir_get(void);
  *
  * @since 1.8
  */
-EAPI const char *efreet_videos_dir_get(void);
+EFREET_API const char *efreet_videos_dir_get(void);
 
 /**
  * @return Returns the Eina_List of preference ordered extra config directories
@@ -190,7 +190,7 @@ EAPI const char *efreet_videos_dir_get(void);
  * list then the next call to efreet_config_dirs_get() will return your
  * modified values. DO NOT free this list.
  */
-EAPI Eina_List *efreet_config_dirs_get(void);
+EFREET_API Eina_List *efreet_config_dirs_get(void);
 
 
 /**
@@ -205,7 +205,7 @@ EAPI Eina_List *efreet_config_dirs_get(void);
  * @see efreet_download_dir_get()
  * @see efreet_config_home_get()
  */
-EAPI const char *efreet_cache_home_get(void);
+EFREET_API const char *efreet_cache_home_get(void);
 
 /**
  * @return Returns the XDG User Runtime directory.
@@ -252,13 +252,13 @@ EAPI const char *efreet_cache_home_get(void);
  *
  * @since 1.8
  */
-EAPI const char *efreet_runtime_dir_get(void);
+EFREET_API const char *efreet_runtime_dir_get(void);
 
 /**
  * @return Returns the current hostname
  * @brief Returns the current hostname or empty string if not found
  */
-EAPI const char *efreet_hostname_get(void);
+EFREET_API const char *efreet_hostname_get(void);
 
 /**
  * Efreet_Event_Cache_Update

--- a/src/lib/efreet/efreet_cache.c
+++ b/src/lib/efreet/efreet_cache.c
@@ -103,9 +103,9 @@ static Eina_Bool disable_cache;
 static Eina_Bool run_in_tree;
 static int relaunch_try = 0;
 
-EAPI int EFREET_EVENT_ICON_CACHE_UPDATE = 0;
-EAPI int EFREET_EVENT_DESKTOP_CACHE_UPDATE = 0;
-EAPI int EFREET_EVENT_DESKTOP_CACHE_BUILD = 0;
+EFREET_API int EFREET_EVENT_ICON_CACHE_UPDATE = 0;
+EFREET_API int EFREET_EVENT_DESKTOP_CACHE_UPDATE = 0;
+EFREET_API int EFREET_EVENT_DESKTOP_CACHE_BUILD = 0;
 
 #define IPC_HEAD(_type) \
    Ecore_Ipc_Event_Server_##_type *e = event; \
@@ -282,7 +282,7 @@ _icon_desktop_cache_update_event_add(int event_type)
    ecore_event_add(event_type, ev, icon_cache_update_free, l);
 }
 
-EAPI void (*_efreet_mime_update_func) (void) = NULL;
+EFREET_API void (*_efreet_mime_update_func) (void) = NULL;
 
 static Eina_Bool
 _cb_server_data(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
@@ -470,9 +470,9 @@ efreet_cache_shutdown(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI const char *
+EFREET_API const char *
 efreet_icon_cache_file(const char *theme)
 {
     static char cache_file[PATH_MAX] = { '\0' };
@@ -488,9 +488,9 @@ efreet_icon_cache_file(const char *theme)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI const char *
+EFREET_API const char *
 efreet_icon_theme_cache_file(void)
 {
     char tmp[PATH_MAX] = { '\0' };
@@ -505,9 +505,9 @@ efreet_icon_theme_cache_file(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI const char *
+EFREET_API const char *
 efreet_desktop_util_cache_file(void)
 {
     char tmp[PATH_MAX] = { '\0' };
@@ -534,9 +534,9 @@ efreet_desktop_util_cache_file(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eet_Data_Descriptor *
+EFREET_API Eet_Data_Descriptor *
 efreet_version_edd(void)
 {
     Eet_Data_Descriptor_Class eddc;
@@ -556,9 +556,9 @@ efreet_version_edd(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eet_Data_Descriptor *
+EFREET_API Eet_Data_Descriptor *
 efreet_hash_array_string_edd(void)
 {
     Eet_Data_Descriptor_Class eddc;
@@ -577,9 +577,9 @@ efreet_hash_array_string_edd(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eet_Data_Descriptor *
+EFREET_API Eet_Data_Descriptor *
 efreet_hash_string_edd(void)
 {
     Eet_Data_Descriptor_Class eddc;
@@ -597,9 +597,9 @@ efreet_hash_string_edd(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eet_Data_Descriptor *
+EFREET_API Eet_Data_Descriptor *
 efreet_array_string_edd(void)
 {
     Eet_Data_Descriptor_Class eddc;
@@ -616,9 +616,9 @@ efreet_array_string_edd(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI const char *
+EFREET_API const char *
 efreet_desktop_cache_file(void)
 {
     char tmp[PATH_MAX] = { '\0' };
@@ -698,9 +698,9 @@ efreet_icon_directory_edd(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eet_Data_Descriptor *
+EFREET_API Eet_Data_Descriptor *
 efreet_icon_edd(void)
 {
     Eet_Data_Descriptor_Class eddc;
@@ -739,9 +739,9 @@ efreet_icon_edd(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eet_Data_Descriptor *
+EFREET_API Eet_Data_Descriptor *
 efreet_icon_theme_edd(Eina_Bool cache)
 {
     Eet_Data_Descriptor_Class eddc;
@@ -803,9 +803,9 @@ efreet_icon_theme_edd(Eina_Bool cache)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eet_Data_Descriptor *
+EFREET_API Eet_Data_Descriptor *
 efreet_icon_fallback_edd(void)
 {
     Eet_Data_Descriptor_Class eddc;
@@ -823,9 +823,9 @@ efreet_icon_fallback_edd(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI Eet_Data_Descriptor *
+EFREET_API Eet_Data_Descriptor *
 efreet_desktop_edd(void)
 {
     Eet_Data_Descriptor_Class eddc;
@@ -1022,9 +1022,9 @@ efreet_cache_icon_theme_list(void)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI void
+EFREET_API void
 efreet_cache_array_string_free(Efreet_Cache_Array_String *array)
 {
     if (!array) return;
@@ -1377,7 +1377,7 @@ hash_array_string_add(void *hash, const char *key, void *data)
     return hash;
 }
 
-EAPI void
+EFREET_API void
 efreet_cache_disable(void)
 {
    Eina_Bool prev = disable_cache;
@@ -1393,7 +1393,7 @@ efreet_cache_disable(void)
      }
 }
 
-EAPI void
+EFREET_API void
 efreet_cache_enable(void)
 {
    Eina_Bool prev = disable_cache;

--- a/src/lib/efreet/efreet_cache_private.h
+++ b/src/lib/efreet/efreet_cache_private.h
@@ -12,45 +12,21 @@
 #define EFREET_CACHE_VERSION "__efreet//version"
 #define EFREET_CACHE_ICON_FALLBACK "__efreet_fallback"
 
-#ifdef EAPI
-# undef EAPI
-#endif
+#include <efreet_api.h>
 
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+EFREET_API const char *efreet_desktop_util_cache_file(void);
+EFREET_API const char *efreet_desktop_cache_file(void);
+EFREET_API const char *efreet_icon_cache_file(const char *theme);
+EFREET_API const char *efreet_icon_theme_cache_file(void);
 
-EAPI const char *efreet_desktop_util_cache_file(void);
-EAPI const char *efreet_desktop_cache_file(void);
-EAPI const char *efreet_icon_cache_file(const char *theme);
-EAPI const char *efreet_icon_theme_cache_file(void);
-
-EAPI Eet_Data_Descriptor *efreet_version_edd(void);
-EAPI Eet_Data_Descriptor *efreet_desktop_edd(void);
-EAPI Eet_Data_Descriptor *efreet_hash_array_string_edd(void);
-EAPI Eet_Data_Descriptor *efreet_hash_string_edd(void);
-EAPI Eet_Data_Descriptor *efreet_array_string_edd(void);
-EAPI Eet_Data_Descriptor *efreet_icon_theme_edd(Eina_Bool cache);
-EAPI Eet_Data_Descriptor *efreet_icon_edd(void);
-EAPI Eet_Data_Descriptor *efreet_icon_fallback_edd(void);
+EFREET_API Eet_Data_Descriptor *efreet_version_edd(void);
+EFREET_API Eet_Data_Descriptor *efreet_desktop_edd(void);
+EFREET_API Eet_Data_Descriptor *efreet_hash_array_string_edd(void);
+EFREET_API Eet_Data_Descriptor *efreet_hash_string_edd(void);
+EFREET_API Eet_Data_Descriptor *efreet_array_string_edd(void);
+EFREET_API Eet_Data_Descriptor *efreet_icon_theme_edd(Eina_Bool cache);
+EFREET_API Eet_Data_Descriptor *efreet_icon_edd(void);
+EFREET_API Eet_Data_Descriptor *efreet_icon_fallback_edd(void);
 
 typedef struct _Efreet_Cache_Icon_Theme Efreet_Cache_Icon_Theme;
 typedef struct _Efreet_Cache_Directory Efreet_Cache_Directory;
@@ -82,8 +58,5 @@ struct _Efreet_Cache_Desktop
 
     double check_time; /**< Last time we check for disk modification */
 };
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/efreet/efreet_desktop.c
+++ b/src/lib/efreet/efreet_desktop.c
@@ -30,9 +30,9 @@ static Eina_List *efreet_desktop_types = NULL;
 
 static Eina_Lock _lock;
 
-EAPI int EFREET_DESKTOP_TYPE_APPLICATION = 0;
-EAPI int EFREET_DESKTOP_TYPE_LINK = 0;
-EAPI int EFREET_DESKTOP_TYPE_DIRECTORY = 0;
+EFREET_API int EFREET_DESKTOP_TYPE_APPLICATION = 0;
+EFREET_API int EFREET_DESKTOP_TYPE_LINK = 0;
+EFREET_API int EFREET_DESKTOP_TYPE_DIRECTORY = 0;
 
 /**
  * @internal
@@ -146,7 +146,7 @@ efreet_desktop_shutdown(void)
     _efreet_desktop_log_dom = -1;
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_desktop_get(const char *file)
 {
     Efreet_Desktop *desktop;
@@ -194,7 +194,7 @@ efreet_desktop_get(const char *file)
 #endif
 }
 
-EAPI int
+EFREET_API int
 efreet_desktop_ref(Efreet_Desktop *desktop)
 {
     int ret;
@@ -207,7 +207,7 @@ efreet_desktop_ref(Efreet_Desktop *desktop)
     return ret;
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_desktop_empty_new(const char *file)
 {
     Efreet_Desktop *desktop;
@@ -235,7 +235,7 @@ efreet_desktop_empty_new(const char *file)
     return desktop;
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_desktop_new(const char *file)
 {
     Efreet_Desktop *desktop = NULL;
@@ -264,7 +264,7 @@ efreet_desktop_new(const char *file)
     return efreet_desktop_uncached_new(file);
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_desktop_uncached_new(const char *file)
 {
     Efreet_Desktop *desktop = NULL;
@@ -293,7 +293,7 @@ efreet_desktop_uncached_new(const char *file)
     return desktop;
 }
 
-EAPI int
+EFREET_API int
 efreet_desktop_save(Efreet_Desktop *desktop)
 {
     Efreet_Desktop_Type_Info *info;
@@ -349,7 +349,7 @@ efreet_desktop_save(Efreet_Desktop *desktop)
     return ok;
 }
 
-EAPI int
+EFREET_API int
 efreet_desktop_save_as(Efreet_Desktop *desktop, const char *file)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(desktop, 0);
@@ -363,7 +363,7 @@ efreet_desktop_save_as(Efreet_Desktop *desktop, const char *file)
     return efreet_desktop_save(desktop);
 }
 
-EAPI void
+EFREET_API void
 efreet_desktop_free(Efreet_Desktop *desktop)
 {
     if (!desktop) return;
@@ -432,26 +432,26 @@ efreet_desktop_free(Efreet_Desktop *desktop)
     eina_lock_release(&_lock);
 }
 
-EAPI void
+EFREET_API void
 efreet_desktop_environment_set(const char *environment)
 {
    eina_stringshare_replace(&desktop_environment, environment);
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_desktop_environment_get(void)
 {
     return desktop_environment;
 }
 
-EAPI unsigned int
+EFREET_API unsigned int
 efreet_desktop_category_count_get(Efreet_Desktop *desktop)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(desktop, 0);
     return eina_list_count(desktop->categories);
 }
 
-EAPI void
+EFREET_API void
 efreet_desktop_category_add(Efreet_Desktop *desktop, const char *category)
 {
     EINA_SAFETY_ON_NULL_RETURN(desktop);
@@ -466,7 +466,7 @@ efreet_desktop_category_add(Efreet_Desktop *desktop, const char *category)
     eina_lock_release(&_lock);
 }
 
-EAPI int
+EFREET_API int
 efreet_desktop_category_del(Efreet_Desktop *desktop, const char *category)
 {
     char *found = NULL;
@@ -487,7 +487,7 @@ efreet_desktop_category_del(Efreet_Desktop *desktop, const char *category)
     return 0;
 }
 
-EAPI int
+EFREET_API int
 efreet_desktop_type_add(const char *type, Efreet_Desktop_Type_Parse_Cb parse_func,
                         Efreet_Desktop_Type_Save_Cb save_func,
                         Efreet_Desktop_Type_Free_Cb free_func)
@@ -511,7 +511,7 @@ efreet_desktop_type_add(const char *type, Efreet_Desktop_Type_Parse_Cb parse_fun
     return id;
 }
 
-EAPI int
+EFREET_API int
 efreet_desktop_type_alias(int from_type, const char *alias)
 {
     Efreet_Desktop_Type_Info *info;
@@ -521,7 +521,7 @@ efreet_desktop_type_alias(int from_type, const char *alias)
     return efreet_desktop_type_add(alias, info->parse_func, info->save_func, info->free_func);
 }
 
-EAPI Eina_Bool
+EFREET_API Eina_Bool
 efreet_desktop_x_field_set(Efreet_Desktop *desktop, const char *key, const char *data)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(desktop, EINA_FALSE);
@@ -539,7 +539,7 @@ efreet_desktop_x_field_set(Efreet_Desktop *desktop, const char *key, const char 
     return EINA_TRUE;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_desktop_x_field_get(Efreet_Desktop *desktop, const char *key)
 {
     const char *ret;
@@ -562,7 +562,7 @@ efreet_desktop_x_field_get(Efreet_Desktop *desktop, const char *key)
     return ret;
 }
 
-EAPI Eina_Bool
+EFREET_API Eina_Bool
 efreet_desktop_x_field_del(Efreet_Desktop *desktop, const char *key)
 {
     Eina_Bool ret;
@@ -576,14 +576,14 @@ efreet_desktop_x_field_del(Efreet_Desktop *desktop, const char *key)
     return ret;
 }
 
-EAPI void *
+EFREET_API void *
 efreet_desktop_type_data_get(Efreet_Desktop *desktop)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(desktop, NULL);
     return desktop->type_data;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_desktop_string_list_parse(const char *string)
 {
     Eina_List *list = NULL;
@@ -617,7 +617,7 @@ efreet_desktop_string_list_parse(const char *string)
     return list;
 }
 
-EAPI char *
+EFREET_API char *
 efreet_desktop_string_list_join(Eina_List *list)
 {
     Eina_List *l;

--- a/src/lib/efreet/efreet_desktop.h
+++ b/src/lib/efreet/efreet_desktop.h
@@ -13,21 +13,21 @@
  */
 
 
-EAPI extern int EFREET_DESKTOP_TYPE_APPLICATION;
-EAPI extern int EFREET_DESKTOP_TYPE_LINK;
-EAPI extern int EFREET_DESKTOP_TYPE_DIRECTORY;
+EFREET_API extern int EFREET_DESKTOP_TYPE_APPLICATION;
+EFREET_API extern int EFREET_DESKTOP_TYPE_LINK;
+EFREET_API extern int EFREET_DESKTOP_TYPE_DIRECTORY;
 
 /**
  * Event id for cache update. All users of efreet_desktop_get must listen to
  * this event and refetch. The old eet cache will be closed and mem will
  * be invalidated.
  */
-EAPI extern int EFREET_EVENT_DESKTOP_CACHE_UPDATE;
+EFREET_API extern int EFREET_EVENT_DESKTOP_CACHE_UPDATE;
 /**
  * Event id for cache build complete.
  * @since 1.1.0
  */
-EAPI extern int EFREET_EVENT_DESKTOP_CACHE_BUILD;
+EFREET_API extern int EFREET_EVENT_DESKTOP_CACHE_BUILD;
 
 /**
  * Efreet_Desktop_Action
@@ -146,21 +146,21 @@ struct _Efreet_Desktop
  * the Efreet_Desktop struct should be invalidated and reloaded from a new
  * cache file.
  */
-EAPI Efreet_Desktop   *efreet_desktop_get(const char *file);
+EFREET_API Efreet_Desktop   *efreet_desktop_get(const char *file);
 
 /**
  * @param desktop The Efreet_Desktop to ref
  * @return Returns the new reference count
  * @brief Increases reference count on desktop
  */
-EAPI int               efreet_desktop_ref(Efreet_Desktop *desktop);
+EFREET_API int               efreet_desktop_ref(Efreet_Desktop *desktop);
 
 /**
  * @param file The file to create the Efreet_Desktop from
  * @return Returns a new empty_Efreet_Desktop on success, NULL on failure
  * @brief Creates a new empty Efreet_Desktop structure or NULL on failure
  */
-EAPI Efreet_Desktop   *efreet_desktop_empty_new(const char *file);
+EFREET_API Efreet_Desktop   *efreet_desktop_empty_new(const char *file);
 
 /**
  * @param file The file to get the Efreet_Desktop from
@@ -174,7 +174,7 @@ EAPI Efreet_Desktop   *efreet_desktop_empty_new(const char *file);
  * the Efreet_Desktop struct should be invalidated and reloaded from a new
  * cache file.
  */
-EAPI Efreet_Desktop   *efreet_desktop_new(const char *file);
+EFREET_API Efreet_Desktop   *efreet_desktop_new(const char *file);
 
 /**
  * @param file The file to create the Efreet_Desktop from
@@ -188,14 +188,14 @@ EAPI Efreet_Desktop   *efreet_desktop_new(const char *file);
  * Data in the structure is allocated with strdup, so use free and strdup to
  * change values.
  */
-EAPI Efreet_Desktop   *efreet_desktop_uncached_new(const char *file);
+EFREET_API Efreet_Desktop   *efreet_desktop_uncached_new(const char *file);
 
 /**
  * @param desktop The Efreet_Desktop to work with
  * @return Returns no value
  * @brief Frees the Efreet_Desktop structure and all of it's data
  */
-EAPI void              efreet_desktop_free(Efreet_Desktop *desktop);
+EFREET_API void              efreet_desktop_free(Efreet_Desktop *desktop);
 
 /**
  * @def efreet_desktop_unref(desktop)
@@ -210,7 +210,7 @@ EAPI void              efreet_desktop_free(Efreet_Desktop *desktop);
  * @brief Saves any changes made to @a desktop back to the file on the
  * filesystem
  */
-EAPI int               efreet_desktop_save(Efreet_Desktop *desktop);
+EFREET_API int               efreet_desktop_save(Efreet_Desktop *desktop);
 
 /**
  * @param desktop The desktop file to save
@@ -221,7 +221,7 @@ EAPI int               efreet_desktop_save(Efreet_Desktop *desktop);
  * Please use efreet_desktop_uncached_new() on an existing file
  * before using efreet_desktop_save_as()
  */
-EAPI int               efreet_desktop_save_as(Efreet_Desktop *desktop,
+EFREET_API int               efreet_desktop_save_as(Efreet_Desktop *desktop,
                                                 const char *file);
 
 
@@ -231,7 +231,7 @@ EAPI int               efreet_desktop_save_as(Efreet_Desktop *desktop,
  * @param data The data pointer to pass
  * @brief Parses the @a desktop exec line and runs the command.
  */
-EAPI void              efreet_desktop_exec(Efreet_Desktop *desktop,
+EFREET_API void              efreet_desktop_exec(Efreet_Desktop *desktop,
                                            Eina_List *files, void *data);
 
 
@@ -239,14 +239,14 @@ EAPI void              efreet_desktop_exec(Efreet_Desktop *desktop,
  * @param environment the environment name
  * @brief sets the global desktop environment name
  */
-EAPI void              efreet_desktop_environment_set(const char *environment);
+EFREET_API void              efreet_desktop_environment_set(const char *environment);
 
 /**
  * @return environment the environment name
  * @brief gets the global desktop environment name
  * (e.g. "Enlightenment" or "Gnome")
  */
-EAPI const char       *efreet_desktop_environment_get(void);
+EFREET_API const char       *efreet_desktop_environment_get(void);
 
 /**
  * @param desktop the desktop entry
@@ -259,7 +259,7 @@ EAPI const char       *efreet_desktop_environment_get(void);
  * @brief Get a command to use to execute a desktop entry, and receive progress
  * updates for downloading of remote URI's passed in.
  */
-EAPI void             *efreet_desktop_command_progress_get(Efreet_Desktop *desktop,
+EFREET_API void             *efreet_desktop_command_progress_get(Efreet_Desktop *desktop,
                                          Eina_List *files,
                                          Efreet_Desktop_Command_Cb cb_command,
                                          Efreet_Desktop_Progress_Cb cb_prog,
@@ -273,7 +273,7 @@ EAPI void             *efreet_desktop_command_progress_get(Efreet_Desktop *deskt
  * @return Returns the return value of @p func on success or NULL on failure
  * @brief Get a command to use to execute a desktop entry.
  */
-EAPI void              *efreet_desktop_command_get(Efreet_Desktop *desktop,
+EFREET_API void              *efreet_desktop_command_get(Efreet_Desktop *desktop,
                                          Eina_List *files,
                                          Efreet_Desktop_Command_Cb func,
                                          void *data);
@@ -286,7 +286,7 @@ EAPI void              *efreet_desktop_command_get(Efreet_Desktop *desktop,
  *
  * The returned list and each of its elements must be freed.
  */
-EAPI Eina_List *      efreet_desktop_command_local_get(Efreet_Desktop *desktop,
+EFREET_API Eina_List *      efreet_desktop_command_local_get(Efreet_Desktop *desktop,
                                          Eina_List *files);
 
 
@@ -296,14 +296,14 @@ EAPI Eina_List *      efreet_desktop_command_local_get(Efreet_Desktop *desktop,
  * @brief Retrieves the number of categories the given @a desktop belongs
  * too
  */
-EAPI unsigned int      efreet_desktop_category_count_get(Efreet_Desktop *desktop);
+EFREET_API unsigned int      efreet_desktop_category_count_get(Efreet_Desktop *desktop);
 
 /**
  * @param desktop the desktop
  * @param category the category name
  * @brief add a category to a desktop
  */
-EAPI void              efreet_desktop_category_add(Efreet_Desktop *desktop,
+EFREET_API void              efreet_desktop_category_add(Efreet_Desktop *desktop,
                                               const char *category);
 
 /**
@@ -312,7 +312,7 @@ EAPI void              efreet_desktop_category_add(Efreet_Desktop *desktop,
  * @brief removes a category from a desktop
  * @return 1 if the desktop had his category listed, 0 otherwise
  */
-EAPI int               efreet_desktop_category_del(Efreet_Desktop *desktop,
+EFREET_API int               efreet_desktop_category_del(Efreet_Desktop *desktop,
                                               const char *category);
 
 
@@ -324,7 +324,7 @@ EAPI int               efreet_desktop_category_del(Efreet_Desktop *desktop,
  * @return Returns the id of the new type
  * @brief Adds the given type to the list of types in the system
  */
-EAPI int               efreet_desktop_type_add(const char *type,
+EFREET_API int               efreet_desktop_type_add(const char *type,
                                     Efreet_Desktop_Type_Parse_Cb parse_func,
                                     Efreet_Desktop_Type_Save_Cb save_func,
                                     Efreet_Desktop_Type_Free_Cb free_func);
@@ -337,7 +337,7 @@ EAPI int               efreet_desktop_type_add(const char *type,
  *
  * This allows applications to add non-standard types that behave exactly as standard types.
  */
-EAPI int               efreet_desktop_type_alias (int from_type,
+EFREET_API int               efreet_desktop_type_alias (int from_type,
                                              const char *alias);
 
 /**
@@ -345,7 +345,7 @@ EAPI int               efreet_desktop_type_alias (int from_type,
  * @param desktop the desktop
  * @return type specific data, or NULL if there is none
  */
-EAPI void             *efreet_desktop_type_data_get(Efreet_Desktop *desktop);
+EFREET_API void             *efreet_desktop_type_data_get(Efreet_Desktop *desktop);
 
 
 /**
@@ -353,14 +353,14 @@ EAPI void             *efreet_desktop_type_data_get(Efreet_Desktop *desktop);
  * @return an Eina_List of ecore string's
  * @brief Parse ';' separate list of strings according to the desktop spec
  */
-EAPI Eina_List        *efreet_desktop_string_list_parse(const char *string);
+EFREET_API Eina_List        *efreet_desktop_string_list_parse(const char *string);
 
 /**
  * @param list Eina_List with strings
  * @return a raw string list
  * @brief Create a ';' separate list of strings according to the desktop spec
  */
-EAPI char             *efreet_desktop_string_list_join(Eina_List *list);
+EFREET_API char             *efreet_desktop_string_list_join(Eina_List *list);
 
 
 /**
@@ -372,7 +372,7 @@ EAPI char             *efreet_desktop_string_list_join(Eina_List *list);
  *
  * The key has to start with "X-"
  */
-EAPI Eina_Bool         efreet_desktop_x_field_set(Efreet_Desktop *desktop, const char *key, const char *data);
+EFREET_API Eina_Bool         efreet_desktop_x_field_set(Efreet_Desktop *desktop, const char *key, const char *data);
 
 /**
  * @brief Get the value for a X- field (Non spec) in the structure
@@ -380,7 +380,7 @@ EAPI Eina_Bool         efreet_desktop_x_field_set(Efreet_Desktop *desktop, const
  * @param key the key
  * @return The value referenced by the key, or NULL if the key does not exist
  */
-EAPI const char *      efreet_desktop_x_field_get(Efreet_Desktop *desktop, const char *key);
+EFREET_API const char *      efreet_desktop_x_field_get(Efreet_Desktop *desktop, const char *key);
 
 /**
  * @brief Delete the key and value for a X- field (Non spec) in the structure
@@ -388,7 +388,7 @@ EAPI const char *      efreet_desktop_x_field_get(Efreet_Desktop *desktop, const
  * @param key the key
  * @return EINA_TRUE if the key existed
  */
-EAPI Eina_Bool         efreet_desktop_x_field_del(Efreet_Desktop *desktop, const char *key);
+EFREET_API Eina_Bool         efreet_desktop_x_field_del(Efreet_Desktop *desktop, const char *key);
 
 /**
  * @}

--- a/src/lib/efreet/efreet_desktop_command.c
+++ b/src/lib/efreet/efreet_desktop_command.c
@@ -113,20 +113,20 @@ static char *efreet_string_append_char(char *dest, int *size,
                                         int *len, char c);
 
 
-EAPI void
+EFREET_API void
 efreet_desktop_exec(Efreet_Desktop *desktop, Eina_List *files, void *data)
 {
     efreet_desktop_command_get(desktop, files, efreet_desktop_exec_cb, data);
 }
 
-EAPI void *
+EFREET_API void *
 efreet_desktop_command_get(Efreet_Desktop *desktop, Eina_List *files,
                             Efreet_Desktop_Command_Cb func, void *data)
 {
     return efreet_desktop_command_progress_get(desktop, files, func, NULL, data);
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_desktop_command_local_get(Efreet_Desktop *desktop, Eina_List *files)
 {
     Efreet_Desktop_Command *command;
@@ -166,7 +166,7 @@ efreet_desktop_command_local_get(Efreet_Desktop *desktop, Eina_List *files)
     return execs;
 }
 
-EAPI void *
+EFREET_API void *
 efreet_desktop_command_progress_get(Efreet_Desktop *desktop, Eina_List *files,
                                     Efreet_Desktop_Command_Cb cb_command,
                                     Efreet_Desktop_Progress_Cb cb_progress,

--- a/src/lib/efreet/efreet_icon.c
+++ b/src/lib/efreet/efreet_icon.c
@@ -93,7 +93,7 @@ efreet_icon_extensions_refresh(void)
    efreet_cache_icon_exts_add(efreet_icon_extensions);
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_icon_deprecated_user_dir_get(void)
 {
     const char *user;
@@ -114,7 +114,7 @@ efreet_icon_deprecated_user_dir_get(void)
     return efreet_icon_deprecated_user_dir;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_icon_user_dir_get(void)
 {
     const char *user;
@@ -135,7 +135,7 @@ efreet_icon_user_dir_get(void)
     return efreet_icon_user_dir;
 }
 
-EAPI void
+EFREET_API void
 efreet_icon_extension_add(const char *ext)
 {
     Eina_List *l;
@@ -154,26 +154,26 @@ efreet_icon_extension_add(const char *ext)
     efreet_icon_extensions_refresh();
 }
 
-EAPI Eina_List **
+EFREET_API Eina_List **
 efreet_icon_extra_list_get(void)
 {
     ecore_job_add(efreet_cache_icon_dirs_add_cb, NULL);
     return &efreet_extra_icon_dirs;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_icon_extensions_list_get(void)
 {
     return efreet_icon_extensions;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_icon_theme_list_get(void)
 {
     return efreet_cache_icon_theme_list();
 }
 
-EAPI Efreet_Icon_Theme *
+EFREET_API Efreet_Icon_Theme *
 efreet_icon_theme_find(const char *theme_name)
 {
     if (!theme_name) return NULL;
@@ -219,7 +219,7 @@ efreet_icon_remove_extension(const char *icon)
 }
 #endif
 
-EAPI const char *
+EFREET_API const char *
 efreet_icon_path_find(const char *theme_name, const char *icon, unsigned int size)
 {
 #ifdef SLOPPY_SPEC
@@ -267,7 +267,7 @@ efreet_icon_path_find(const char *theme_name, const char *icon, unsigned int siz
     return value;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_icon_list_find(const char *theme_name, Eina_List *icons,
                       unsigned int size)
 {
@@ -346,7 +346,7 @@ efreet_icon_list_find(const char *theme_name, Eina_List *icons,
     return value;
 }
 
-EAPI Efreet_Icon *
+EFREET_API Efreet_Icon *
 efreet_icon_find(const char *theme_name, const char *icon, unsigned int size)
 {
     const char *path;
@@ -408,7 +408,7 @@ efreet_icon_new(const char *path)
     return icon;
 }
 
-EAPI void
+EFREET_API void
 efreet_icon_free(Efreet_Icon *icon)
 {
     if (!icon) return;

--- a/src/lib/efreet/efreet_icon.h
+++ b/src/lib/efreet/efreet_icon.h
@@ -16,7 +16,7 @@
 /**
  * Event id for cache update.
  */
-EAPI extern int EFREET_EVENT_ICON_CACHE_UPDATE;
+EFREET_API extern int EFREET_EVENT_ICON_CACHE_UPDATE;
 
 /**
  * The possible contexts for an icon directory
@@ -144,20 +144,20 @@ struct Efreet_Icon_Point
  * @return Returns the user icon directory
  * @brief Returns the user icon directory
  */
-EAPI const char        *efreet_icon_user_dir_get(void);
+EFREET_API const char        *efreet_icon_user_dir_get(void);
 
 /**
  * @return Returns the deprecated user icon directory
  * @brief Returns the deprecated user icon directory
  */
-EAPI const char        *efreet_icon_deprecated_user_dir_get(void);
+EFREET_API const char        *efreet_icon_deprecated_user_dir_get(void);
 
 /**
  * @param ext The extension to add to the list of checked extensions
  * @return Returns no value.
  * @brief Adds the given extension to the list of possible icon extensions
  */
-EAPI void               efreet_icon_extension_add(const char *ext);
+EFREET_API void               efreet_icon_extension_add(const char *ext);
 
 
 /**
@@ -168,13 +168,13 @@ EAPI void               efreet_icon_extension_add(const char *ext);
  * from first to last directory in this list. the strings in the list should
  * be created with eina_stringshare_add().
  */
-EAPI Eina_List        **efreet_icon_extra_list_get(void);
+EFREET_API Eina_List        **efreet_icon_extra_list_get(void);
 
 /**
  * @return Returns a list of strings that are icon extensions to look for
  * @brief Gets the list of all icon extensions to look for
  */
-EAPI Eina_List         *efreet_icon_extensions_list_get(void);
+EFREET_API Eina_List         *efreet_icon_extensions_list_get(void);
 
 /**
  * @return Returns a list of Efreet_Icon structs for all the non-hidden icon
@@ -182,7 +182,7 @@ EAPI Eina_List         *efreet_icon_extensions_list_get(void);
  * @brief Retrieves all of the non-hidden icon themes available on the system.
  * The returned list must be freed. Do not free the list data.
  */
-EAPI Eina_List         *efreet_icon_theme_list_get(void);
+EFREET_API Eina_List         *efreet_icon_theme_list_get(void);
 
 /**
  * @param theme_name The theme to look for
@@ -190,7 +190,7 @@ EAPI Eina_List         *efreet_icon_theme_list_get(void);
  * none exists.
  * @brief Tries to get the icon theme structure for the given theme name
  */
-EAPI Efreet_Icon_Theme *efreet_icon_theme_find(const char *theme_name);
+EFREET_API Efreet_Icon_Theme *efreet_icon_theme_find(const char *theme_name);
 
 /**
  * @param theme_name The icon theme to look for
@@ -200,7 +200,7 @@ EAPI Efreet_Icon_Theme *efreet_icon_theme_find(const char *theme_name);
  * if the icon is not found
  * @brief Retrieves all of the information about the given icon.
  */
-EAPI Efreet_Icon       *efreet_icon_find(const char *theme_name,
+EFREET_API Efreet_Icon       *efreet_icon_find(const char *theme_name,
                                             const char *icon,
                                             unsigned int size);
 
@@ -218,7 +218,7 @@ EAPI Efreet_Icon       *efreet_icon_find(const char *theme_name,
  * There is no guarantee for how long the pointer to the path will be valid.
  * If the pointer is to be kept, the user must create a copy of the path.
  */
-EAPI const char        *efreet_icon_list_find(const char *theme_name,
+EFREET_API const char        *efreet_icon_list_find(const char *theme_name,
                                                 Eina_List *icons,
                                                 unsigned int size);
 
@@ -232,7 +232,7 @@ EAPI const char        *efreet_icon_list_find(const char *theme_name,
  * There is no guarantee for how long the pointer to the path will be valid.
  * If the pointer is to be kept, the user must create a copy of the path.
  */
-EAPI const char        *efreet_icon_path_find(const char *theme_name,
+EFREET_API const char        *efreet_icon_path_find(const char *theme_name,
                                                 const char *icon,
                                                 unsigned int size);
 
@@ -241,7 +241,7 @@ EAPI const char        *efreet_icon_path_find(const char *theme_name,
  * @return Returns no value.
  * @brief Free's the given icon and all its internal data.
  */
-EAPI void               efreet_icon_free(Efreet_Icon *icon);
+EFREET_API void               efreet_icon_free(Efreet_Icon *icon);
 
 /**
  * @}

--- a/src/lib/efreet/efreet_ini.c
+++ b/src/lib/efreet/efreet_ini.c
@@ -50,7 +50,7 @@ efreet_ini_shutdown(void)
     _efreet_ini_log_dom = -1;
 }
 
-EAPI Efreet_Ini *
+EFREET_API Efreet_Ini *
 efreet_ini_new(const char *file)
 {
     Efreet_Ini *ini;
@@ -230,7 +230,7 @@ error:
     return NULL;
 }
 
-EAPI void
+EFREET_API void
 efreet_ini_free(Efreet_Ini *ini)
 {
     if (!ini) return;
@@ -239,7 +239,7 @@ efreet_ini_free(Efreet_Ini *ini)
     FREE(ini);
 }
 
-EAPI int
+EFREET_API int
 efreet_ini_save(Efreet_Ini *ini, const char *file)
 {
     char *dir;
@@ -265,7 +265,7 @@ efreet_ini_save(Efreet_Ini *ini, const char *file)
     return 1;
 }
 
-EAPI int
+EFREET_API int
 efreet_ini_section_set(Efreet_Ini *ini, const char *section)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(ini, 0);
@@ -276,7 +276,7 @@ efreet_ini_section_set(Efreet_Ini *ini, const char *section)
     return (ini->section ? 1 : 0);
 }
 
-EAPI void
+EFREET_API void
 efreet_ini_section_add(Efreet_Ini *ini, const char *section)
 {
     Eina_Hash *hash;
@@ -292,7 +292,7 @@ efreet_ini_section_add(Efreet_Ini *ini, const char *section)
     eina_hash_add(ini->data, section, hash);
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_ini_string_get(Efreet_Ini *ini, const char *key)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(ini, NULL);
@@ -302,7 +302,7 @@ efreet_ini_string_get(Efreet_Ini *ini, const char *key)
     return eina_hash_find(ini->section, key);
 }
 
-EAPI void
+EFREET_API void
 efreet_ini_string_set(Efreet_Ini *ini, const char *key, const char *value)
 {
     EINA_SAFETY_ON_NULL_RETURN(ini);
@@ -313,7 +313,7 @@ efreet_ini_string_set(Efreet_Ini *ini, const char *key, const char *value)
     eina_hash_add(ini->section, key, eina_stringshare_add(value));
 }
 
-EAPI int
+EFREET_API int
 efreet_ini_int_get(Efreet_Ini *ini, const char *key)
 {
     const char *str;
@@ -328,7 +328,7 @@ efreet_ini_int_get(Efreet_Ini *ini, const char *key)
     return -1;
 }
 
-EAPI void
+EFREET_API void
 efreet_ini_int_set(Efreet_Ini *ini, const char *key, int value)
 {
     char str[12];
@@ -341,7 +341,7 @@ efreet_ini_int_set(Efreet_Ini *ini, const char *key, int value)
     efreet_ini_string_set(ini, key, str);
 }
 
-EAPI double
+EFREET_API double
 efreet_ini_double_get(Efreet_Ini *ini, const char *key)
 {
     const char *str;
@@ -356,7 +356,7 @@ efreet_ini_double_get(Efreet_Ini *ini, const char *key)
     return -1;
 }
 
-EAPI void
+EFREET_API void
 efreet_ini_double_set(Efreet_Ini *ini, const char *key, double value)
 {
     char str[512];
@@ -373,7 +373,7 @@ efreet_ini_double_set(Efreet_Ini *ini, const char *key, double value)
     efreet_ini_string_set(ini, key, str);
 }
 
-EAPI unsigned int
+EFREET_API unsigned int
 efreet_ini_boolean_get(Efreet_Ini *ini, const char *key)
 {
     const char *str;
@@ -388,7 +388,7 @@ efreet_ini_boolean_get(Efreet_Ini *ini, const char *key)
     return 0;
 }
 
-EAPI void
+EFREET_API void
 efreet_ini_boolean_set(Efreet_Ini *ini, const char *key, unsigned int value)
 {
     EINA_SAFETY_ON_NULL_RETURN(ini);
@@ -399,7 +399,7 @@ efreet_ini_boolean_set(Efreet_Ini *ini, const char *key, unsigned int value)
     else efreet_ini_string_set(ini, key, "false");
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_ini_localestring_get(Efreet_Ini *ini, const char *key)
 {
     const char *lang, *country, *modifier;
@@ -457,7 +457,7 @@ efreet_ini_localestring_get(Efreet_Ini *ini, const char *key)
     return val;
 }
 
-EAPI void
+EFREET_API void
 efreet_ini_localestring_set(Efreet_Ini *ini, const char *key, const char *value)
 {
     const char *lang, *country, *modifier;
@@ -493,7 +493,7 @@ efreet_ini_localestring_set(Efreet_Ini *ini, const char *key, const char *value)
     efreet_ini_string_set(ini, buf, value);
 }
 
-EAPI void
+EFREET_API void
 efreet_ini_key_unset(Efreet_Ini *ini, const char *key)
 {
     EINA_SAFETY_ON_NULL_RETURN(ini);

--- a/src/lib/efreet/efreet_ini.h
+++ b/src/lib/efreet/efreet_ini.h
@@ -34,14 +34,14 @@ struct Efreet_Ini
  * @brief Creates and initializes a new Ini structure with the contents of
  * @a file, or NULL on failure
  */
-EAPI Efreet_Ini  *efreet_ini_new(const char *file);
+EFREET_API Efreet_Ini  *efreet_ini_new(const char *file);
 
 /**
  * @param ini The Efreet_Ini to work with
  * @return Returns no value
  * @brief Frees the given Efree_Ini structure.
  */
-EAPI void         efreet_ini_free(Efreet_Ini *ini);
+EFREET_API void         efreet_ini_free(Efreet_Ini *ini);
 
 /**
  * @param ini The Efreet_Ini to work with
@@ -49,7 +49,7 @@ EAPI void         efreet_ini_free(Efreet_Ini *ini);
  * @return Returns no value
  * @brief Saves the given Efree_Ini structure.
  */
-EAPI int          efreet_ini_save(Efreet_Ini *ini, const char *path);
+EFREET_API int          efreet_ini_save(Efreet_Ini *ini, const char *path);
 
 
 /**
@@ -58,7 +58,7 @@ EAPI int          efreet_ini_save(Efreet_Ini *ini, const char *path);
  * @return Returns 1 if the section exists, otherwise 0
  * @brief Sets the current working section of the ini file to @a section
  */
-EAPI int          efreet_ini_section_set(Efreet_Ini *ini, const char *section);
+EFREET_API int          efreet_ini_section_set(Efreet_Ini *ini, const char *section);
 
 /**
  * @param ini The Efreet_Ini to work with
@@ -66,7 +66,7 @@ EAPI int          efreet_ini_section_set(Efreet_Ini *ini, const char *section);
  * @return Returns no value
  * @brief Adds a new working section of the ini file to @a section
  */
-EAPI void         efreet_ini_section_add(Efreet_Ini *ini, const char *section);
+EFREET_API void         efreet_ini_section_add(Efreet_Ini *ini, const char *section);
 
 
 /**
@@ -76,7 +76,7 @@ EAPI void         efreet_ini_section_add(Efreet_Ini *ini, const char *section);
  * found.
  * @brief Retrieves the value for the given key or NULL if none found.
  */
-EAPI const char  *efreet_ini_string_get(Efreet_Ini *ini, const char *key);
+EFREET_API const char  *efreet_ini_string_get(Efreet_Ini *ini, const char *key);
 
 /**
  * @param ini The Efree_Ini to work with
@@ -85,7 +85,7 @@ EAPI const char  *efreet_ini_string_get(Efreet_Ini *ini, const char *key);
  * @return Returns no value
  * @brief Sets the value for the given key
  */
-EAPI void         efreet_ini_string_set(Efreet_Ini *ini, const char *key,
+EFREET_API void         efreet_ini_string_set(Efreet_Ini *ini, const char *key,
                                                     const char *value);
 
 
@@ -96,7 +96,7 @@ EAPI void         efreet_ini_string_set(Efreet_Ini *ini, const char *key,
  *         if none found
  * @brief Retrieves the utf8 encoded string associated with @a key in the current locale or NULL if none found
  */
-EAPI const char  *efreet_ini_localestring_get(Efreet_Ini *ini, const char *key);
+EFREET_API const char  *efreet_ini_localestring_get(Efreet_Ini *ini, const char *key);
 
 /**
  * @param ini The ini struct to work with
@@ -105,7 +105,7 @@ EAPI const char  *efreet_ini_localestring_get(Efreet_Ini *ini, const char *key);
  * @return Returns no value
  * @brief Sets the value for the given key
  */
-EAPI void         efreet_ini_localestring_set(Efreet_Ini *ini, const char *key,
+EFREET_API void         efreet_ini_localestring_set(Efreet_Ini *ini, const char *key,
                                                     const char *value);
 
 
@@ -115,7 +115,7 @@ EAPI void         efreet_ini_localestring_set(Efreet_Ini *ini, const char *key,
  * @return Returns 1 if the boolean is true, 0 otherwise
  * @brief Retrieves the boolean value at key @a key from the ini @a ini
  */
-EAPI unsigned int efreet_ini_boolean_get(Efreet_Ini *ini, const char *key);
+EFREET_API unsigned int efreet_ini_boolean_get(Efreet_Ini *ini, const char *key);
 
 /**
  * @param ini The ini struct to work with
@@ -124,7 +124,7 @@ EAPI unsigned int efreet_ini_boolean_get(Efreet_Ini *ini, const char *key);
  * @return Returns no value
  * @brief Sets the value for the given key
  */
-EAPI void         efreet_ini_boolean_set(Efreet_Ini *ini, const char *key,
+EFREET_API void         efreet_ini_boolean_set(Efreet_Ini *ini, const char *key,
                                                     unsigned int value);
 
 
@@ -135,7 +135,7 @@ EAPI void         efreet_ini_boolean_set(Efreet_Ini *ini, const char *key,
  * found.
  * @brief Retrieves the value for the given key or -1 if none found.
  */
-EAPI int          efreet_ini_int_get(Efreet_Ini *ini, const char *key);
+EFREET_API int          efreet_ini_int_get(Efreet_Ini *ini, const char *key);
 
 /**
  * @param ini The Efree_Ini to work with
@@ -144,7 +144,7 @@ EAPI int          efreet_ini_int_get(Efreet_Ini *ini, const char *key);
  * @return Returns no value
  * @brief Sets the value for the given key
  */
-EAPI void         efreet_ini_int_set(Efreet_Ini *ini, const char *key, int value);
+EFREET_API void         efreet_ini_int_set(Efreet_Ini *ini, const char *key, int value);
 
 
 /**
@@ -154,7 +154,7 @@ EAPI void         efreet_ini_int_set(Efreet_Ini *ini, const char *key, int value
  * found.
  * @brief Retrieves the value for the given key or -1 if none found.
  */
-EAPI double       efreet_ini_double_get(Efreet_Ini *ini, const char *key);
+EFREET_API double       efreet_ini_double_get(Efreet_Ini *ini, const char *key);
 
 /**
  * @param ini The Efree_Ini to work with
@@ -163,7 +163,7 @@ EAPI double       efreet_ini_double_get(Efreet_Ini *ini, const char *key);
  * @return Returns no value
  * @brief Sets the value for the given key
  */
-EAPI void         efreet_ini_double_set(Efreet_Ini *ini, const char *key,
+EFREET_API void         efreet_ini_double_set(Efreet_Ini *ini, const char *key,
                                                     double value);
 
 
@@ -173,7 +173,7 @@ EAPI void         efreet_ini_double_set(Efreet_Ini *ini, const char *key,
  * @return Returns no value
  * @brief Remove the given key from the ini struct
  */
-EAPI void         efreet_ini_key_unset(Efreet_Ini *ini, const char *key);
+EFREET_API void         efreet_ini_key_unset(Efreet_Ini *ini, const char *key);
 
 /**
  * @}

--- a/src/lib/efreet/efreet_menu.c
+++ b/src/lib/efreet/efreet_menu.c
@@ -448,7 +448,7 @@ efreet_menu_init(void)
     return 1;
 }
 
-EAPI int
+EFREET_API int
 efreet_menu_kde_legacy_init(void)
 {
     FILE *f;
@@ -506,7 +506,7 @@ efreet_menu_shutdown(void)
     _efreet_menu_log_dom = -1;
 }
 
-EAPI Efreet_Menu *
+EFREET_API Efreet_Menu *
 efreet_menu_new(const char *name)
 {
     Efreet_Menu *menu;
@@ -519,7 +519,7 @@ efreet_menu_new(const char *name)
     return menu;
 }
 
-EAPI void
+EFREET_API void
 efreet_menu_file_set(const char *file)
 {
     IF_RELEASE(efreet_menu_file);
@@ -528,7 +528,7 @@ efreet_menu_file_set(const char *file)
 }
 
 /* deprecated */
-EFREET_DEPRECATED_API EAPI void
+EFREET_DEPRECATED_API EFREET_API void
 efreet_menu_async_get(Efreet_Menu_Cb func EINA_UNUSED, const void *data EINA_UNUSED)
 {
     ERR("%s is deprecated and shouldn't be called", __func__);
@@ -536,7 +536,7 @@ efreet_menu_async_get(Efreet_Menu_Cb func EINA_UNUSED, const void *data EINA_UNU
     return;
 }
 
-EAPI Efreet_Menu *
+EFREET_API Efreet_Menu *
 efreet_menu_get(void)
 {
     char menu[PATH_MAX];
@@ -572,7 +572,7 @@ efreet_menu_get(void)
 }
 
 /* deprecated */
-EFREET_DEPRECATED_API EAPI void
+EFREET_DEPRECATED_API EFREET_API void
 efreet_menu_async_parse(const char *path EINA_UNUSED, Efreet_Menu_Cb func EINA_UNUSED, const void *data EINA_UNUSED)
 {
     ERR("%s is deprecated and shouldn't be called", __func__);
@@ -580,7 +580,7 @@ efreet_menu_async_parse(const char *path EINA_UNUSED, Efreet_Menu_Cb func EINA_U
     return;
 }
 
-EAPI Efreet_Menu *
+EFREET_API Efreet_Menu *
 efreet_menu_parse(const char *path)
 {
     Efreet_Xml *xml;
@@ -648,7 +648,7 @@ error:
     return entry;
 }
 
-EAPI int
+EFREET_API int
 efreet_menu_save(Efreet_Menu *menu, const char *path)
 {
     FILE *f;
@@ -667,7 +667,7 @@ efreet_menu_save(Efreet_Menu *menu, const char *path)
     return ret;
 }
 
-EAPI int
+EFREET_API int
 efreet_menu_desktop_insert(Efreet_Menu *menu, Efreet_Desktop *desktop, int pos)
 {
     Efreet_Menu *entry;
@@ -697,7 +697,7 @@ efreet_menu_desktop_insert(Efreet_Menu *menu, Efreet_Desktop *desktop, int pos)
     return 1;
 }
 
-EAPI int
+EFREET_API int
 efreet_menu_desktop_remove(Efreet_Menu *menu, Efreet_Desktop *desktop)
 {
     Efreet_Menu *entry;
@@ -717,7 +717,7 @@ efreet_menu_desktop_remove(Efreet_Menu *menu, Efreet_Desktop *desktop)
     return 0;
 }
 
-EAPI void
+EFREET_API void
 efreet_menu_dump(Efreet_Menu *menu, const char *indent)
 {
     Eina_List *l;
@@ -2339,7 +2339,7 @@ efreet_menu_entry_new(void)
     return entry;
 }
 
-EAPI void
+EFREET_API void
 efreet_menu_free(Efreet_Menu *entry)
 {
     Efreet_Menu *sub;
@@ -2357,7 +2357,7 @@ efreet_menu_free(Efreet_Menu *entry)
     FREE(entry);
 }
 
-EAPI void
+EFREET_API void
 efreet_menu_ref(Efreet_Menu *entry)
 {
     Efreet_Menu *sub;
@@ -2370,7 +2370,7 @@ efreet_menu_ref(Efreet_Menu *entry)
     entry->references++;
 }
 
-EAPI void
+EFREET_API void
 efreet_menu_unref(Efreet_Menu *entry)
 {
     efreet_menu_free(entry);

--- a/src/lib/efreet/efreet_menu.h
+++ b/src/lib/efreet/efreet_menu.h
@@ -57,7 +57,7 @@ typedef void (*Efreet_Menu_Cb) (void *data, Efreet_Menu *menu);
  * @brief Initialize legacy kde support. This function blocks while
  * the kde-config script is run.
  */
-EAPI int              efreet_menu_kde_legacy_init(void);
+EFREET_API int              efreet_menu_kde_legacy_init(void);
 
 /**
  * @param name The internal name of the menu
@@ -65,7 +65,7 @@ EAPI int              efreet_menu_kde_legacy_init(void);
  * NULL on failure
  * @brief Creates a new menu
  */
-EAPI Efreet_Menu     *efreet_menu_new(const char *name);
+EFREET_API Efreet_Menu     *efreet_menu_new(const char *name);
 
 /**
  * @brief Override which file is used for menu creation
@@ -74,7 +74,7 @@ EAPI Efreet_Menu     *efreet_menu_new(const char *name);
  * This file is only used if it exists, else the standard files will be used
  * for the menu.
  */
-EAPI void             efreet_menu_file_set(const char *file);
+EFREET_API void             efreet_menu_file_set(const char *file);
 
 /**
  * Creates the Efreet_Menu representation of the default menu or
@@ -84,14 +84,14 @@ EAPI void             efreet_menu_file_set(const char *file);
  *
  * @deprecated
  */
-EFREET_DEPRECATED_API EAPI void             efreet_menu_async_get(Efreet_Menu_Cb func, const void *data);
+EFREET_DEPRECATED_API EFREET_API void             efreet_menu_async_get(Efreet_Menu_Cb func, const void *data);
 
 /**
  * @return Returns the Efreet_Menu representation of the default menu or
  * NULL if none found
  * @brief Creates the default menu representation
  */
-EAPI Efreet_Menu     *efreet_menu_get(void);
+EFREET_API Efreet_Menu     *efreet_menu_get(void);
 
 /**
  * Parses the given .menu file and creates the menu representation, and
@@ -102,7 +102,7 @@ EAPI Efreet_Menu     *efreet_menu_get(void);
  *
  * @deprecated
  */
-EFREET_DEPRECATED_API EAPI void             efreet_menu_async_parse(const char *path, Efreet_Menu_Cb func, const void *data);
+EFREET_DEPRECATED_API EFREET_API void             efreet_menu_async_parse(const char *path, Efreet_Menu_Cb func, const void *data);
 
 /**
  * @param path The path of the menu to load
@@ -110,7 +110,7 @@ EFREET_DEPRECATED_API EAPI void             efreet_menu_async_parse(const char *
  * failure
  * @brief Parses the given .menu file and creates the menu representation
  */
-EAPI Efreet_Menu     *efreet_menu_parse(const char *path);
+EFREET_API Efreet_Menu     *efreet_menu_parse(const char *path);
 
 /**
  * @param menu The menu to work with
@@ -118,14 +118,14 @@ EAPI Efreet_Menu     *efreet_menu_parse(const char *path);
  * @return Returns 1 on success, 0 on failure
  * @brief Saves the menu to file
  */
-EAPI int              efreet_menu_save(Efreet_Menu *menu, const char *path);
+EFREET_API int              efreet_menu_save(Efreet_Menu *menu, const char *path);
 
 /**
  * @param menu The Efreet_Menu to free
  * @return Returns no value
  * @brief Frees the given structure (if refcount at 1 at the time of this call)
  */
-EAPI void             efreet_menu_free(Efreet_Menu *menu);
+EFREET_API void             efreet_menu_free(Efreet_Menu *menu);
 
 /**
  * @param menu The Efreet_Menu to reference
@@ -133,7 +133,7 @@ EAPI void             efreet_menu_free(Efreet_Menu *menu);
  * @brief Incriments refcount for the menu
  * @since 1.11
  */
-EAPI void             efreet_menu_ref(Efreet_Menu *menu);
+EFREET_API void             efreet_menu_ref(Efreet_Menu *menu);
 
 
 /**
@@ -142,7 +142,7 @@ EAPI void             efreet_menu_ref(Efreet_Menu *menu);
  * @brief Decrements refcount for the menu, and on 0 frees
  * @since 1.11
  */
-EAPI void             efreet_menu_unref(Efreet_Menu *menu);
+EFREET_API void             efreet_menu_unref(Efreet_Menu *menu);
 
 
 /**
@@ -153,7 +153,7 @@ EAPI void             efreet_menu_unref(Efreet_Menu *menu);
  * @brief Insert a desktop element in a menu structure. Only accepts desktop files
  * in default directories.
  */
-EAPI int              efreet_menu_desktop_insert(Efreet_Menu *menu,
+EFREET_API int              efreet_menu_desktop_insert(Efreet_Menu *menu,
                                                     Efreet_Desktop *desktop,
                                                     int pos);
 
@@ -164,7 +164,7 @@ EAPI int              efreet_menu_desktop_insert(Efreet_Menu *menu,
  * @brief Remove a desktop element in a menu structure. Only accepts desktop files
  * in default directories.
  */
-EAPI int              efreet_menu_desktop_remove(Efreet_Menu *menu,
+EFREET_API int              efreet_menu_desktop_remove(Efreet_Menu *menu,
                                                     Efreet_Desktop *desktop);
 
 
@@ -175,7 +175,7 @@ EAPI int              efreet_menu_desktop_remove(Efreet_Menu *menu,
  * @return Returns no value
  * @brief Dumps the contents of the menu to the command line
  */
-EAPI void             efreet_menu_dump(Efreet_Menu *menu, const char *indent);
+EFREET_API void             efreet_menu_dump(Efreet_Menu *menu, const char *indent);
 
 /**
  * @}

--- a/src/lib/efreet/efreet_mime.c
+++ b/src/lib/efreet/efreet_mime.c
@@ -417,19 +417,19 @@ efreet_internal_mime_shutdown(void)
    return _efreet_mime_init_count;
 }
 
-EAPI int
+EFREET_API int
 efreet_mime_init(void)
 {
    return efreet_init();
 }
 
-EAPI int
+EFREET_API int
 efreet_mime_shutdown(void)
 {
    return efreet_shutdown();
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_mime_type_get(const char *file)
 {
    const char *type = NULL;
@@ -455,7 +455,7 @@ efreet_mime_type_get(const char *file)
    return efreet_mime_fallback_check(file);
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_mime_type_icon_get(const char *mime, const char *theme, unsigned int size)
 {
    const char *icon = NULL;
@@ -534,7 +534,7 @@ efreet_mime_type_icon_get(const char *mime, const char *theme, unsigned int size
    return icon;
 }
 
-EAPI void
+EFREET_API void
 efreet_mime_type_cache_clear(void)
 {
    if (mime_icons)
@@ -545,21 +545,21 @@ efreet_mime_type_cache_clear(void)
    mime_icons = eina_hash_stringshared_new(EINA_FREE_CB(efreet_mime_icon_entry_head_free));
 }
 
-EAPI void
+EFREET_API void
 efreet_mime_type_cache_flush(void)
 {
    efreet_mime_icons_flush(ecore_loop_time_get());
 }
 
 
-EAPI const char *
+EFREET_API const char *
 efreet_mime_magic_type_get(const char *file)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(file, NULL);
    return efreet_mime_magic_check_priority(file, 0, 0);
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_mime_globs_type_get(const char *file)
 {
    char *sl, *p;
@@ -606,14 +606,14 @@ efreet_mime_globs_type_get(const char *file)
    return NULL;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_mime_special_type_get(const char *file)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(file, NULL);
    return efreet_mime_special_check(file);
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_mime_fallback_type_get(const char *file)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(file, NULL);

--- a/src/lib/efreet/efreet_private.h
+++ b/src/lib/efreet/efreet_private.h
@@ -1,31 +1,7 @@
 #ifndef EFREET_PRIVATE_H
 #define EFREET_PRIVATE_H
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <efreet_api.h>
 
 #ifdef ENABLE_NLS
 # include <libintl.h>
@@ -201,7 +177,7 @@ void efreet_icon_extensions_refresh(void);
 
 int efreet_menu_init(void);
 void efreet_menu_shutdown(void);
-EAPI Eina_List *efreet_default_dirs_get(const char *user_dir,
+EFREET_API Eina_List *efreet_default_dirs_get(const char *user_dir,
                                         Eina_List *system_dirs,
                                         const char *suffix);
 
@@ -223,10 +199,10 @@ int efreet_internal_trash_shutdown(void);
 const char *efreet_home_dir_get(void);
 void        efreet_dirs_reset(void);
 
-EAPI const char *efreet_lang_get(void);
-EAPI const char *efreet_lang_country_get(void);
-EAPI const char *efreet_lang_modifier_get(void);
-EAPI const char *efreet_language_get(void);
+EFREET_API const char *efreet_lang_get(void);
+EFREET_API const char *efreet_lang_country_get(void);
+EFREET_API const char *efreet_lang_modifier_get(void);
+EFREET_API const char *efreet_language_get(void);
 
 size_t efreet_array_cat(char *buffer, size_t size, const char *strs[]);
 
@@ -249,18 +225,15 @@ Efreet_Cache_Hash *efreet_cache_util_hash_string(const char *key);
 Efreet_Cache_Hash *efreet_cache_util_hash_array_string(const char *key);
 Efreet_Cache_Array_String *efreet_cache_util_names(const char *key);
 
-EAPI void efreet_cache_array_string_free(Efreet_Cache_Array_String *array);
+EFREET_API void efreet_cache_array_string_free(Efreet_Cache_Array_String *array);
 
-EAPI void efreet_hash_free(Eina_Hash *hash, Eina_Free_Cb free_cb);
-EAPI void efreet_setowner(const char *path);
-EAPI void efreet_fsetowner(int fd);
+EFREET_API void efreet_hash_free(Eina_Hash *hash, Eina_Free_Cb free_cb);
+EFREET_API void efreet_setowner(const char *path);
+EFREET_API void efreet_fsetowner(int fd);
 
-EAPI extern int efreet_cache_update;
+EFREET_API extern int efreet_cache_update;
 
-EAPI extern void (*_efreet_mime_update_func) (void);
-
-#undef EAPI
-#define EAPI
+EFREET_API extern void (*_efreet_mime_update_func) (void);
 
 /**
  * @}

--- a/src/lib/efreet/efreet_trash.c
+++ b/src/lib/efreet/efreet_trash.c
@@ -64,19 +64,19 @@ efreet_internal_trash_shutdown(void)
     return _efreet_trash_init_count;
 }
 
-EAPI int
+EFREET_API int
 efreet_trash_init(void)
 {
    return efreet_init();
 }
 
-EAPI int
+EFREET_API int
 efreet_trash_shutdown(void)
 {
    return efreet_shutdown();
 }
 
-EAPI const char*
+EFREET_API const char*
 efreet_trash_dir_get(const char *file)
 {
     char buf[PATH_MAX + PATH_MAX + 128];
@@ -171,7 +171,7 @@ efreet_trash_dir_get(const char *file)
     return trash_dir;
 }
 
-EAPI int
+EFREET_API int
 efreet_trash_delete_uri(Efreet_Uri *uri, int force_delete)
 {
     char dest[PATH_MAX];
@@ -258,7 +258,7 @@ efreet_trash_delete_uri(Efreet_Uri *uri, int force_delete)
     return 1;
 }
 
-EAPI int
+EFREET_API int
 efreet_trash_is_empty(void)
 {
     char buf[PATH_MAX];
@@ -269,7 +269,7 @@ efreet_trash_is_empty(void)
     return ecore_file_dir_is_empty(buf);
 }
 
-EAPI int
+EFREET_API int
 efreet_trash_empty_trash(void)
 {
     char buf[PATH_MAX];
@@ -286,7 +286,7 @@ efreet_trash_empty_trash(void)
     return 1;
 }
 
-EAPI Eina_List*
+EFREET_API Eina_List*
 efreet_trash_ls(void)
 {
     char *infofile;

--- a/src/lib/efreet/efreet_uri.c
+++ b/src/lib/efreet/efreet_uri.c
@@ -16,7 +16,7 @@
 
 /* The URI standard is at http://tools.ietf.org/html/std66 */
 
-EAPI Efreet_Uri *
+EFREET_API Efreet_Uri *
 efreet_uri_decode(const char *full_uri)
 {
     Efreet_Uri *uri;
@@ -87,7 +87,7 @@ efreet_uri_decode(const char *full_uri)
     return uri;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_uri_encode(Efreet_Uri *uri)
 {
     char dest[PATH_MAX * 3 + 4];
@@ -116,7 +116,7 @@ efreet_uri_encode(Efreet_Uri *uri)
     return eina_stringshare_add(dest);
 }
 
-EAPI void
+EFREET_API void
 efreet_uri_free(Efreet_Uri *uri)
 {
     if (!uri) return;

--- a/src/lib/efreet/efreet_uri.h
+++ b/src/lib/efreet/efreet_uri.h
@@ -38,7 +38,7 @@ struct Efreet_Uri
  * @note The resulting string will contain the protocol and the path but not
  * the hostname, as many apps doesn't handle it.
  */
-EAPI const char *efreet_uri_encode(Efreet_Uri *uri);
+EFREET_API const char *efreet_uri_encode(Efreet_Uri *uri);
 
 /**
  * @param val a valid uri string to parse
@@ -47,13 +47,13 @@ EAPI const char *efreet_uri_encode(Efreet_Uri *uri);
  * hostname in the uri then the hostname parameter will be NULL. All the uri
  * escaped chars will be converted to normal.
  */
-EAPI Efreet_Uri *efreet_uri_decode(const char *val);
+EFREET_API Efreet_Uri *efreet_uri_decode(const char *val);
 
 /**
  * @param uri The uri to free
  * @brief Free the given uri structure.
  */
-EAPI void        efreet_uri_free(Efreet_Uri *uri);
+EFREET_API void        efreet_uri_free(Efreet_Uri *uri);
 
 
 /**

--- a/src/lib/efreet/efreet_utils.c
+++ b/src/lib/efreet/efreet_utils.c
@@ -95,7 +95,7 @@ efreet_util_path_in_default(const char *section, const char *path)
     return ret;
 }
 
-EAPI const char *
+EFREET_API const char *
 efreet_util_path_to_file_id(const char *path)
 {
     size_t len, len2;
@@ -140,21 +140,21 @@ efreet_util_path_to_file_id(const char *path)
     return file_id;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_desktop_mime_list(const char *mime)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(mime, NULL);
     return efreet_util_cache_list("mime_types", mime);
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_util_desktop_wm_class_find(const char *wmname, const char *wmclass)
 {
     EINA_SAFETY_ON_TRUE_RETURN_VAL((!wmname) && (!wmclass), NULL);
     return efreet_util_cache_find("startup_wm_class", wmname, wmclass);
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_util_desktop_file_id_find(const char *file_id)
 {
     Efreet_Cache_Hash *hash;
@@ -240,7 +240,7 @@ efreet_util_cmd_args_get(const char *cmd)
    return args;
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_util_desktop_exec_find(const char *exec)
 {
     Efreet_Cache_Hash *hash = NULL;
@@ -322,28 +322,28 @@ done:
     return bestret;
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_util_desktop_name_find(const char *name)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(name, NULL);
     return efreet_util_cache_find("name", name, NULL);
 }
 
-EAPI Efreet_Desktop *
+EFREET_API Efreet_Desktop *
 efreet_util_desktop_generic_name_find(const char *generic_name)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(generic_name, NULL);
     return efreet_util_cache_find("generic_name", generic_name, NULL);
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_desktop_name_glob_list(const char *glob)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(glob, NULL);
     return efreet_util_cache_glob_list("name", glob);
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_desktop_exec_glob_list(const char *glob)
 {
     Efreet_Cache_Hash *hash = NULL;
@@ -390,21 +390,21 @@ efreet_util_desktop_exec_glob_list(const char *glob)
     return ret;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_desktop_generic_name_glob_list(const char *glob)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(glob, NULL);
     return efreet_util_cache_glob_list("generic_name", glob);
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_desktop_comment_glob_list(const char *glob)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(glob, NULL);
     return efreet_util_cache_glob_list("comment", glob);
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_desktop_categories_list(void)
 {
     Efreet_Cache_Array_String *array;
@@ -418,14 +418,14 @@ efreet_util_desktop_categories_list(void)
     return ret;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_desktop_category_list(const char *category)
 {
     EINA_SAFETY_ON_NULL_RETURN_VAL(category, NULL);
     return efreet_util_cache_list("categories", category);
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_desktop_environments_list(void)
 {
     Efreet_Cache_Array_String *array;
@@ -454,7 +454,7 @@ efreet_util_glob_match(const char *str, const char *glob)
     return 0;
 }
 
-EAPI Eina_List *
+EFREET_API Eina_List *
 efreet_util_menus_find(void)
 {
     Eina_List *menus = NULL;
@@ -599,9 +599,9 @@ efreet_util_cache_glob_list(const char *search, const char *what)
 }
 
 /*
- * Needs EAPI because of helper binaries
+ * Needs EFREET_API because of helper binaries
  */
-EAPI void
+EFREET_API void
 efreet_hash_free(Eina_Hash *hash, Eina_Free_Cb free_cb)
 {
     eina_hash_free_cb_set(hash, free_cb);

--- a/src/lib/efreet/efreet_utils.h
+++ b/src/lib/efreet/efreet_utils.h
@@ -20,7 +20,7 @@
  *
  * @return File id for path or NULL
  */
-EAPI const char *efreet_util_path_to_file_id(const char *path);
+EFREET_API const char *efreet_util_path_to_file_id(const char *path);
 
 
 /**
@@ -31,7 +31,7 @@ EAPI const char *efreet_util_path_to_file_id(const char *path);
  * @param mime the mime type
  * @return a list of desktops
  */
-EAPI Eina_List *efreet_util_desktop_mime_list(const char *mime);
+EFREET_API Eina_List *efreet_util_desktop_mime_list(const char *mime);
 
 
 /**
@@ -43,7 +43,7 @@ EAPI Eina_List *efreet_util_desktop_mime_list(const char *mime);
  * @param wmclass the wm class
  * @return a list of desktops
  */
-EAPI Efreet_Desktop *efreet_util_desktop_wm_class_find(const char *wmname, const char *wmclass);
+EFREET_API Efreet_Desktop *efreet_util_desktop_wm_class_find(const char *wmname, const char *wmclass);
 
 /**
  * Find a desktop by file id
@@ -53,7 +53,7 @@ EAPI Efreet_Desktop *efreet_util_desktop_wm_class_find(const char *wmname, const
  * @param file_id the file id
  * @return a desktop
  */
-EAPI Efreet_Desktop *efreet_util_desktop_file_id_find(const char *file_id);
+EFREET_API Efreet_Desktop *efreet_util_desktop_file_id_find(const char *file_id);
 
 /**
  * Find a desktop by exec
@@ -63,7 +63,7 @@ EAPI Efreet_Desktop *efreet_util_desktop_file_id_find(const char *file_id);
  * @param exec the exec name
  * @return a desktop
  */
-EAPI Efreet_Desktop *efreet_util_desktop_exec_find(const char *exec);
+EFREET_API Efreet_Desktop *efreet_util_desktop_exec_find(const char *exec);
 
 /**
  * Find a desktop by name
@@ -73,7 +73,7 @@ EAPI Efreet_Desktop *efreet_util_desktop_exec_find(const char *exec);
  * @param name the name
  * @return a desktop
  */
-EAPI Efreet_Desktop *efreet_util_desktop_name_find(const char *name);
+EFREET_API Efreet_Desktop *efreet_util_desktop_name_find(const char *name);
 
 /**
  * Find a desktop by generic name
@@ -83,7 +83,7 @@ EAPI Efreet_Desktop *efreet_util_desktop_name_find(const char *name);
  * @param generic_name the generic name
  * @return a desktop
  */
-EAPI Efreet_Desktop *efreet_util_desktop_generic_name_find(const char *generic_name);
+EFREET_API Efreet_Desktop *efreet_util_desktop_generic_name_find(const char *generic_name);
 
 
 /**
@@ -94,7 +94,7 @@ EAPI Efreet_Desktop *efreet_util_desktop_generic_name_find(const char *generic_n
  * @param glob the pattern to match
  * @return a list of desktops
  */
-EAPI Eina_List *efreet_util_desktop_name_glob_list(const char *glob);
+EFREET_API Eina_List *efreet_util_desktop_name_glob_list(const char *glob);
 
 /**
  * Find all desktops where exec matches a glob pattern
@@ -104,7 +104,7 @@ EAPI Eina_List *efreet_util_desktop_name_glob_list(const char *glob);
  * @param glob the pattern to match
  * @return a list of desktops
  */
-EAPI Eina_List *efreet_util_desktop_exec_glob_list(const char *glob);
+EFREET_API Eina_List *efreet_util_desktop_exec_glob_list(const char *glob);
 
 /**
  * Find all desktops where generic name matches a glob pattern
@@ -114,7 +114,7 @@ EAPI Eina_List *efreet_util_desktop_exec_glob_list(const char *glob);
  * @param glob the pattern to match
  * @return a list of desktops
  */
-EAPI Eina_List *efreet_util_desktop_generic_name_glob_list(const char *glob);
+EFREET_API Eina_List *efreet_util_desktop_generic_name_glob_list(const char *glob);
 
 /**
  * Find all desktops where comment matches a glob pattern
@@ -124,7 +124,7 @@ EAPI Eina_List *efreet_util_desktop_generic_name_glob_list(const char *glob);
  * @param glob the pattern to match
  * @return a list of desktops
  */
-EAPI Eina_List *efreet_util_desktop_comment_glob_list(const char *glob);
+EFREET_API Eina_List *efreet_util_desktop_comment_glob_list(const char *glob);
 
 
 /**
@@ -133,7 +133,7 @@ EAPI Eina_List *efreet_util_desktop_comment_glob_list(const char *glob);
  *
  * @return an Eina_List of category names (const char *)
  */
-EAPI Eina_List *efreet_util_desktop_categories_list(void);
+EFREET_API Eina_List *efreet_util_desktop_categories_list(void);
 
 /**
  * Find all desktops in a given category
@@ -143,14 +143,14 @@ EAPI Eina_List *efreet_util_desktop_categories_list(void);
  * @param category the category name
  * @return a list of desktops
  */
-EAPI Eina_List *efreet_util_desktop_category_list(const char *category);
+EFREET_API Eina_List *efreet_util_desktop_category_list(const char *category);
 
 
 /**
  * Returns a list of .menu files found in the various config dirs.
  * @return An eina list of menu file paths (const char *). This must be freed with EINA_LIST_FREE.
  */
-EAPI Eina_List *efreet_util_menus_find(void);
+EFREET_API Eina_List *efreet_util_menus_find(void);
 
 /**
  * Find all known desktop environments
@@ -159,7 +159,7 @@ EAPI Eina_List *efreet_util_menus_find(void);
  *
  * @return an Eina_List of desktop environments names (const char *)
  */
-EAPI Eina_List *efreet_util_desktop_environments_list(void);
+EFREET_API Eina_List *efreet_util_desktop_environments_list(void);
 
 
 /**

--- a/src/lib/efreet/meson.build
+++ b/src/lib/efreet/meson.build
@@ -41,7 +41,7 @@ efreet_lib = library('efreet',
     dependencies: efreet_pub_deps + efreet_ext_deps + efreet_deps,
     include_directories : config_dir + [include_directories('.')],
     install: true,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DEFREET_BUILD'],
     version : meson.project_version()
 )
 


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.