### PR TITLE
[elua] Use ELUA_API instead of EAPI

### DIFF
--- a/src/lib/elua/Elua.h
+++ b/src/lib/elua/Elua.h
@@ -26,31 +26,7 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <elua_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -116,7 +92,7 @@ typedef struct _Elua_State Elua_State;
  *
  * @ingroup Elua
  */
-EAPI int elua_init(void);
+ELUA_API int elua_init(void);
 
 /**
  * @brief Shutdown the Elua library.
@@ -129,7 +105,7 @@ EAPI int elua_init(void);
  *
  * @ingroup Elua
  */
-EAPI int elua_shutdown(void);
+ELUA_API int elua_shutdown(void);
 
 /**
  * @brief Create a new Elua state.
@@ -145,7 +121,7 @@ EAPI int elua_shutdown(void);
  *
  * @ingroup Elua
  */
-EAPI Elua_State *elua_state_new(const char *progname);
+ELUA_API Elua_State *elua_state_new(const char *progname);
 
 /**
  * @brief Retrieve an Elua state from a Lua state.
@@ -160,7 +136,7 @@ EAPI Elua_State *elua_state_new(const char *progname);
  *
  * @ingroup Elua
  */
-EAPI Elua_State *elua_state_from_lua_state_get(lua_State *L);
+ELUA_API Elua_State *elua_state_from_lua_state_get(lua_State *L);
 
 /**
  * @brief Destroy an Elua state.
@@ -172,7 +148,7 @@ EAPI Elua_State *elua_state_from_lua_state_get(lua_State *L);
  *
  * @ingroup Elua
  */
-EAPI void elua_state_free(Elua_State *es);
+ELUA_API void elua_state_free(Elua_State *es);
 
 /**
  * @brief Set the Elua directory paths.
@@ -201,7 +177,7 @@ EAPI void elua_state_free(Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI void elua_state_dirs_set(Elua_State *es, const char *core,
+ELUA_API void elua_state_dirs_set(Elua_State *es, const char *core,
                               const char *mods, const char *apps);
 
 /**
@@ -223,7 +199,7 @@ EAPI void elua_state_dirs_set(Elua_State *es, const char *core,
  *
  * @ingroup Elua
  */
-EAPI void elua_state_dirs_fill(Elua_State *es, Eina_Bool ignore_env);
+ELUA_API void elua_state_dirs_fill(Elua_State *es, Eina_Bool ignore_env);
 
 /**
  * @brief Retrieve the Elua core dir.
@@ -233,7 +209,7 @@ EAPI void elua_state_dirs_fill(Elua_State *es, Eina_Bool ignore_env);
  *
  * @ingroup Elua
  */
-EAPI Eina_Stringshare *elua_state_core_dir_get(const Elua_State *es);
+ELUA_API Eina_Stringshare *elua_state_core_dir_get(const Elua_State *es);
 
 /**
  * @brief Retrieve the Elua module dir.
@@ -243,7 +219,7 @@ EAPI Eina_Stringshare *elua_state_core_dir_get(const Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI Eina_Stringshare *elua_state_mod_dir_get(const Elua_State *es);
+ELUA_API Eina_Stringshare *elua_state_mod_dir_get(const Elua_State *es);
 
 /**
  * @brief Retrieve the Elua apps dir.
@@ -253,7 +229,7 @@ EAPI Eina_Stringshare *elua_state_mod_dir_get(const Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI Eina_Stringshare *elua_state_apps_dir_get(const Elua_State *es);
+ELUA_API Eina_Stringshare *elua_state_apps_dir_get(const Elua_State *es);
 
 /**
  * @brief Retrieve the prog name set on state creation.
@@ -263,7 +239,7 @@ EAPI Eina_Stringshare *elua_state_apps_dir_get(const Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI Eina_Stringshare *elua_state_prog_name_get(const Elua_State *es);
+ELUA_API Eina_Stringshare *elua_state_prog_name_get(const Elua_State *es);
 
 /**
  * @brief Add another path to look up modules in to the state.
@@ -274,7 +250,7 @@ EAPI Eina_Stringshare *elua_state_prog_name_get(const Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI void elua_state_include_path_add(Elua_State *es, const char *path);
+ELUA_API void elua_state_include_path_add(Elua_State *es, const char *path);
 
 /**
  * @brief Push the Elua "require" function onto the Lua stack.
@@ -284,7 +260,7 @@ EAPI void elua_state_include_path_add(Elua_State *es, const char *path);
  *
  * @ingroup Elua
  */
-EAPI Eina_Bool elua_state_require_ref_push(Elua_State *es);
+ELUA_API Eina_Bool elua_state_require_ref_push(Elua_State *es);
 
 /**
  * @brief Push the Elua app loader function onto the Lua stack.
@@ -294,7 +270,7 @@ EAPI Eina_Bool elua_state_require_ref_push(Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI Eina_Bool elua_state_appload_ref_push(Elua_State *es);
+ELUA_API Eina_Bool elua_state_appload_ref_push(Elua_State *es);
 
 /**
  * @brief Retrieve the Lua state from an Elua state.
@@ -308,7 +284,7 @@ EAPI Eina_Bool elua_state_appload_ref_push(Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI lua_State *elua_state_lua_state_get(const Elua_State *es);
+ELUA_API lua_State *elua_state_lua_state_get(const Elua_State *es);
 
 /**
  * @brief Set up the Elua state.
@@ -333,7 +309,7 @@ EAPI lua_State *elua_state_lua_state_get(const Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI Eina_Bool elua_state_setup(Elua_State *es);
+ELUA_API Eina_Bool elua_state_setup(Elua_State *es);
 
 /**
  * @brief Loads a file using Elua's own mmap-based IO.
@@ -350,7 +326,7 @@ EAPI Eina_Bool elua_state_setup(Elua_State *es);
  *
  * @ingroup Elua
  */
-EAPI int elua_io_loadfile(const Elua_State *es, const char *fname);
+ELUA_API int elua_io_loadfile(const Elua_State *es, const char *fname);
 
 /**
  * @brief Requires a module.
@@ -363,7 +339,7 @@ EAPI int elua_io_loadfile(const Elua_State *es, const char *fname);
  *
  * @ingroup Elua
  */
-EAPI Eina_Bool elua_util_require(Elua_State *es, const char *libname);
+ELUA_API Eina_Bool elua_util_require(Elua_State *es, const char *libname);
 
 /**
  * @brief Runs a file.
@@ -376,7 +352,7 @@ EAPI Eina_Bool elua_util_require(Elua_State *es, const char *libname);
  *
  * @ingroup Elua
  */
-EAPI Eina_Bool elua_util_file_run(Elua_State *es, const char *fname);
+ELUA_API Eina_Bool elua_util_file_run(Elua_State *es, const char *fname);
 
 /**
  * @brief Runs a string.
@@ -390,7 +366,7 @@ EAPI Eina_Bool elua_util_file_run(Elua_State *es, const char *fname);
  *
  * @ingroup Elua
  */
-EAPI Eina_Bool elua_util_string_run(Elua_State *es, const char *chunk,
+ELUA_API Eina_Bool elua_util_string_run(Elua_State *es, const char *chunk,
                                     const char *chname);
 
 /**
@@ -408,7 +384,7 @@ EAPI Eina_Bool elua_util_string_run(Elua_State *es, const char *chunk,
  *
  * @ingroup Elua
  */
-EAPI int elua_util_app_load(Elua_State *es, const char *appname);
+ELUA_API int elua_util_app_load(Elua_State *es, const char *appname);
 
 /**
  * @brief Runs a script.
@@ -437,7 +413,7 @@ EAPI int elua_util_app_load(Elua_State *es, const char *appname);
  *
  * @ingroup Elua
  */
-EAPI Eina_Bool elua_util_script_run(Elua_State *es, int argc, char **argv,
+ELUA_API Eina_Bool elua_util_script_run(Elua_State *es, int argc, char **argv,
                                     int n, int *quit);
 
 /**
@@ -454,7 +430,7 @@ EAPI Eina_Bool elua_util_script_run(Elua_State *es, int argc, char **argv,
  *
  * @ingroup Elua
  */
-EAPI int elua_util_error_report(const Elua_State *es, int status);
+ELUA_API int elua_util_error_report(const Elua_State *es, int status);
 
 /**
  * @}
@@ -465,8 +441,5 @@ EAPI int elua_util_error_report(const Elua_State *es, int status);
 #ifdef __cplusplus
 } // extern "C" {
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/elua/cache.c
+++ b/src/lib/elua/cache.c
@@ -141,7 +141,7 @@ getf_map(lua_State *L EINA_UNUSED, void *ud, size_t *size)
    return fmap;
 }
 
-EAPI int
+ELUA_API int
 elua_io_loadfile(const Elua_State *es, const char *fname)
 {
    Map_Stream s;

--- a/src/lib/elua/elua.c
+++ b/src/lib/elua/elua.c
@@ -11,7 +11,7 @@ static Eina_Prefix *_elua_pfx = NULL;
 static int _elua_init_counter = 0;
 int _elua_log_dom = -1;
 
-EAPI int
+ELUA_API int
 elua_init(void)
 {
    const char *dom = "elua";
@@ -43,7 +43,7 @@ elua_init(void)
    return ++_elua_init_counter;
 }
 
-EAPI int
+ELUA_API int
 elua_shutdown(void)
 {
    if (_elua_init_counter <= 0)
@@ -70,7 +70,7 @@ elua_shutdown(void)
    return _elua_init_counter;
 }
 
-EAPI Elua_State *
+ELUA_API Elua_State *
 elua_state_new(const char *progname)
 {
    Elua_State *ret = NULL;
@@ -107,7 +107,7 @@ elua_state_new(const char *progname)
    return ret;
 }
 
-EAPI void
+ELUA_API void
 elua_state_free(Elua_State *es)
 {
    void *data;
@@ -134,7 +134,7 @@ elua_state_free(Elua_State *es)
    free(es);
 }
 
-EAPI void
+ELUA_API void
 elua_state_dirs_set(Elua_State *es, const char *core, const char *mods,
                     const char *apps)
 {
@@ -163,7 +163,7 @@ elua_state_dirs_set(Elua_State *es, const char *core, const char *mods,
      }
 }
 
-EAPI void
+ELUA_API void
 elua_state_dirs_fill(Elua_State *es, Eina_Bool ignore_env)
 {
    const char *coredir = NULL, *moddir = NULL, *appsdir = NULL;
@@ -213,35 +213,35 @@ elua_state_dirs_fill(Elua_State *es, Eina_Bool ignore_env)
      }
 }
 
-EAPI Eina_Stringshare *
+ELUA_API Eina_Stringshare *
 elua_state_core_dir_get(const Elua_State *es)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, NULL);
    return es->coredir;
 }
 
-EAPI Eina_Stringshare *
+ELUA_API Eina_Stringshare *
 elua_state_mod_dir_get(const Elua_State *es)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, NULL);
    return es->moddir;
 }
 
-EAPI Eina_Stringshare *
+ELUA_API Eina_Stringshare *
 elua_state_apps_dir_get(const Elua_State *es)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, NULL);
    return es->appsdir;
 }
 
-EAPI Eina_Stringshare *
+ELUA_API Eina_Stringshare *
 elua_state_prog_name_get(const Elua_State *es)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, NULL);
    return es->progname;
 }
 
-EAPI void
+ELUA_API void
 elua_state_include_path_add(Elua_State *es, const char *path)
 {
    char *spath = NULL;
@@ -253,7 +253,7 @@ elua_state_include_path_add(Elua_State *es, const char *path)
    free(spath);
 }
 
-EAPI Eina_Bool
+ELUA_API Eina_Bool
 elua_state_require_ref_push(Elua_State *es)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, EINA_FALSE);
@@ -262,7 +262,7 @@ elua_state_require_ref_push(Elua_State *es)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ELUA_API Eina_Bool
 elua_state_appload_ref_push(Elua_State *es)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, EINA_FALSE);
@@ -271,14 +271,14 @@ elua_state_appload_ref_push(Elua_State *es)
    return EINA_TRUE;
 }
 
-EAPI lua_State *
+ELUA_API lua_State *
 elua_state_lua_state_get(const Elua_State *es)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, NULL);
    return es->luastate;
 }
 
-EAPI Elua_State *
+ELUA_API Elua_State *
 elua_state_from_lua_state_get(lua_State *L)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(L, NULL);
@@ -580,7 +580,7 @@ _elua_module_system_init(lua_State *L)
    return 2;
 }
 
-EAPI Eina_Bool
+ELUA_API Eina_Bool
 elua_state_setup(Elua_State *es)
 {
    Eina_Stringshare *data;
@@ -674,7 +674,7 @@ _elua_getargs(Elua_State *es, int argc, char **argv, int n)
    return narg;
 }
 
-EAPI Eina_Bool
+ELUA_API Eina_Bool
 elua_util_require(Elua_State *es, const char *libname)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, EINA_FALSE);
@@ -688,7 +688,7 @@ elua_util_require(Elua_State *es, const char *libname)
    return !elua_util_error_report(es, lua_pcall(es->luastate, 1, 0, 0));
 }
 
-EAPI Eina_Bool
+ELUA_API Eina_Bool
 elua_util_file_run(Elua_State *es, const char *fname)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, EINA_FALSE);
@@ -696,7 +696,7 @@ elua_util_file_run(Elua_State *es, const char *fname)
                                   || _elua_docall(es, 0, 1));
 }
 
-EAPI Eina_Bool
+ELUA_API Eina_Bool
 elua_util_string_run(Elua_State *es, const char *chunk, const char *chname)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, EINA_FALSE);
@@ -705,7 +705,7 @@ elua_util_string_run(Elua_State *es, const char *chunk, const char *chname)
                                       || _elua_docall(es, 0, 0));
 }
 
-EAPI int
+ELUA_API int
 elua_util_app_load(Elua_State *es, const char *appname)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(es, -1);
@@ -721,7 +721,7 @@ elua_util_app_load(Elua_State *es, const char *appname)
    return 0;
 }
 
-EAPI Eina_Bool
+ELUA_API Eina_Bool
 elua_util_script_run(Elua_State *es, int argc, char **argv, int n, int *quit)
 {
    int status, narg;
@@ -765,7 +765,7 @@ _elua_errmsg(const char *pname, const char *msg)
    ERR("%s%s%s", pname ? pname : "", pname ? ": " : "", msg);
 }
 
-EAPI int
+ELUA_API int
 elua_util_error_report(const Elua_State *es, int status)
 {
    EINA_SAFETY_ON_FALSE_RETURN_VAL(es, status);

--- a/src/lib/elua/elua_api.h
+++ b/src/lib/elua/elua_api.h
@@ -6,7 +6,7 @@
 #endif
 
 #ifdef _WIN32
-# ifndef EFL_STATIC
+# ifndef ELUA_STATIC
 #  ifdef ELUA_BUILD
 #   define ELUA_API __declspec(dllexport)
 #  else

--- a/src/lib/elua/elua_api.h
+++ b/src/lib/elua/elua_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ELUA_API_H
+#define _EFL_ELUA_API_H
+
+#ifdef ELUA_API
+#error ELUA_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_STATIC
+#  ifdef ELUA_BUILD
+#   define ELUA_API __declspec(dllexport)
+#  else
+#   define ELUA_API __declspec(dllimport)
+#  endif
+# else
+#  define ELUA_API
+# endif
+# define ELUA_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ELUA_API __attribute__ ((visibility("default")))
+#   define ELUA_API_WEAK __attribute__ ((weak))
+#  else
+#   define ELUA_API
+#   define ELUA_API_WEAK
+#  endif
+# else
+#  define ELUA_API
+#  define ELUA_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/elua/meson.build
+++ b/src/lib/elua/meson.build
@@ -21,7 +21,7 @@ elua_lib = library('elua',
     dependencies: elua_lib_deps + elua_deps + elua_pub_deps,
     include_directories : config_dir + [include_directories(join_paths('..','..'))],
     install: true,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DELUA_BUILD'],
     version : meson.project_version()
 )
 


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.