### PR TITLE
[elput] Use ELPUT_API instead of EAPI

### DIFF
--- a/src/lib/elput/Elput.h
+++ b/src/lib/elput/Elput.h
@@ -4,19 +4,7 @@
 # ifdef EFL_BETA_API_SUPPORT
 #  include <Eina.h>
 
-#  ifdef EAPI
-#   undef EAPI
-#  endif
-
-#  ifdef __GNUC__
-#   if __GNUC__ >= 4
-#    define EAPI __attribute__ ((visibility("default")))
-#   else
-#    define EAPI
-#   endif
-#  else
-#   define EAPI
-#  endif
+#  include <elput_api.h>
 
 typedef enum
 {
@@ -125,17 +113,17 @@ typedef struct _Elput_Event_Switch
 } Elput_Event_Switch;
 
 
-EAPI extern int ELPUT_EVENT_SEAT_CAPS;
-EAPI extern int ELPUT_EVENT_SEAT_FRAME;
-EAPI extern int ELPUT_EVENT_MODIFIERS_SEND;
-EAPI extern int ELPUT_EVENT_DEVICE_CHANGE;
-EAPI extern int ELPUT_EVENT_SESSION_ACTIVE;
+ELPUT_API extern int ELPUT_EVENT_SEAT_CAPS;
+ELPUT_API extern int ELPUT_EVENT_SEAT_FRAME;
+ELPUT_API extern int ELPUT_EVENT_MODIFIERS_SEND;
+ELPUT_API extern int ELPUT_EVENT_DEVICE_CHANGE;
+ELPUT_API extern int ELPUT_EVENT_SESSION_ACTIVE;
 
 /** @since 1.19 */
-EAPI extern int ELPUT_EVENT_POINTER_MOTION;
+ELPUT_API extern int ELPUT_EVENT_POINTER_MOTION;
 
 /** @since 1.21 */
-EAPI extern int ELPUT_EVENT_SWITCH;
+ELPUT_API extern int ELPUT_EVENT_SWITCH;
 
 /**
  * @file
@@ -168,7 +156,7 @@ EAPI extern int ELPUT_EVENT_SWITCH;
  * @ingroup Elput_Init_Group
  * @since 1.18
  */
-EAPI int elput_init(void);
+ELPUT_API int elput_init(void);
 
 /**
  * Shutdown the Elput library
@@ -179,7 +167,7 @@ EAPI int elput_init(void);
  * @ingroup Elput_Init_Group
  * @since 1.18
  */
-EAPI int elput_shutdown(void);
+ELPUT_API int elput_shutdown(void);
 
 /**
  * @defgroup Elput_Manager_Group Elput Manager
@@ -199,7 +187,7 @@ EAPI int elput_shutdown(void);
  * @ingroup Elput_Manager_Group
  * @since 1.18
  */
-EAPI Elput_Manager *elput_manager_connect(const char *seat, unsigned int tty);
+ELPUT_API Elput_Manager *elput_manager_connect(const char *seat, unsigned int tty);
 
 /**
  * Disconnect an input manager
@@ -209,7 +197,7 @@ EAPI Elput_Manager *elput_manager_connect(const char *seat, unsigned int tty);
  * @ingroup Elput_Manager_Group
  * @since 1.18
  */
-EAPI void elput_manager_disconnect(Elput_Manager *manager);
+ELPUT_API void elput_manager_disconnect(Elput_Manager *manager);
 
 /**
  * Request input manager to open a file
@@ -223,7 +211,7 @@ EAPI void elput_manager_disconnect(Elput_Manager *manager);
  * @ingroup Elput_Manager_Group
  * @since 1.18
  */
-EAPI int elput_manager_open(Elput_Manager *manager, const char *path, int flags);
+ELPUT_API int elput_manager_open(Elput_Manager *manager, const char *path, int flags);
 
 /**
  * Request input manager to close a file
@@ -234,7 +222,7 @@ EAPI int elput_manager_open(Elput_Manager *manager, const char *path, int flags)
  * @ingroup Elput_Manager_Group
  * @since 1.18
  */
-EAPI void elput_manager_close(Elput_Manager *manager, int fd);
+ELPUT_API void elput_manager_close(Elput_Manager *manager, int fd);
 
 /**
  * Request to switch to a given vt
@@ -247,7 +235,7 @@ EAPI void elput_manager_close(Elput_Manager *manager, int fd);
  * @ingroup Elput_Manager_Group
  * @since 1.18
  */
-EAPI Eina_Bool elput_manager_vt_set(Elput_Manager *manager, int vt);
+ELPUT_API Eina_Bool elput_manager_vt_set(Elput_Manager *manager, int vt);
 
 /**
  * Get the list of seats from a manager
@@ -259,7 +247,7 @@ EAPI Eina_Bool elput_manager_vt_set(Elput_Manager *manager, int vt);
  * @ingroup Elput_Manager_Group
  * @since 1.18
  */
-EAPI const Eina_List *elput_manager_seats_get(Elput_Manager *manager);
+ELPUT_API const Eina_List *elput_manager_seats_get(Elput_Manager *manager);
 
 
 /**
@@ -277,7 +265,7 @@ EAPI const Eina_List *elput_manager_seats_get(Elput_Manager *manager);
  * @ingroup Elput_Manager_Group
  * @since 1.18
  */
-EAPI void elput_manager_window_set(Elput_Manager *manager, unsigned int window);
+ELPUT_API void elput_manager_window_set(Elput_Manager *manager, unsigned int window);
 
 /**
  * @defgroup Elput_Input_Group Elput input functions
@@ -295,7 +283,7 @@ EAPI void elput_manager_window_set(Elput_Manager *manager, unsigned int window);
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI Eina_Bool elput_input_init(Elput_Manager *manager);
+ELPUT_API Eina_Bool elput_input_init(Elput_Manager *manager);
 
 /**
  * Shutdown input
@@ -305,7 +293,7 @@ EAPI Eina_Bool elput_input_init(Elput_Manager *manager);
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI void elput_input_shutdown(Elput_Manager *manager);
+ELPUT_API void elput_input_shutdown(Elput_Manager *manager);
 
 /**
  * Get the pointer position on a given seat
@@ -318,7 +306,7 @@ EAPI void elput_input_shutdown(Elput_Manager *manager);
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI void elput_input_pointer_xy_get(Elput_Manager *manager, const char *seat, int *x, int *y);
+ELPUT_API void elput_input_pointer_xy_get(Elput_Manager *manager, const char *seat, int *x, int *y);
 
 /**
  * Set the pointer position on a given seat
@@ -331,7 +319,7 @@ EAPI void elput_input_pointer_xy_get(Elput_Manager *manager, const char *seat, i
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI void elput_input_pointer_xy_set(Elput_Manager *manager, const char *seat, int x, int y);
+ELPUT_API void elput_input_pointer_xy_set(Elput_Manager *manager, const char *seat, int x, int y);
 
 /**
  * Set the pointer left-handed mode
@@ -345,7 +333,7 @@ EAPI void elput_input_pointer_xy_set(Elput_Manager *manager, const char *seat, i
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI Eina_Bool elput_input_pointer_left_handed_set(Elput_Manager *manager, const char *seat, Eina_Bool left);
+ELPUT_API Eina_Bool elput_input_pointer_left_handed_set(Elput_Manager *manager, const char *seat, Eina_Bool left);
 
 /**
  * Set the maximum position of any existing mouse pointers
@@ -357,7 +345,7 @@ EAPI Eina_Bool elput_input_pointer_left_handed_set(Elput_Manager *manager, const
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI void elput_input_pointer_max_set(Elput_Manager *manager, int maxw, int maxh);
+ELPUT_API void elput_input_pointer_max_set(Elput_Manager *manager, int maxw, int maxh);
 
 /**
  * Set pointer value rotation
@@ -370,7 +358,7 @@ EAPI void elput_input_pointer_max_set(Elput_Manager *manager, int maxw, int maxh
  * @ingroup Elput_Input_Group
  * @since 1.20
  */
-EAPI Eina_Bool elput_input_pointer_rotation_set(Elput_Manager *manager, int rotation);
+ELPUT_API Eina_Bool elput_input_pointer_rotation_set(Elput_Manager *manager, int rotation);
 
 /**
  * Set tap-to-click status
@@ -384,7 +372,7 @@ EAPI Eina_Bool elput_input_pointer_rotation_set(Elput_Manager *manager, int rota
  * @ingroup Elput_Input_Group
  * @since 1.22
  */
-EAPI void elput_input_touch_tap_to_click_enabled_set(Elput_Manager *manager, const char *seat, Eina_Bool enabled);
+ELPUT_API void elput_input_touch_tap_to_click_enabled_set(Elput_Manager *manager, const char *seat, Eina_Bool enabled);
 
 /**
  * Calibrate input devices for given screen size
@@ -396,7 +384,7 @@ EAPI void elput_input_touch_tap_to_click_enabled_set(Elput_Manager *manager, con
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI void elput_input_devices_calibrate(Elput_Manager *manager, int w, int h);
+ELPUT_API void elput_input_devices_calibrate(Elput_Manager *manager, int w, int h);
 
 /**
  * Enable key remap functionality
@@ -409,7 +397,7 @@ EAPI void elput_input_devices_calibrate(Elput_Manager *manager, int w, int h);
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI Eina_Bool elput_input_key_remap_enable(Elput_Manager *manager, Eina_Bool enable);
+ELPUT_API Eina_Bool elput_input_key_remap_enable(Elput_Manager *manager, Eina_Bool enable);
 
 /**
  * Set a given set of keys as remapped keys
@@ -424,7 +412,7 @@ EAPI Eina_Bool elput_input_key_remap_enable(Elput_Manager *manager, Eina_Bool en
  * @ingroup Elput_Input_Group
  * @since 1.18
  */
-EAPI Eina_Bool elput_input_key_remap_set(Elput_Manager *manager, int *from_keys, int *to_keys, int num);
+ELPUT_API Eina_Bool elput_input_key_remap_set(Elput_Manager *manager, int *from_keys, int *to_keys, int num);
 
 /**
  * Set info to be used for keyboards
@@ -437,7 +425,7 @@ EAPI Eina_Bool elput_input_key_remap_set(Elput_Manager *manager, int *from_keys,
  * @ingroup Elput_Input_Group
  * @since 1.20
  */
-EAPI void elput_input_keyboard_info_set(Elput_Manager *manager, void *context, void *keymap, int group);
+ELPUT_API void elput_input_keyboard_info_set(Elput_Manager *manager, void *context, void *keymap, int group);
 
 /**
  * Set group layout to be used for keyboards
@@ -448,7 +436,7 @@ EAPI void elput_input_keyboard_info_set(Elput_Manager *manager, void *context, v
  * @ingroup Elput_Input_Group
  * @since 1.20
  */
-EAPI void elput_input_keyboard_group_set(Elput_Manager *manager, int group);
+ELPUT_API void elput_input_keyboard_group_set(Elput_Manager *manager, int group);
 
 /**
  * Set the pointer acceleration profile
@@ -460,7 +448,7 @@ EAPI void elput_input_keyboard_group_set(Elput_Manager *manager, int group);
  * @ingroup Elput_Input_Group
  * @since 1.19
  */
-EAPI void elput_input_pointer_accel_profile_set(Elput_Manager *manager, const char *seat, uint32_t profile);
+ELPUT_API void elput_input_pointer_accel_profile_set(Elput_Manager *manager, const char *seat, uint32_t profile);
 
 /**
  * Set the pointer acceleration speed
@@ -472,7 +460,7 @@ EAPI void elput_input_pointer_accel_profile_set(Elput_Manager *manager, const ch
  * @ingroup Elput_Input_Group
  * @since 1.21
  */
-EAPI void elput_input_pointer_accel_speed_set(Elput_Manager *manager, const char *seat, double speed);
+ELPUT_API void elput_input_pointer_accel_speed_set(Elput_Manager *manager, const char *seat, double speed);
 
 /**
  * @defgroup Elput_Touch_Group Configuration of touch devices
@@ -495,7 +483,7 @@ EAPI void elput_input_pointer_accel_speed_set(Elput_Manager *manager, const char
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_drag_enabled_set(Elput_Device *device, Eina_Bool enabled);
+ELPUT_API Eina_Bool elput_touch_drag_enabled_set(Elput_Device *device, Eina_Bool enabled);
 
 /**
  * Get if tap-and-drag is enabled on this device.
@@ -507,7 +495,7 @@ EAPI Eina_Bool elput_touch_drag_enabled_set(Elput_Device *device, Eina_Bool enab
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_drag_enabled_get(Elput_Device *device);
+ELPUT_API Eina_Bool elput_touch_drag_enabled_get(Elput_Device *device);
 
 /**
  * Enable or disable drag-lock during tapping on a device.
@@ -525,7 +513,7 @@ EAPI Eina_Bool elput_touch_drag_enabled_get(Elput_Device *device);
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_drag_lock_enabled_set(Elput_Device *device, Eina_Bool enabled);
+ELPUT_API Eina_Bool elput_touch_drag_lock_enabled_set(Elput_Device *device, Eina_Bool enabled);
 
 /**
  * Get if drag-lock is enabled on this device.
@@ -537,7 +525,7 @@ EAPI Eina_Bool elput_touch_drag_lock_enabled_set(Elput_Device *device, Eina_Bool
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_drag_lock_enabled_get(Elput_Device *device);
+ELPUT_API Eina_Bool elput_touch_drag_lock_enabled_get(Elput_Device *device);
 
 /**
  * Enable or disable touchpad dwt (disable-while-typing) feature.
@@ -553,7 +541,7 @@ EAPI Eina_Bool elput_touch_drag_lock_enabled_get(Elput_Device *device);
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_dwt_enabled_set(Elput_Device *device, Eina_Bool enabled);
+ELPUT_API Eina_Bool elput_touch_dwt_enabled_set(Elput_Device *device, Eina_Bool enabled);
 
 /**
  * Get if touchpad dwt (disable-while-typing) is enabled.
@@ -565,7 +553,7 @@ EAPI Eina_Bool elput_touch_dwt_enabled_set(Elput_Device *device, Eina_Bool enabl
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_dwt_enabled_get(Elput_Device *device);
+ELPUT_API Eina_Bool elput_touch_dwt_enabled_get(Elput_Device *device);
 
 /**
  * Set the scroll method used for this device.
@@ -581,7 +569,7 @@ EAPI Eina_Bool elput_touch_dwt_enabled_get(Elput_Device *device);
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_scroll_method_set(Elput_Device *device, int method);
+ELPUT_API Eina_Bool elput_touch_scroll_method_set(Elput_Device *device, int method);
 
 /**
  * Get the current scroll method set on a device
@@ -593,7 +581,7 @@ EAPI Eina_Bool elput_touch_scroll_method_set(Elput_Device *device, int method);
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI int elput_touch_scroll_method_get(Elput_Device *device);
+ELPUT_API int elput_touch_scroll_method_get(Elput_Device *device);
 
 /**
  * Set the button click method for a device.
@@ -609,7 +597,7 @@ EAPI int elput_touch_scroll_method_get(Elput_Device *device);
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_click_method_set(Elput_Device *device, int method);
+ELPUT_API Eina_Bool elput_touch_click_method_set(Elput_Device *device, int method);
 
 /**
  * Get the current button click method for a device
@@ -621,7 +609,7 @@ EAPI Eina_Bool elput_touch_click_method_set(Elput_Device *device, int method);
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI int elput_touch_click_method_get(Elput_Device *device);
+ELPUT_API int elput_touch_click_method_get(Elput_Device *device);
 
 /**
  * Enable or disable tap-to-click on a given device
@@ -634,7 +622,7 @@ EAPI int elput_touch_click_method_get(Elput_Device *device);
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_tap_enabled_set(Elput_Device *device, Eina_Bool enabled);
+ELPUT_API Eina_Bool elput_touch_tap_enabled_set(Elput_Device *device, Eina_Bool enabled);
 
 /**
  * Get if tap-to-click is enabled on a given device
@@ -646,7 +634,7 @@ EAPI Eina_Bool elput_touch_tap_enabled_set(Elput_Device *device, Eina_Bool enabl
  * @ingroup Elput_Touch_Group
  * @since 1.19
  */
-EAPI Eina_Bool elput_touch_tap_enabled_get(Elput_Device *device);
+ELPUT_API Eina_Bool elput_touch_tap_enabled_get(Elput_Device *device);
 
 
 /**
@@ -662,7 +650,7 @@ EAPI Eina_Bool elput_touch_tap_enabled_get(Elput_Device *device);
  * @ingroup Elput_Device_Group
  * @since 1.20
  */
-EAPI Elput_Seat *elput_device_seat_get(const Elput_Device *dev);
+ELPUT_API Elput_Seat *elput_device_seat_get(const Elput_Device *dev);
 
 /**
  * Get the caps for a device
@@ -671,7 +659,7 @@ EAPI Elput_Seat *elput_device_seat_get(const Elput_Device *dev);
  * @ingroup Elput_Device_Group
  * @since 1.20
  */
-EAPI Elput_Device_Caps elput_device_caps_get(const Elput_Device *dev);
+ELPUT_API Elput_Device_Caps elput_device_caps_get(const Elput_Device *dev);
 
 /**
  * Return the output name associated with a given device
@@ -683,7 +671,7 @@ EAPI Elput_Device_Caps elput_device_caps_get(const Elput_Device *dev);
  * @ingroup Elput_Device_Group
  * @since 1.20
  */
-EAPI Eina_Stringshare *elput_device_output_name_get(Elput_Device *device);
+ELPUT_API Eina_Stringshare *elput_device_output_name_get(Elput_Device *device);
 
 /**
  * @defgroup Elput_Seat_Group Elput seat functions
@@ -701,7 +689,7 @@ EAPI Eina_Stringshare *elput_device_output_name_get(Elput_Device *device);
  * @ingroup Elput_Seat_Group
  * @since 1.20
  */
-EAPI const Eina_List *elput_seat_devices_get(const Elput_Seat *seat);
+ELPUT_API const Eina_List *elput_seat_devices_get(const Elput_Seat *seat);
 
 /**
  * Get the name of a given seat
@@ -713,7 +701,7 @@ EAPI const Eina_List *elput_seat_devices_get(const Elput_Seat *seat);
  * @ingroup Elput_Seat_Group
  * @since 1.20
  */
-EAPI Eina_Stringshare *elput_seat_name_get(const Elput_Seat *seat);
+ELPUT_API Eina_Stringshare *elput_seat_name_get(const Elput_Seat *seat);
 
 /**
  * Get the manager of a given seat
@@ -725,10 +713,7 @@ EAPI Eina_Stringshare *elput_seat_name_get(const Elput_Seat *seat);
  * @ingroup Elput_Seat_Group
  * @since 1.20
  */
-EAPI Elput_Manager *elput_seat_manager_get(const Elput_Seat *seat);
+ELPUT_API Elput_Manager *elput_seat_manager_get(const Elput_Seat *seat);
 # endif
-
-# undef EAPI
-# define EAPI
 
 #endif

--- a/src/lib/elput/elput.c
+++ b/src/lib/elput/elput.c
@@ -6,16 +6,16 @@ static int _elput_init_count = 0;
 /* external variables */
 int _elput_log_dom = -1;
 
-EAPI int ELPUT_EVENT_SEAT_CAPS = 0;
-EAPI int ELPUT_EVENT_SEAT_FRAME = 0;
-EAPI int ELPUT_EVENT_KEYMAP_SEND = 0;
-EAPI int ELPUT_EVENT_MODIFIERS_SEND = 0;
-EAPI int ELPUT_EVENT_DEVICE_CHANGE = 0;
-EAPI int ELPUT_EVENT_SESSION_ACTIVE = 0;
-EAPI int ELPUT_EVENT_POINTER_MOTION = 0;
-EAPI int ELPUT_EVENT_SWITCH = 0;
+ELPUT_API int ELPUT_EVENT_SEAT_CAPS = 0;
+ELPUT_API int ELPUT_EVENT_SEAT_FRAME = 0;
+ELPUT_API int ELPUT_EVENT_KEYMAP_SEND = 0;
+ELPUT_API int ELPUT_EVENT_MODIFIERS_SEND = 0;
+ELPUT_API int ELPUT_EVENT_DEVICE_CHANGE = 0;
+ELPUT_API int ELPUT_EVENT_SESSION_ACTIVE = 0;
+ELPUT_API int ELPUT_EVENT_POINTER_MOTION = 0;
+ELPUT_API int ELPUT_EVENT_SWITCH = 0;
 
-EAPI int
+ELPUT_API int
 elput_init(void)
 {
    if (++_elput_init_count != 1) return _elput_init_count;
@@ -55,7 +55,7 @@ eina_err:
    return --_elput_init_count;
 }
 
-EAPI int
+ELPUT_API int
 elput_shutdown(void)
 {
    if (_elput_init_count < 1) return 0;

--- a/src/lib/elput/elput_api.h
+++ b/src/lib/elput/elput_api.h
@@ -6,7 +6,7 @@
 #endif
 
 #ifdef _WIN32
-# ifndef EFL_STATIC
+# ifndef ELPUT_STATIC
 #  ifdef ELPUT_BUILD
 #   define ELPUT_API __declspec(dllexport)
 #  else

--- a/src/lib/elput/elput_api.h
+++ b/src/lib/elput/elput_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ELPUT_API_H
+#define _EFL_ELPUT_API_H
+
+#ifdef ELPUT_API
+#error ELPUT_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_STATIC
+#  ifdef ELPUT_BUILD
+#   define ELPUT_API __declspec(dllexport)
+#  else
+#   define ELPUT_API __declspec(dllimport)
+#  endif
+# else
+#  define ELPUT_API
+# endif
+# define ELPUT_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ELPUT_API __attribute__ ((visibility("default")))
+#   define ELPUT_API_WEAK __attribute__ ((weak))
+#  else
+#   define ELPUT_API
+#   define ELPUT_API_WEAK
+#  endif
+# else
+#  define ELPUT_API
+#  define ELPUT_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/elput/elput_input.c
+++ b/src/lib/elput/elput_input.c
@@ -448,7 +448,7 @@ _elput_input_disable(Elput_Manager *manager)
    manager->input.suspended = EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_input_init(Elput_Manager *manager)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(manager, EINA_FALSE);
@@ -463,7 +463,7 @@ elput_input_init(Elput_Manager *manager)
    return !!manager->input.thread;
 }
 
-EAPI void
+ELPUT_API void
 elput_input_shutdown(Elput_Manager *manager)
 {
    Elput_Seat *seat;
@@ -485,7 +485,7 @@ elput_input_shutdown(Elput_Manager *manager)
      }
 }
 
-EAPI void
+ELPUT_API void
 elput_input_pointer_xy_get(Elput_Manager *manager, const char *seat, int *x, int *y)
 {
    Elput_Seat *eseat;
@@ -508,7 +508,7 @@ elput_input_pointer_xy_get(Elput_Manager *manager, const char *seat, int *x, int
      }
 }
 
-EAPI void
+ELPUT_API void
 elput_input_pointer_xy_set(Elput_Manager *manager, const char *seat, int x, int y)
 {
    Elput_Seat *eseat;
@@ -549,7 +549,7 @@ elput_input_pointer_xy_set(Elput_Manager *manager, const char *seat, int x, int 
      }
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_input_pointer_left_handed_set(Elput_Manager *manager, const char *seat, Eina_Bool left)
 {
    Elput_Seat *eseat;
@@ -590,7 +590,7 @@ elput_input_pointer_left_handed_set(Elput_Manager *manager, const char *seat, Ei
    return EINA_TRUE;
 }
 
-EAPI void
+ELPUT_API void
 elput_input_pointer_max_set(Elput_Manager *manager, int maxw, int maxh)
 {
    EINA_SAFETY_ON_NULL_RETURN(manager);
@@ -598,7 +598,7 @@ elput_input_pointer_max_set(Elput_Manager *manager, int maxw, int maxh)
    manager->input.pointer_h = maxh;
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_input_pointer_rotation_set(Elput_Manager *manager, int rotation)
 {
    Elput_Seat *eseat;
@@ -649,7 +649,7 @@ elput_input_pointer_rotation_set(Elput_Manager *manager, int rotation)
    return EINA_TRUE;
 }
 
-EAPI void
+ELPUT_API void
 elput_input_devices_calibrate(Elput_Manager *manager, int w, int h)
 {
    Elput_Seat *eseat;
@@ -672,7 +672,7 @@ elput_input_devices_calibrate(Elput_Manager *manager, int w, int h)
      }
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_input_key_remap_enable(Elput_Manager *manager, Eina_Bool enable)
 {
    Elput_Seat *eseat;
@@ -699,7 +699,7 @@ elput_input_key_remap_enable(Elput_Manager *manager, Eina_Bool enable)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_input_key_remap_set(Elput_Manager *manager, int *from_keys, int *to_keys, int num)
 {
    Elput_Seat *eseat;
@@ -738,7 +738,7 @@ elput_input_key_remap_set(Elput_Manager *manager, int *from_keys, int *to_keys, 
    return EINA_TRUE;
 }
 
-EAPI void
+ELPUT_API void
 elput_input_keyboard_info_set(Elput_Manager *manager, void *context, void *keymap, int group)
 {
    Eina_List *l;
@@ -761,7 +761,7 @@ elput_input_keyboard_info_set(Elput_Manager *manager, void *context, void *keyma
      _keyboard_keymap_update(seat);
 }
 
-EAPI void
+ELPUT_API void
 elput_input_keyboard_group_set(Elput_Manager *manager, int group)
 {
    Eina_List *l;
@@ -774,7 +774,7 @@ elput_input_keyboard_group_set(Elput_Manager *manager, int group)
      _keyboard_group_update(seat);
 }
 
-EAPI void
+ELPUT_API void
 elput_input_pointer_accel_profile_set(Elput_Manager *manager, const char *seat, uint32_t profile)
 {
    Elput_Seat *eseat;
@@ -809,7 +809,7 @@ elput_input_pointer_accel_profile_set(Elput_Manager *manager, const char *seat, 
      }
 }
 
-EAPI void
+ELPUT_API void
 elput_input_pointer_accel_speed_set(Elput_Manager *manager, const char *seat, double speed)
 {
    Elput_Seat *eseat;
@@ -847,7 +847,7 @@ elput_input_pointer_accel_speed_set(Elput_Manager *manager, const char *seat, do
      }
 }
 
-EAPI void
+ELPUT_API void
 elput_input_touch_tap_to_click_enabled_set(Elput_Manager *manager, const char *seat, Eina_Bool enabled)
 {
    Elput_Seat *eseat;
@@ -885,21 +885,21 @@ elput_input_touch_tap_to_click_enabled_set(Elput_Manager *manager, const char *s
      }
 }
 
-EAPI Elput_Seat *
+ELPUT_API Elput_Seat *
 elput_device_seat_get(const Elput_Device *dev)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(dev, NULL);
    return dev->seat;
 }
 
-EAPI Elput_Device_Caps
+ELPUT_API Elput_Device_Caps
 elput_device_caps_get(const Elput_Device *dev)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(dev, 0);
    return dev->caps;
 }
 
-EAPI Eina_Stringshare *
+ELPUT_API Eina_Stringshare *
 elput_device_output_name_get(Elput_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, NULL);
@@ -907,21 +907,21 @@ elput_device_output_name_get(Elput_Device *device)
    return device->output_name;
 }
 
-EAPI const Eina_List *
+ELPUT_API const Eina_List *
 elput_seat_devices_get(const Elput_Seat *seat)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(seat, NULL);
    return seat->devices;
 }
 
-EAPI Eina_Stringshare *
+ELPUT_API Eina_Stringshare *
 elput_seat_name_get(const Elput_Seat *seat)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(seat, NULL);
    return seat->name;
 }
 
-EAPI Elput_Manager *
+ELPUT_API Elput_Manager *
 elput_seat_manager_get(const Elput_Seat *seat)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(seat, NULL);

--- a/src/lib/elput/elput_manager.c
+++ b/src/lib/elput/elput_manager.c
@@ -34,7 +34,7 @@ _cb_key_down(void *data, int type EINA_UNUSED, void *event)
    return ECORE_CALLBACK_RENEW;
 }
 
-EAPI Elput_Manager *
+ELPUT_API Elput_Manager *
 elput_manager_connect(const char *seat, unsigned int tty)
 {
    Elput_Interface **it;
@@ -52,7 +52,7 @@ elput_manager_connect(const char *seat, unsigned int tty)
    return NULL;
 }
 
-EAPI void
+ELPUT_API void
 elput_manager_disconnect(Elput_Manager *manager)
 {
    EINA_SAFETY_ON_NULL_RETURN(manager);
@@ -69,7 +69,7 @@ elput_manager_disconnect(Elput_Manager *manager)
      manager->interface->disconnect(manager);
 }
 
-EAPI int
+ELPUT_API int
 elput_manager_open(Elput_Manager *manager, const char *path, int flags)
 {
    int ret = -1;
@@ -95,7 +95,7 @@ elput_manager_open(Elput_Manager *manager, const char *path, int flags)
    return ret;
 }
 
-EAPI void
+ELPUT_API void
 elput_manager_close(Elput_Manager *manager, int fd)
 {
    EINA_SAFETY_ON_NULL_RETURN(manager);
@@ -111,7 +111,7 @@ elput_manager_close(Elput_Manager *manager, int fd)
      manager->interface->close(manager, fd);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_manager_vt_set(Elput_Manager *manager, int vt)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(manager, EINA_FALSE);
@@ -124,7 +124,7 @@ elput_manager_vt_set(Elput_Manager *manager, int vt)
    return EINA_FALSE;
 }
 
-EAPI void
+ELPUT_API void
 elput_manager_window_set(Elput_Manager *manager, unsigned int window)
 {
    EINA_SAFETY_ON_NULL_RETURN(manager);
@@ -132,7 +132,7 @@ elput_manager_window_set(Elput_Manager *manager, unsigned int window)
    manager->window = window;
 }
 
-EAPI const Eina_List *
+ELPUT_API const Eina_List *
 elput_manager_seats_get(Elput_Manager *manager)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(manager, NULL);

--- a/src/lib/elput/elput_touch.c
+++ b/src/lib/elput/elput_touch.c
@@ -8,7 +8,7 @@ _check_status(int ret)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_drag_enabled_set(Elput_Device *device, Eina_Bool enabled)
 {
    int ret = -1;
@@ -31,7 +31,7 @@ elput_touch_drag_enabled_set(Elput_Device *device, Eina_Bool enabled)
    return _check_status(ret);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_drag_enabled_get(Elput_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);
@@ -39,7 +39,7 @@ elput_touch_drag_enabled_get(Elput_Device *device)
    return libinput_device_config_tap_get_drag_enabled(device->device);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_drag_lock_enabled_set(Elput_Device *device, Eina_Bool enabled)
 {
    int ret = -1;
@@ -62,7 +62,7 @@ elput_touch_drag_lock_enabled_set(Elput_Device *device, Eina_Bool enabled)
    return _check_status(ret);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_drag_lock_enabled_get(Elput_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);
@@ -70,7 +70,7 @@ elput_touch_drag_lock_enabled_get(Elput_Device *device)
    return libinput_device_config_tap_get_drag_lock_enabled(device->device);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_dwt_enabled_set(Elput_Device *device, Eina_Bool enabled)
 {
    int ret = -1;
@@ -96,7 +96,7 @@ elput_touch_dwt_enabled_set(Elput_Device *device, Eina_Bool enabled)
    return _check_status(ret);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_dwt_enabled_get(Elput_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);
@@ -107,7 +107,7 @@ elput_touch_dwt_enabled_get(Elput_Device *device)
    return libinput_device_config_dwt_get_enabled(device->device);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_scroll_method_set(Elput_Device *device, int method)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);
@@ -119,7 +119,7 @@ elput_touch_scroll_method_set(Elput_Device *device, int method)
    return EINA_FALSE;
 }
 
-EAPI int
+ELPUT_API int
 elput_touch_scroll_method_get(Elput_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, -1);
@@ -127,7 +127,7 @@ elput_touch_scroll_method_get(Elput_Device *device)
    return libinput_device_config_scroll_get_method(device->device);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_click_method_set(Elput_Device *device, int method)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);
@@ -139,7 +139,7 @@ elput_touch_click_method_set(Elput_Device *device, int method)
    return EINA_FALSE;
 }
 
-EAPI int
+ELPUT_API int
 elput_touch_click_method_get(Elput_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, -1);
@@ -147,7 +147,7 @@ elput_touch_click_method_get(Elput_Device *device)
    return libinput_device_config_click_get_method(device->device);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_tap_enabled_set(Elput_Device *device, Eina_Bool enabled)
 {
    int ret = -1;
@@ -170,7 +170,7 @@ elput_touch_tap_enabled_set(Elput_Device *device, Eina_Bool enabled)
    return _check_status(ret);
 }
 
-EAPI Eina_Bool
+ELPUT_API Eina_Bool
 elput_touch_tap_enabled_get(Elput_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);

--- a/src/lib/elput/meson.build
+++ b/src/lib/elput/meson.build
@@ -22,7 +22,7 @@ elput_ext_deps += dependency('libudev')
 
 elput_lib = library('elput',
     elput_src, pub_eo_file_target,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DELPUT_BUILD'],
     dependencies: elput_pub_deps + elput_deps + elput_ext_deps,
     include_directories : config_dir,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.