### PR TITLE
[ecore_avahi] Use ECORE_AVAHI_API instead of EAPI

### DIFF
--- a/src/lib/ecore_avahi/Ecore_Avahi.h
+++ b/src/lib/ecore_avahi/Ecore_Avahi.h
@@ -7,31 +7,7 @@
 #ifndef _ECORE_AVAHI_H
 # define _ECORE_AVAHI_H
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_avahi_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,7 +31,7 @@ typedef struct _Ecore_Avahi Ecore_Avahi; /**< A handle for an Avahi instance. */
  * @return A handler that reference the AvahiPoll context
  * @since 1.9
  */
-EAPI Ecore_Avahi *ecore_avahi_add(void);
+ECORE_AVAHI_API Ecore_Avahi *ecore_avahi_add(void);
 
 /**
  * @brief Deletes the specified handler of an AvahiPoll.
@@ -66,7 +42,7 @@ EAPI Ecore_Avahi *ecore_avahi_add(void);
  * Be aware there should not be any reference still using that handler before
  * destroying it.
  */
-EAPI void         ecore_avahi_del(Ecore_Avahi *handler);
+ECORE_AVAHI_API void         ecore_avahi_del(Ecore_Avahi *handler);
 
 /**
  * @brief Gets the AvahiPoll structure to integrate with Ecore main loop.
@@ -75,7 +51,7 @@ EAPI void         ecore_avahi_del(Ecore_Avahi *handler);
  * @return return the actual AvahiPoll structure to use with Avahi.
  * @since 1.9
  */
-EAPI const void  *ecore_avahi_poll_get(Ecore_Avahi *handler); // return AvahiPoll
+ECORE_AVAHI_API const void  *ecore_avahi_poll_get(Ecore_Avahi *handler); // return AvahiPoll
 
 /**
  * @}
@@ -84,8 +60,5 @@ EAPI const void  *ecore_avahi_poll_get(Ecore_Avahi *handler); // return AvahiPol
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_avahi/ecore_avahi.c
+++ b/src/lib/ecore_avahi/ecore_avahi.c
@@ -188,7 +188,7 @@ _ecore_avahi_timeout_free(AvahiTimeout *t)
 }
 #endif
 
-EAPI Ecore_Avahi *
+ECORE_AVAHI_API Ecore_Avahi *
 ecore_avahi_add(void)
 {
 #ifdef HAVE_AVAHI
@@ -213,7 +213,7 @@ ecore_avahi_add(void)
 #endif
 }
 
-EAPI void
+ECORE_AVAHI_API void
 ecore_avahi_del(Ecore_Avahi *handler)
 {
 #ifdef HAVE_AVAHI
@@ -238,7 +238,7 @@ ecore_avahi_del(Ecore_Avahi *handler)
 #endif
 }
 
-EAPI const void *
+ECORE_AVAHI_API const void *
 ecore_avahi_poll_get(Ecore_Avahi *handler)
 {
 #ifdef HAVE_AVAHI

--- a/src/lib/ecore_avahi/ecore_avahi_api.h
+++ b/src/lib/ecore_avahi/ecore_avahi_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_AVAHI_API_H
+#define _EFL_ECORE_AVAHI_API_H
+
+#ifdef ECORE_AVAHI_API
+#error ECORE_AVAHI_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_AVAHI_STATIC
+#  ifdef ECORE_AVAHI_BUILD
+#   define ECORE_AVAHI_API __declspec(dllexport)
+#  else
+#   define ECORE_AVAHI_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_AVAHI_API
+# endif
+# define ECORE_AVAHI_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_AVAHI_API __attribute__ ((visibility("default")))
+#   define ECORE_AVAHI_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_AVAHI_API
+#   define ECORE_AVAHI_API_WEAK
+#  endif
+# else
+#  define ECORE_AVAHI_API
+#  define ECORE_AVAHI_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_avahi/meson.build
+++ b/src/lib/ecore_avahi/meson.build
@@ -9,7 +9,7 @@ config_h.set('HAVE_AVAHI', '1')
 
 ecore_avahi_lib = library('ecore_avahi',
     ecore_avahi_src,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_AVAHI_BUILD'],
     dependencies: [m] + ecore_avahi_deps + ecore_avahi_pub_deps,
     include_directories : config_dir + [include_directories(join_paths('..','..'))],
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.