### PR TITLE
[ethumb] Use ETHUMB_API instead of EAPI

### DIFF
--- a/src/lib/ethumb/Ethumb.h
+++ b/src/lib/ethumb/Ethumb.h
@@ -4,31 +4,7 @@
 #include <Eina.h>
 #include <Efl_Config.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ethumb_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,7 +24,7 @@ extern "C" {
         int revision; /** < git revision (0 if a proper release or the git revision number Ethumb is built from) */
      } Ethumb_Version;
 
-   EAPI extern Ethumb_Version *ethumb_version;
+   ETHUMB_API extern Ethumb_Version *ethumb_version;
 
 /**
  * @page ethumb_main Ethumb
@@ -148,23 +124,23 @@ typedef void (*Ethumb_Generate_Cb)(void *data, Ethumb *e, Eina_Bool success);
  * @brief Initialize ethumb.
  * @return 1 or greater on success, 0 otherwise.
  */
-EAPI int ethumb_init(void);
+ETHUMB_API int ethumb_init(void);
 /**
  * @brief Shutdown ethumb, unloading all currently-loaded modules.
  * @return 0 if ethumb shuts down, an integer greater than 0 otherwise.
  */
-EAPI int ethumb_shutdown(void);
+ETHUMB_API int ethumb_shutdown(void);
 
 /**
  * @brief Create a new ethumb object.
  * return The newly-created ethumb object
  */
-EAPI Ethumb * ethumb_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
+ETHUMB_API Ethumb * ethumb_new(void) EINA_MALLOC EINA_WARN_UNUSED_RESULT;
 
 /**
  * @brief Free an ethumb object.
  */
-EAPI void ethumb_free(Ethumb *e);
+ETHUMB_API void ethumb_free(Ethumb *e);
 
 /**
  * @}
@@ -192,7 +168,7 @@ EAPI void ethumb_free(Ethumb *e);
  *
  * @return EINA_TRUE on success and EINA_FALSE on failure
  */
-EAPI Eina_Bool    ethumb_frame_set(Ethumb *e, const char *theme_file, const char *group, const char *swallow) EINA_ARG_NONNULL(1);
+ETHUMB_API Eina_Bool    ethumb_frame_set(Ethumb *e, const char *theme_file, const char *group, const char *swallow) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Retreives the current ethumb frame of and Ethumb instance.
@@ -202,7 +178,7 @@ EAPI Eina_Bool    ethumb_frame_set(Ethumb *e, const char *theme_file, const char
  * @param group will be setted with the edje group
  * @param swallow will be setted with the edje swallow
  */
-EAPI void         ethumb_frame_get(const Ethumb *e, const char **theme_file, const char **group, const char **swallow) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_frame_get(const Ethumb *e, const char **theme_file, const char **group, const char **swallow) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Set the ethumb thumbnails path
@@ -211,7 +187,7 @@ EAPI void         ethumb_frame_get(const Ethumb *e, const char **theme_file, con
  * @param path The thumbnails path
  *
  */
-EAPI void         ethumb_thumb_dir_path_set(Ethumb *e, const char *path) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_dir_path_set(Ethumb *e, const char *path) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Get the ethumb thumbnails path
@@ -220,7 +196,7 @@ EAPI void         ethumb_thumb_dir_path_set(Ethumb *e, const char *path) EINA_AR
  *
  * @return The thumbnails path for the current thumbnailer
  */
-EAPI const char  *ethumb_thumb_dir_path_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API const char  *ethumb_thumb_dir_path_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Set the thumbnails category
@@ -228,7 +204,7 @@ EAPI const char  *ethumb_thumb_dir_path_get(const Ethumb *e) EINA_WARN_UNUSED_RE
  * @param e handle of the current thumbnailer.
  * @param category the category to set
  */
-EAPI void         ethumb_thumb_category_set(Ethumb *e, const char *category) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_category_set(Ethumb *e, const char *category) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Get the thumbnails category
@@ -237,12 +213,12 @@ EAPI void         ethumb_thumb_category_set(Ethumb *e, const char *category) EIN
  *
  * @return the current thumbnailer thumbnails category
  */
-EAPI const char  *ethumb_thumb_category_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API const char  *ethumb_thumb_category_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
-EAPI void         ethumb_thumb_path_set(Ethumb *e, const char *path, const char *key) EINA_ARG_NONNULL(1);
-EAPI void         ethumb_thumb_path_get(Ethumb *e, const char **path, const char **key) EINA_ARG_NONNULL(1);
-EAPI void         ethumb_thumb_hash(Ethumb *e) EINA_ARG_NONNULL(1);
-EAPI void         ethumb_thumb_hash_copy(Ethumb *dst, const Ethumb *src) EINA_ARG_NONNULL(1, 2);
+ETHUMB_API void         ethumb_thumb_path_set(Ethumb *e, const char *path, const char *key) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_path_get(Ethumb *e, const char **path, const char **key) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_hash(Ethumb *e) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_hash_copy(Ethumb *dst, const Ethumb *src) EINA_ARG_NONNULL(1, 2);
 
 typedef enum _Ethumb_Thumb_FDO_Size
 {
@@ -277,7 +253,7 @@ typedef enum _Ethumb_Thumb_Orientation
   ETHUMB_THUMB_ORIENT_ORIGINAL  /**< use orientation from metadata (EXIF-only currently) */
 } Ethumb_Thumb_Orientation;
 
-EAPI void ethumb_thumb_fdo_set(Ethumb *e, Ethumb_Thumb_FDO_Size s) EINA_ARG_NONNULL(1);
+ETHUMB_API void ethumb_thumb_fdo_set(Ethumb *e, Ethumb_Thumb_FDO_Size s) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Set the size of thumbnails.
@@ -286,7 +262,7 @@ EAPI void ethumb_thumb_fdo_set(Ethumb *e, Ethumb_Thumb_FDO_Size s) EINA_ARG_NONN
  * @param tw Thumbnail width.
  * @param th Thumbnail height.
  */
-EAPI void ethumb_thumb_size_set(Ethumb *e, int tw, int th) EINA_ARG_NONNULL(1);
+ETHUMB_API void ethumb_thumb_size_set(Ethumb *e, int tw, int th) EINA_ARG_NONNULL(1);
 /**
  * @brief Get the size of thumbnails.
  *
@@ -294,7 +270,7 @@ EAPI void ethumb_thumb_size_set(Ethumb *e, int tw, int th) EINA_ARG_NONNULL(1);
  * @param[out] tw Pointer to an int to store the thumbnail width.
  * @param[out] th Pointer to an int to store the thumbnail height.
  */
-EAPI void ethumb_thumb_size_get(const Ethumb *e, int *tw, int *th) EINA_ARG_NONNULL(1);
+ETHUMB_API void ethumb_thumb_size_get(const Ethumb *e, int *tw, int *th) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Set the fileformat of the thumbnails
@@ -303,7 +279,7 @@ EAPI void ethumb_thumb_size_get(const Ethumb *e, int *tw, int *th) EINA_ARG_NONN
  *
  * @param e A pointer to an Ethumb object.
  */
-EAPI void                     ethumb_thumb_format_set(Ethumb *e, Ethumb_Thumb_Format f) EINA_ARG_NONNULL(1);
+ETHUMB_API void                     ethumb_thumb_format_set(Ethumb *e, Ethumb_Thumb_Format f) EINA_ARG_NONNULL(1);
 /**
  * @brief Get the fileformat of the thumbnails
  *
@@ -312,7 +288,7 @@ EAPI void                     ethumb_thumb_format_set(Ethumb *e, Ethumb_Thumb_Fo
  *
  * @see ethumb_thumb_format_set
  */
-EAPI Ethumb_Thumb_Format      ethumb_thumb_format_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API Ethumb_Thumb_Format      ethumb_thumb_format_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Set the aspect ratio policy.
@@ -324,14 +300,14 @@ EAPI Ethumb_Thumb_Format      ethumb_thumb_format_get(const Ethumb *e) EINA_WARN
  * @param e A pointer to an Ethumb object.
  * @param aspect  The new aspect ratio policy.
  */
-EAPI void                     ethumb_thumb_aspect_set(Ethumb *e, Ethumb_Thumb_Aspect aspect) EINA_ARG_NONNULL(1);
+ETHUMB_API void                     ethumb_thumb_aspect_set(Ethumb *e, Ethumb_Thumb_Aspect aspect) EINA_ARG_NONNULL(1);
 /**
  * @brief Get the aspect ratio policy.
  *
  * @param e A pointer to an Ethumb object.
  * @return The aspect ratio policy.
  */
-EAPI Ethumb_Thumb_Aspect      ethumb_thumb_aspect_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API Ethumb_Thumb_Aspect      ethumb_thumb_aspect_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Set the thumbnail rotation or flip.
@@ -339,17 +315,17 @@ EAPI Ethumb_Thumb_Aspect      ethumb_thumb_aspect_get(const Ethumb *e) EINA_WARN
  * @param e A pointer to an Ethumb object.
  * @param orientation The new orientation.
  */
-EAPI void                     ethumb_thumb_orientation_set(Ethumb *e, Ethumb_Thumb_Orientation orientation) EINA_ARG_NONNULL(1);
+ETHUMB_API void                     ethumb_thumb_orientation_set(Ethumb *e, Ethumb_Thumb_Orientation orientation) EINA_ARG_NONNULL(1);
 /**
  * @brief Get the thumbnail rotation.
  *
  * @param e A pointer to an Ethumb object.
  * @return The current rotation.
  */
-EAPI Ethumb_Thumb_Orientation ethumb_thumb_orientation_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API Ethumb_Thumb_Orientation ethumb_thumb_orientation_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
-EAPI void         ethumb_thumb_crop_align_set(Ethumb *e, float x, float y) EINA_ARG_NONNULL(1);
-EAPI void         ethumb_thumb_crop_align_get(const Ethumb *e, float *x, float *y) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_crop_align_set(Ethumb *e, float x, float y) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_crop_align_get(const Ethumb *e, float *x, float *y) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Set the thumbnail compression quality.
@@ -357,14 +333,14 @@ EAPI void         ethumb_thumb_crop_align_get(const Ethumb *e, float *x, float *
  * @param e A pointer to an Ethumb object.
  * @param quality Compression quality (from 0 to 100, 100 being the best; default is 80)
  */
-EAPI void         ethumb_thumb_quality_set(Ethumb *e, int quality) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_quality_set(Ethumb *e, int quality) EINA_ARG_NONNULL(1);
 /**
  * @brief Get the thumbnail compression quality.
  *
  * @param e A pointer to an Ethumb object.
  * @return The current compression quality (from 0 to 100, 100 being the best)
  */
-EAPI int          ethumb_thumb_quality_get(const Ethumb *e) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+ETHUMB_API int          ethumb_thumb_quality_get(const Ethumb *e) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief Set the compression rate
@@ -373,7 +349,7 @@ EAPI int          ethumb_thumb_quality_get(const Ethumb *e) EINA_ARG_NONNULL(1) 
  * @param compress the compression rate (in percentage)
  *
  */
-EAPI void         ethumb_thumb_compress_set(Ethumb *e, int compress) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_thumb_compress_set(Ethumb *e, int compress) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Get the compression rate
@@ -382,7 +358,7 @@ EAPI void         ethumb_thumb_compress_set(Ethumb *e, int compress) EINA_ARG_NO
  *
  * @return the compression rate (in percentage)
  */
-EAPI int          ethumb_thumb_compress_get(const Ethumb *e) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+ETHUMB_API int          ethumb_thumb_compress_get(const Ethumb *e) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
 /**
  * @brief set the video play start point
@@ -392,7 +368,7 @@ EAPI int          ethumb_thumb_compress_get(const Ethumb *e) EINA_ARG_NONNULL(1)
  * @param e handle of the current thumbnailer.
  * @param start the start point (float from 0.0 to 1.0)
  */
-EAPI void         ethumb_video_start_set(Ethumb *e, float start) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_video_start_set(Ethumb *e, float start) EINA_ARG_NONNULL(1);
 
 /**
  * @brief get the video play start point
@@ -403,23 +379,23 @@ EAPI void         ethumb_video_start_set(Ethumb *e, float start) EINA_ARG_NONNUL
  *
  * @return the start point (float from 0.0 to 1.0)
  */
-EAPI float        ethumb_video_start_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API float        ethumb_video_start_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Set the video time (duration) in seconds.
- * 
+ *
  * @param e handle of the current thumbnailer.
  * @param time the video duration in seconds
- */ 
-EAPI void         ethumb_video_time_set(Ethumb *e, float time) EINA_ARG_NONNULL(1);
+ */
+ETHUMB_API void         ethumb_video_time_set(Ethumb *e, float time) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Get the video time (duration) in seconds.
- * 
+ *
  * @param e handle of the current thumbnailer.
  * @return the video duration in seconds
- */ 
-EAPI float        ethumb_video_time_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ */
+ETHUMB_API float        ethumb_video_time_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Set the video frame interval, in seconds
@@ -432,7 +408,7 @@ EAPI float        ethumb_video_time_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT
  * @param e handle of the current thumbnailer.
  * @param interval the frame display interval in seconds
  */
-EAPI void         ethumb_video_interval_set(Ethumb *e, float interval) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_video_interval_set(Ethumb *e, float interval) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Get the video frame interval, in seconds
@@ -440,7 +416,7 @@ EAPI void         ethumb_video_interval_set(Ethumb *e, float interval) EINA_ARG_
  * @param e handle of the current thumbnailer.
  * @return the frame display interval in seconds
  */
-EAPI float        ethumb_video_interval_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API float        ethumb_video_interval_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Set the number of times the video loops (if applicable).
@@ -448,14 +424,14 @@ EAPI float        ethumb_video_interval_get(const Ethumb *e) EINA_WARN_UNUSED_RE
  * @param e A pointer to an Ethumb object.
  * @param ntimes The number of times the video loops.
  */
-EAPI void         ethumb_video_ntimes_set(Ethumb *e, unsigned int ntimes) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_video_ntimes_set(Ethumb *e, unsigned int ntimes) EINA_ARG_NONNULL(1);
 /**
  * @brief Get the number of times the video loops (if applicable).
  *
  * @param e A pointer to an Ethumb object.
  * @return The number of times the video loops.
  */
-EAPI unsigned int ethumb_video_ntimes_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API unsigned int ethumb_video_ntimes_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Set the thumbnail framerate.
@@ -463,14 +439,14 @@ EAPI unsigned int ethumb_video_ntimes_get(const Ethumb *e) EINA_WARN_UNUSED_RESU
  * @param e A pointer to an Ethumb object.
  * @param fps New framerate of the thumbnail (default 10).
  */
-EAPI void         ethumb_video_fps_set(Ethumb *e, unsigned int fps) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_video_fps_set(Ethumb *e, unsigned int fps) EINA_ARG_NONNULL(1);
 /**
  * @brief Get the thumbnail framerate.
  *
  * @param e A pointer to an Ethumb object.
  * @return Current framerate of the thumbnail.
  */
-EAPI unsigned int ethumb_video_fps_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API unsigned int ethumb_video_fps_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Set the page number to thumbnail in paged documents
@@ -478,7 +454,7 @@ EAPI unsigned int ethumb_video_fps_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT 
  * @param e handle of the current thumbnailer.
  * @param page the page number.
  */
-EAPI void         ethumb_document_page_set(Ethumb *e, unsigned int page) EINA_ARG_NONNULL(1);
+ETHUMB_API void         ethumb_document_page_set(Ethumb *e, unsigned int page) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Get the page number thumbnailed in paged documents
@@ -486,7 +462,7 @@ EAPI void         ethumb_document_page_set(Ethumb *e, unsigned int page) EINA_AR
  * @param e handle of the current thumbnailer.
  * @return the page number.
  */
-EAPI unsigned int ethumb_document_page_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API unsigned int ethumb_document_page_get(const Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 /**
  * @}
  */
@@ -505,7 +481,7 @@ EAPI unsigned int ethumb_document_page_get(const Ethumb *e) EINA_WARN_UNUSED_RES
  *            (EET or Edje for instance), @a key is the key used to locate the
  *            right resource inside the file. NULL if not applicable.
  */
-EAPI Eina_Bool ethumb_file_set(Ethumb *e, const char *path, const char *key) EINA_ARG_NONNULL(1, 2);
+ETHUMB_API Eina_Bool ethumb_file_set(Ethumb *e, const char *path, const char *key) EINA_ARG_NONNULL(1, 2);
 /**
  * @brief Get the file for which to generate thumbnails.
  *
@@ -515,14 +491,14 @@ EAPI Eina_Bool ethumb_file_set(Ethumb *e, const char *path, const char *key) EIN
  *                 can store several of them. NULL if not applicable.
  * @see ethumb_file_set
  */
-EAPI void      ethumb_file_get(const Ethumb *e, const char **path, const char **key) EINA_ARG_NONNULL(1);
+ETHUMB_API void      ethumb_file_get(const Ethumb *e, const char **path, const char **key) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Reset the source file information.
  *
  * @param e A pointer to an Ethumb object.
  */
-EAPI void      ethumb_file_free(Ethumb *e) EINA_ARG_NONNULL(1);
+ETHUMB_API void      ethumb_file_free(Ethumb *e) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Generate the thumbnail.
@@ -533,7 +509,7 @@ EAPI void      ethumb_file_free(Ethumb *e) EINA_ARG_NONNULL(1);
  *
  * @return EINA_TRUE on success and EINA_FALSE on failure
  */
-EAPI Eina_Bool ethumb_generate(Ethumb *e, Ethumb_Generate_Cb finished_cb, const void *data, Eina_Free_Cb free_data) EINA_ARG_NONNULL(1, 2);
+ETHUMB_API Eina_Bool ethumb_generate(Ethumb *e, Ethumb_Generate_Cb finished_cb, const void *data, Eina_Free_Cb free_data) EINA_ARG_NONNULL(1, 2);
 
 /**
  * @brief test if the thumbnailer exists
@@ -542,7 +518,7 @@ EAPI Eina_Bool ethumb_generate(Ethumb *e, Ethumb_Generate_Cb finished_cb, const 
  *
  * @return EINA_TRUE if thumbnailer exists and EINA_FALSE otherwise.
  */
-EAPI Eina_Bool ethumb_exists(Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
+ETHUMB_API Eina_Bool ethumb_exists(Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL(1) EINA_PURE;
 
 /**
  * @brief Duplicate an thumbnailer
@@ -551,7 +527,7 @@ EAPI Eina_Bool ethumb_exists(Ethumb *e) EINA_WARN_UNUSED_RESULT EINA_ARG_NONNULL
  *
  * @return a new allocated copy of the thumbnailer.
  */
-EAPI Ethumb *ethumb_dup(const Ethumb *e) EINA_ARG_NONNULL(1);
+ETHUMB_API Ethumb *ethumb_dup(const Ethumb *e) EINA_ARG_NONNULL(1);
 
 /**
  * @brief Compare two thumbnailers.
@@ -561,12 +537,12 @@ EAPI Ethumb *ethumb_dup(const Ethumb *e) EINA_ARG_NONNULL(1);
  *
  * @return EINA_TRUE if the thumbnailers are equal and EINA_FALSE otherwise
  */
-EAPI Eina_Bool ethumb_cmp(const Ethumb *e1, const Ethumb *e2) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT EINA_PURE;
+ETHUMB_API Eina_Bool ethumb_cmp(const Ethumb *e1, const Ethumb *e2) EINA_ARG_NONNULL(1, 2) EINA_WARN_UNUSED_RESULT EINA_PURE;
 
-EAPI int ethumb_hash(const void *key, int key_length) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
-EAPI int ethumb_key_cmp(const void *key1, int key1_length,
+ETHUMB_API int ethumb_hash(const void *key, int key_length) EINA_ARG_NONNULL(1) EINA_WARN_UNUSED_RESULT EINA_PURE;
+ETHUMB_API int ethumb_key_cmp(const void *key1, int key1_length,
                         const void *key2, int key2_length) EINA_ARG_NONNULL(1, 3) EINA_WARN_UNUSED_RESULT EINA_PURE;
-EAPI unsigned int ethumb_length(const void *key) EINA_PURE EINA_WARN_UNUSED_RESULT;
+ETHUMB_API unsigned int ethumb_length(const void *key) EINA_PURE EINA_WARN_UNUSED_RESULT;
 
   /**
  * @}
@@ -578,8 +554,5 @@ EAPI unsigned int ethumb_length(const void *key) EINA_PURE EINA_WARN_UNUSED_RESU
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif /* __ETHUMB_H__ */

--- a/src/lib/ethumb/Ethumb_Plugin.h
+++ b/src/lib/ethumb/Ethumb_Plugin.h
@@ -5,35 +5,7 @@
 #include <Ecore_Evas.h>
 #include <Ethumb.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <ethumb_api.h.h>
 
 typedef struct _Ethumb_Plugin Ethumb_Plugin;
 
@@ -47,24 +19,21 @@ struct _Ethumb_Plugin
    void (*thumb_cancel)(Ethumb *, void *);
 };
 
-EAPI Eina_Bool ethumb_plugin_register(const Ethumb_Plugin *plugin);
-EAPI Eina_Bool ethumb_plugin_unregister(const Ethumb_Plugin *plugin);
+ETHUMB_API Eina_Bool ethumb_plugin_register(const Ethumb_Plugin *plugin);
+ETHUMB_API Eina_Bool ethumb_plugin_unregister(const Ethumb_Plugin *plugin);
 
-EAPI void ethumb_calculate_aspect_from_ratio(Ethumb *e, float ia, int *w, int *h);
-EAPI void ethumb_calculate_aspect(Ethumb *e, int iw, int ih, int *w, int *h);
-EAPI void ethumb_calculate_fill_from_ratio(Ethumb *e, float ia, int *fx, int *fy, int *fw, int *fh);
-EAPI void ethumb_calculate_fill(Ethumb *e, int iw, int ih, int *fx, int *fy, int *fw, int *fh);
-EAPI Eina_Bool ethumb_plugin_image_resize(Ethumb *e, int w, int h);
-EAPI Eina_Bool ethumb_image_save(Ethumb *e);
-EAPI void ethumb_finished_callback_call(Ethumb *e, int result);
-EAPI Evas * ethumb_evas_get(const Ethumb *e);
-EAPI Ecore_Evas * ethumb_ecore_evas_get(const Ethumb *e);
+ETHUMB_API void ethumb_calculate_aspect_from_ratio(Ethumb *e, float ia, int *w, int *h);
+ETHUMB_API void ethumb_calculate_aspect(Ethumb *e, int iw, int ih, int *w, int *h);
+ETHUMB_API void ethumb_calculate_fill_from_ratio(Ethumb *e, float ia, int *fx, int *fy, int *fw, int *fh);
+ETHUMB_API void ethumb_calculate_fill(Ethumb *e, int iw, int ih, int *fx, int *fy, int *fw, int *fh);
+ETHUMB_API Eina_Bool ethumb_plugin_image_resize(Ethumb *e, int w, int h);
+ETHUMB_API Eina_Bool ethumb_image_save(Ethumb *e);
+ETHUMB_API void ethumb_finished_callback_call(Ethumb *e, int result);
+ETHUMB_API Evas * ethumb_evas_get(const Ethumb *e);
+ETHUMB_API Ecore_Evas * ethumb_ecore_evas_get(const Ethumb *e);
 
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif /* _ETHUMB_PLUGIN_H_ */

--- a/src/lib/ethumb/ethumb.c
+++ b/src/lib/ethumb/ethumb.c
@@ -68,7 +68,7 @@
 #include "../../static_libs/buildsystem/buildsystem.h"
 
 static Ethumb_Version _version = { VMAJ, VMIN, VMIC, VREV };
-EAPI Ethumb_Version *ethumb_version = &_version;
+ETHUMB_API Ethumb_Version *ethumb_version = &_version;
 
 static int _log_dom = -1;
 #define DBG(...) EINA_LOG_DOM_DBG(_log_dom, __VA_ARGS__)
@@ -89,7 +89,7 @@ static Eina_Hash *_plugins_ext = NULL;
 static Eina_Array *_plugins = NULL;
 static Eina_Prefix *_pfx = NULL;
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_plugin_register(const Ethumb_Plugin *plugin)
 {
    const char * const *ext;
@@ -116,7 +116,7 @@ ethumb_plugin_register(const Ethumb_Plugin *plugin)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_plugin_unregister(const Ethumb_Plugin *plugin)
 {
    const char * const *ext;
@@ -222,7 +222,7 @@ _ethumb_plugins_unload(void)
    _plugins_loaded = EINA_FALSE;
 }
 
-EAPI int
+ETHUMB_API int
 ethumb_init(void)
 {
    const char *home;
@@ -297,7 +297,7 @@ ethumb_init(void)
    return 0;
 }
 
-EAPI int
+ETHUMB_API int
 ethumb_shutdown(void)
 {
    if (initcount <= 0)
@@ -326,7 +326,7 @@ ethumb_shutdown(void)
    return initcount;
 }
 
-EAPI Ethumb *
+ETHUMB_API Ethumb *
 ethumb_new(void)
 {
    Ethumb *ethumb;
@@ -424,7 +424,7 @@ _ethumb_frame_free(Ethumb_Frame *frame)
    free(frame);
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_free(Ethumb *ethumb)
 {
    EINA_SAFETY_ON_NULL_RETURN(ethumb);
@@ -443,7 +443,7 @@ ethumb_free(Ethumb *ethumb)
    free(ethumb);
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_fdo_set(Ethumb *e, Ethumb_Thumb_FDO_Size s)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -473,7 +473,7 @@ ethumb_thumb_fdo_set(Ethumb *e, Ethumb_Thumb_FDO_Size s)
    e->category = NULL;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_size_set(Ethumb *e, int tw, int th)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -485,7 +485,7 @@ ethumb_thumb_size_set(Ethumb *e, int tw, int th)
    e->th = th;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_size_get(const Ethumb *e, int *tw, int *th)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -494,7 +494,7 @@ ethumb_thumb_size_get(const Ethumb *e, int *tw, int *th)
    if (th) *th = e->th;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_format_set(Ethumb *e, Ethumb_Thumb_Format f)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -506,14 +506,14 @@ ethumb_thumb_format_set(Ethumb *e, Ethumb_Thumb_Format f)
    e->format = f;
 }
 
-EAPI Ethumb_Thumb_Format
+ETHUMB_API Ethumb_Thumb_Format
 ethumb_thumb_format_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
    return e->format;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_aspect_set(Ethumb *e, Ethumb_Thumb_Aspect a)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -525,14 +525,14 @@ ethumb_thumb_aspect_set(Ethumb *e, Ethumb_Thumb_Aspect a)
    e->aspect = a;
 }
 
-EAPI Ethumb_Thumb_Aspect
+ETHUMB_API Ethumb_Thumb_Aspect
 ethumb_thumb_aspect_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
    return e->aspect;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_orientation_set(Ethumb *e, Ethumb_Thumb_Orientation o)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -550,14 +550,14 @@ ethumb_thumb_orientation_set(Ethumb *e, Ethumb_Thumb_Orientation o)
    e->orientation = o;
 }
 
-EAPI Ethumb_Thumb_Orientation
+ETHUMB_API Ethumb_Thumb_Orientation
 ethumb_thumb_orientation_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
    return e->orientation;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_crop_align_set(Ethumb *e, float x, float y)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -567,7 +567,7 @@ ethumb_thumb_crop_align_set(Ethumb *e, float x, float y)
    e->crop_y = y;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_crop_align_get(const Ethumb *e, float *x, float *y)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -576,7 +576,7 @@ ethumb_thumb_crop_align_get(const Ethumb *e, float *x, float *y)
    if (y) *y = e->crop_y;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_quality_set(Ethumb *e, int quality)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -585,14 +585,14 @@ ethumb_thumb_quality_set(Ethumb *e, int quality)
    e->quality = quality;
 }
 
-EAPI int
+ETHUMB_API int
 ethumb_thumb_quality_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
    return e->quality;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_compress_set(Ethumb *e, int compress)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -601,14 +601,14 @@ ethumb_thumb_compress_set(Ethumb *e, int compress)
    e->compress = compress;
 }
 
-EAPI int
+ETHUMB_API int
 ethumb_thumb_compress_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
    return e->compress;
 }
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_frame_set(Ethumb *e, const char *theme_file, const char *group, const char *swallow)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
@@ -681,7 +681,7 @@ ethumb_frame_set(Ethumb *e, const char *theme_file, const char *group, const cha
    return EINA_TRUE;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_frame_get(const Ethumb *e, const char **theme_file, const char **group, const char **swallow)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -700,7 +700,7 @@ ethumb_frame_get(const Ethumb *e, const char **theme_file, const char **group, c
      }
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_dir_path_set(Ethumb *e, const char *path)
 {
    char *sanitized_path;
@@ -712,7 +712,7 @@ ethumb_thumb_dir_path_set(Ethumb *e, const char *path)
    free(sanitized_path);
 }
 
-EAPI const char *
+ETHUMB_API const char *
 ethumb_thumb_dir_path_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, NULL);
@@ -720,7 +720,7 @@ ethumb_thumb_dir_path_get(const Ethumb *e)
    return e->thumb_dir;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_category_set(Ethumb *e, const char *category)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -729,7 +729,7 @@ ethumb_thumb_category_set(Ethumb *e, const char *category)
    eina_stringshare_replace(&e->category, category);
 }
 
-EAPI const char *
+ETHUMB_API const char *
 ethumb_thumb_category_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, NULL);
@@ -737,7 +737,7 @@ ethumb_thumb_category_get(const Ethumb *e)
    return e->category;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_video_start_set(Ethumb *e, float start)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -748,7 +748,7 @@ ethumb_video_start_set(Ethumb *e, float start)
    e->video.start = start;
 }
 
-EAPI float
+ETHUMB_API float
 ethumb_video_start_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
@@ -756,7 +756,7 @@ ethumb_video_start_get(const Ethumb *e)
    return e->video.start;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_video_time_set(Ethumb *e, float t)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -765,7 +765,7 @@ ethumb_video_time_set(Ethumb *e, float t)
    e->video.time = t;
 }
 
-EAPI float
+ETHUMB_API float
 ethumb_video_time_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
@@ -773,7 +773,7 @@ ethumb_video_time_get(const Ethumb *e)
    return e->video.time;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_video_interval_set(Ethumb *e, float interval)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -782,7 +782,7 @@ ethumb_video_interval_set(Ethumb *e, float interval)
    e->video.interval = interval;
 }
 
-EAPI float
+ETHUMB_API float
 ethumb_video_interval_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
@@ -790,7 +790,7 @@ ethumb_video_interval_get(const Ethumb *e)
    return e->video.interval;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_video_ntimes_set(Ethumb *e, unsigned int ntimes)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -800,7 +800,7 @@ ethumb_video_ntimes_set(Ethumb *e, unsigned int ntimes)
    e->video.ntimes = ntimes;
 }
 
-EAPI unsigned int
+ETHUMB_API unsigned int
 ethumb_video_ntimes_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
@@ -808,7 +808,7 @@ ethumb_video_ntimes_get(const Ethumb *e)
    return e->video.ntimes;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_video_fps_set(Ethumb *e, unsigned int fps)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -818,7 +818,7 @@ ethumb_video_fps_set(Ethumb *e, unsigned int fps)
    e->video.fps = fps;
 }
 
-EAPI unsigned int
+ETHUMB_API unsigned int
 ethumb_video_fps_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
@@ -826,7 +826,7 @@ ethumb_video_fps_get(const Ethumb *e)
    return e->video.fps;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_document_page_set(Ethumb *e, unsigned int page)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -835,7 +835,7 @@ ethumb_document_page_set(Ethumb *e, unsigned int page)
    e->document.page = page;
 }
 
-EAPI unsigned int
+ETHUMB_API unsigned int
 ethumb_document_page_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, 0);
@@ -843,7 +843,7 @@ ethumb_document_page_get(const Ethumb *e)
    return e->document.page;
 }
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_file_set(Ethumb *e, const char *path, const char *key)
 {
    char *sanitized_path;
@@ -868,7 +868,7 @@ ethumb_file_set(Ethumb *e, const char *path, const char *key)
    return EINA_TRUE;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_file_get(const Ethumb *e, const char **path, const char **key)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -1083,7 +1083,7 @@ _ethumb_file_generate_path(Ethumb *e)
    eina_stringshare_del(category);
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_file_free(Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -1096,7 +1096,7 @@ ethumb_file_free(Ethumb *e)
    eina_stringshare_replace(&e->thumb_key, NULL);
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_path_set(Ethumb *e, const char *path, const char *key)
 {
    char *sanitized_path;
@@ -1118,7 +1118,7 @@ ethumb_thumb_path_set(Ethumb *e, const char *path, const char *key)
      }
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_path_get(Ethumb *e, const char **path, const char **key)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -1129,7 +1129,7 @@ ethumb_thumb_path_get(Ethumb *e, const char **path, const char **key)
    if (key) *key = e->thumb_key;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_hash(Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -1143,7 +1143,7 @@ ethumb_thumb_hash(Ethumb *e)
      }
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_thumb_hash_copy(Ethumb *dst, const Ethumb *src)
 {
    EINA_SAFETY_ON_NULL_RETURN(dst);
@@ -1155,7 +1155,7 @@ ethumb_thumb_hash_copy(Ethumb *dst, const Ethumb *src)
    dst->src_hash = eina_stringshare_ref(src->src_hash);
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_calculate_aspect_from_ratio(Ethumb *e, float ia, int *w, int *h)
 {
    float a;
@@ -1179,7 +1179,7 @@ ethumb_calculate_aspect_from_ratio(Ethumb *e, float ia, int *w, int *h)
      }
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_calculate_aspect(Ethumb *e, int iw, int ih, int *w, int *h)
 {
    float ia;
@@ -1192,7 +1192,7 @@ ethumb_calculate_aspect(Ethumb *e, int iw, int ih, int *w, int *h)
    ethumb_calculate_aspect_from_ratio(e, ia, w, h);
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_calculate_fill_from_ratio(Ethumb *e, float ia, int *fx, int *fy, int *fw, int *fh)
 {
    float a;
@@ -1228,7 +1228,7 @@ ethumb_calculate_fill_from_ratio(Ethumb *e, float ia, int *fx, int *fy, int *fw,
      }
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_calculate_fill(Ethumb *e, int iw, int ih, int *fx, int *fy, int *fw, int *fh)
 {
    float ia;
@@ -1275,7 +1275,7 @@ _ethumb_plugin_generate(Ethumb *e)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_plugin_image_resize(Ethumb *e, int w, int h)
 {
    Evas_Object *img;
@@ -1305,7 +1305,7 @@ ethumb_plugin_image_resize(Ethumb *e, int w, int h)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_image_save(Ethumb *e)
 {
    Eina_Bool r;
@@ -1561,7 +1561,7 @@ _ethumb_finished_idler_cb(void *data)
    return EINA_FALSE;
 }
 
-EAPI void
+ETHUMB_API void
 ethumb_finished_callback_call(Ethumb *e, int result)
 {
    EINA_SAFETY_ON_NULL_RETURN(e);
@@ -1574,7 +1574,7 @@ ethumb_finished_callback_call(Ethumb *e, int result)
    e->pdata = NULL;
 }
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_generate(Ethumb *e, Ethumb_Generate_Cb finished_cb, const void *data, Eina_Free_Cb free_data)
 {
    int r;
@@ -1625,7 +1625,7 @@ ethumb_generate(Ethumb *e, Ethumb_Generate_Cb finished_cb, const void *data, Ein
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_exists(Ethumb *e)
 {
    struct stat thumb, src;
@@ -1653,7 +1653,7 @@ ethumb_exists(Ethumb *e)
    return r;
 }
 
-EAPI Evas *
+ETHUMB_API Evas *
 ethumb_evas_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, NULL);
@@ -1661,7 +1661,7 @@ ethumb_evas_get(const Ethumb *e)
    return e->sub_e;
 }
 
-EAPI Ecore_Evas *
+ETHUMB_API Ecore_Evas *
 ethumb_ecore_evas_get(const Ethumb *e)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(e, NULL);
@@ -1669,7 +1669,7 @@ ethumb_ecore_evas_get(const Ethumb *e)
    return e->sub_ee;
 }
 
-EAPI Ethumb *
+ETHUMB_API Ethumb *
 ethumb_dup(const Ethumb *e)
 {
    Ecore_Evas *ee;
@@ -1756,7 +1756,7 @@ ethumb_dup(const Ethumb *e)
   if (!EINA_FLT_EQ(e1->Param, e2->Param))      \
     return EINA_TRUE;
 
-EAPI Eina_Bool
+ETHUMB_API Eina_Bool
 ethumb_cmp(const Ethumb *e1, const Ethumb *e2)
 {
    CHECK_FLT_DELTA(crop_x);
@@ -1783,7 +1783,7 @@ ethumb_cmp(const Ethumb *e1, const Ethumb *e2)
    return EINA_FALSE;
 }
 
-EAPI unsigned int
+ETHUMB_API unsigned int
 ethumb_length(EINA_UNUSED const void *key)
 {
    return sizeof (Ethumb);
@@ -1797,7 +1797,7 @@ ethumb_length(EINA_UNUSED const void *key)
   if (!EINA_FLT_EQ(e1->Param, e2->Param))      \
     return e1->Param - e2->Param;
 
-EAPI int
+ETHUMB_API int
 ethumb_key_cmp(const void *key1, EINA_UNUSED int key1_length,
                const void *key2, EINA_UNUSED int key2_length)
 {
@@ -1841,7 +1841,7 @@ ethumb_key_cmp(const void *key1, EINA_UNUSED int key1_length,
 #define HASH_PARAM_D(Param) r ^= eina_hash_int64((unsigned long long int*)&e->Param, 0);
 #define HASH_PARAM_F(Param) r ^= eina_hash_int32((unsigned int*) &e->Param, 0);
 
-EAPI int
+ETHUMB_API int
 ethumb_hash(const void *key, int key_length EINA_UNUSED)
 {
    const Ethumb *e = key;

--- a/src/lib/ethumb/ethumb_api.h
+++ b/src/lib/ethumb/ethumb_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ETHUMB_API_H
+#define _EFL_ETHUMB_API_H
+
+#ifdef ETHUMB_API
+#error ETHUMB_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_STATIC
+#  ifdef ETHUMB_BUILD
+#   define ETHUMB_API __declspec(dllexport)
+#  else
+#   define ETHUMB_API __declspec(dllimport)
+#  endif
+# else
+#  define ETHUMB_API
+# endif
+# define ETHUMB_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ETHUMB_API __attribute__ ((visibility("default")))
+#   define ETHUMB_API_WEAK __attribute__ ((weak))
+#  else
+#   define ETHUMB_API
+#   define ETHUMB_API_WEAK
+#  endif
+# else
+#  define ETHUMB_API
+#  define ETHUMB_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ethumb/ethumb_api.h
+++ b/src/lib/ethumb/ethumb_api.h
@@ -6,7 +6,7 @@
 #endif
 
 #ifdef _WIN32
-# ifndef EFL_STATIC
+# ifndef ETHUMB_STATIC
 #  ifdef ETHUMB_BUILD
 #   define ETHUMB_API __declspec(dllexport)
 #  else

--- a/src/lib/ethumb/ethumb_private.h
+++ b/src/lib/ethumb/ethumb_private.h
@@ -4,31 +4,7 @@
 #include <Ethumb.h>
 #include <Ethumb_Plugin.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ethumb_api.h>
 
 typedef struct _Ethumb_Frame Ethumb_Frame;
 
@@ -79,8 +55,5 @@ struct _Ethumb
    void *pdata;
    Ethumb_Plugin *plugin;
 };
-
-#undef EAPI
-#define EAPI
 
 #endif /* __ETHUMB_PRIVATE_H__ */

--- a/src/lib/ethumb/meson.build
+++ b/src/lib/ethumb/meson.build
@@ -18,7 +18,7 @@ ethumb_lib = library('ethumb',
     dependencies: ethumb_pub_deps + ethumb_ext_deps + ethumb_deps,
     include_directories : config_dir + [include_directories('.')],
     install: true,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DETHUMB_BUILD'],
     version : meson.project_version()
 )
 


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.