### PR TITLE
[ecore_buffer] Use ECORE_BUFFER_API instead of EAPI

### DIFF
--- a/src/lib/ecore_buffer/Ecore_Buffer.h
+++ b/src/lib/ecore_buffer/Ecore_Buffer.h
@@ -1,31 +1,7 @@
 #ifndef _ECORE_BUFFER_H_
 # define _ECORE_BUFFER_H_
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_buffer_api.h>
 
 /**
  * @defgroup Ecore_Buffer_Group Ecore_Buffer - Graphics buffer functions
@@ -472,7 +448,7 @@ struct _Ecore_Buffer_Backend
  *
  * @see ecore_buffer_shutdown()
  */
-EAPI Eina_Bool     ecore_buffer_init(void);
+ECORE_BUFFER_API Eina_Bool     ecore_buffer_init(void);
 /**
  * @brief Shuts down the Ecore_Buffer system.
  *
@@ -482,7 +458,7 @@ EAPI Eina_Bool     ecore_buffer_init(void);
  *
  * @see ecore_buffer_init()
  */
-EAPI Eina_Bool     ecore_buffer_shutdown(void);
+ECORE_BUFFER_API Eina_Bool     ecore_buffer_shutdown(void);
 /**
  * @brief Registers the given buffer backend.
  *
@@ -492,7 +468,7 @@ EAPI Eina_Bool     ecore_buffer_shutdown(void);
  *
  * @return @c EINA_TRUE if backend has been correctly registered, @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool     ecore_buffer_register(Ecore_Buffer_Backend *be);
+ECORE_BUFFER_API Eina_Bool     ecore_buffer_register(Ecore_Buffer_Backend *be);
 /**
  * @brief Unregisters the given buffer backend.
  *
@@ -500,7 +476,7 @@ EAPI Eina_Bool     ecore_buffer_register(Ecore_Buffer_Backend *be);
  *
  * @param[in] be The backend
  */
-EAPI void          ecore_buffer_unregister(Ecore_Buffer_Backend *be);
+ECORE_BUFFER_API void          ecore_buffer_unregister(Ecore_Buffer_Backend *be);
 /**
  * @brief Creates a new Ecore_Buffer given type.
  *
@@ -514,7 +490,7 @@ EAPI void          ecore_buffer_unregister(Ecore_Buffer_Backend *be);
  *
  * @return Newly allocated Ecore_Buffer instance, NULL otherwise.
  */
-EAPI Ecore_Buffer *ecore_buffer_new(const char *engine, unsigned int width, unsigned int height, Ecore_Buffer_Format format, unsigned int flags);
+ECORE_BUFFER_API Ecore_Buffer *ecore_buffer_new(const char *engine, unsigned int width, unsigned int height, Ecore_Buffer_Format format, unsigned int flags);
 /**
  * @brief Frees the given Ecore_Buffer.
  *
@@ -522,7 +498,7 @@ EAPI Ecore_Buffer *ecore_buffer_new(const char *engine, unsigned int width, unsi
  *
  * @param[in] buf The Ecore_Buffer to free
  */
-EAPI void          ecore_buffer_free(Ecore_Buffer *buf);
+ECORE_BUFFER_API void          ecore_buffer_free(Ecore_Buffer *buf);
 /**
  * @brief Sets a callback for Ecore_Buffer free events.
  *
@@ -537,7 +513,7 @@ EAPI void          ecore_buffer_free(Ecore_Buffer *buf);
  *
  * @see ecore_buffer_free_callback_remove()
  */
-EAPI void          ecore_buffer_free_callback_add(Ecore_Buffer *buf, Ecore_Buffer_Cb  func, void *data);
+ECORE_BUFFER_API void          ecore_buffer_free_callback_add(Ecore_Buffer *buf, Ecore_Buffer_Cb  func, void *data);
 /**
  * @brief Removes a callback for Ecore_Buffer free events.
  *
@@ -549,7 +525,7 @@ EAPI void          ecore_buffer_free_callback_add(Ecore_Buffer *buf, Ecore_Buffe
  *
  * @see ecore_buffer_free_callback_add()
  */
-EAPI void          ecore_buffer_free_callback_remove(Ecore_Buffer *buf, Ecore_Buffer_Cb func, void *data);
+ECORE_BUFFER_API void          ecore_buffer_free_callback_remove(Ecore_Buffer *buf, Ecore_Buffer_Cb func, void *data);
 /**
  * @brief Get a pointer to the raw data of the given Ecore_Buffer.
  *
@@ -557,7 +533,7 @@ EAPI void          ecore_buffer_free_callback_remove(Ecore_Buffer *buf, Ecore_Bu
  *
  * @return The pointer of raw data.
  */
-EAPI void         *ecore_buffer_data_get(Ecore_Buffer *buf);
+ECORE_BUFFER_API void         *ecore_buffer_data_get(Ecore_Buffer *buf);
 /**
  * @brief Returns the Pixmap of given Ecore_Buffer.
  *
@@ -567,7 +543,7 @@ EAPI void         *ecore_buffer_data_get(Ecore_Buffer *buf);
  *
  * @return The Pixmap instance, @c 0 otherwise.
  */
-EAPI Ecore_Pixmap  ecore_buffer_pixmap_get(Ecore_Buffer *buf);
+ECORE_BUFFER_API Ecore_Pixmap  ecore_buffer_pixmap_get(Ecore_Buffer *buf);
 /**
  * @brief Returns the tbm surface handle of given Ecore_Buffer.
  *
@@ -580,7 +556,7 @@ EAPI Ecore_Pixmap  ecore_buffer_pixmap_get(Ecore_Buffer *buf);
  * The tbm surface handle will be used for the API of libtbm.
  * The API is described in tbm_surface.h in libtbm.
  */
-EAPI void         *ecore_buffer_tbm_surface_get(Ecore_Buffer *buf);
+ECORE_BUFFER_API void         *ecore_buffer_tbm_surface_get(Ecore_Buffer *buf);
 /**
  * @brief Returns size of given Ecore_Buffer.
  *
@@ -592,7 +568,7 @@ EAPI void         *ecore_buffer_tbm_surface_get(Ecore_Buffer *buf);
  *
  * @return @c EINA_TRUE on success, @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool     ecore_buffer_size_get(Ecore_Buffer *buf, unsigned int *width, unsigned int *height);
+ECORE_BUFFER_API Eina_Bool     ecore_buffer_size_get(Ecore_Buffer *buf, unsigned int *width, unsigned int *height);
 /**
  * @brief Returns format of given Ecore_Buffer.
  *
@@ -604,7 +580,7 @@ EAPI Eina_Bool     ecore_buffer_size_get(Ecore_Buffer *buf, unsigned int *width,
  *
  * Return value can be one of those pre-defined value such as ECORE_BUFFER_FORMAT_XRGB8888.
  */
-EAPI Ecore_Buffer_Format ecore_buffer_format_get(Ecore_Buffer *buf);
+ECORE_BUFFER_API Ecore_Buffer_Format ecore_buffer_format_get(Ecore_Buffer *buf);
 /**
  * @brief Returns the flags of given Ecore_Buffer.
  *
@@ -616,7 +592,7 @@ EAPI Ecore_Buffer_Format ecore_buffer_format_get(Ecore_Buffer *buf);
  *
  * NOTE: Not Defined yet.
  */
-EAPI unsigned int  ecore_buffer_flags_get(Ecore_Buffer *buf);
+ECORE_BUFFER_API unsigned int  ecore_buffer_flags_get(Ecore_Buffer *buf);
 
 /**
  * @}
@@ -625,8 +601,5 @@ EAPI unsigned int  ecore_buffer_flags_get(Ecore_Buffer *buf);
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_buffer/Ecore_Buffer_Queue.h
+++ b/src/lib/ecore_buffer/Ecore_Buffer_Queue.h
@@ -4,31 +4,7 @@
 #include <Eina.h>
 #include <Ecore_Buffer.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_buffer_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -184,7 +160,7 @@ typedef void (*Ecore_Buffer_Provider_Enqueue_Cb) (Ecore_Buffer_Provider *provide
  *
  * @see ecore_buffer_queue_shutdown()
  */
-EAPI int   ecore_buffer_queue_init(void);
+ECORE_BUFFER_API int   ecore_buffer_queue_init(void);
 /**
  * @brief Shuts down the Ecore_Buffer_Queue system.
  *
@@ -196,7 +172,7 @@ EAPI int   ecore_buffer_queue_init(void);
  *
  * @see ecore_buffer_queue_init()
  */
-EAPI int    ecore_buffer_queue_shutdown(void);
+ECORE_BUFFER_API int    ecore_buffer_queue_shutdown(void);
 
 /**
  * @}
@@ -219,7 +195,7 @@ EAPI int    ecore_buffer_queue_shutdown(void);
  *
  * @return Ecore_Buffer_Consumer instance or @c NULL if creation failed.
  */
-EAPI Ecore_Buffer_Consumer    *ecore_buffer_consumer_new(const char *name, int32_t queue_size, int32_t w, int32_t h);
+ECORE_BUFFER_API Ecore_Buffer_Consumer    *ecore_buffer_consumer_new(const char *name, int32_t queue_size, int32_t w, int32_t h);
 /**
  * @brief Frees an Ecore_Buffer_Consumer.
  *
@@ -229,7 +205,7 @@ EAPI Ecore_Buffer_Consumer    *ecore_buffer_consumer_new(const char *name, int32
  *
  * This frees up any memory used by the Ecore_Buffer_Consumer.
  */
-EAPI void                      ecore_buffer_consumer_free(Ecore_Buffer_Consumer *consumer);
+ECORE_BUFFER_API void                      ecore_buffer_consumer_free(Ecore_Buffer_Consumer *consumer);
 /**
  * @brief Returns the latest Ecore_Buffer submitted by provider.
  *
@@ -244,7 +220,7 @@ EAPI void                      ecore_buffer_consumer_free(Ecore_Buffer_Consumer 
  * Consumer can store Ecore_Buffer submitted by Provider as much as size of queue
  * which is passed as a argument of ecore_buffer_consumer_new().
  */
-EAPI Ecore_Buffer             *ecore_buffer_consumer_buffer_dequeue(Ecore_Buffer_Consumer *consumer);
+ECORE_BUFFER_API Ecore_Buffer             *ecore_buffer_consumer_buffer_dequeue(Ecore_Buffer_Consumer *consumer);
 /**
  * @brief Releases the acquired Ecore_Buffer.
  *
@@ -262,7 +238,7 @@ EAPI Ecore_Buffer             *ecore_buffer_consumer_buffer_dequeue(Ecore_Buffer
  * or freed internally if Ecore_Buffer is not necessary anymore.
  * If not, the resource of Ecore_Buffer is continually owned by consumer until released.
  */
-EAPI Eina_Bool                 ecore_buffer_consumer_buffer_release(Ecore_Buffer_Consumer *consumer, Ecore_Buffer *buffer);
+ECORE_BUFFER_API Eina_Bool                 ecore_buffer_consumer_buffer_release(Ecore_Buffer_Consumer *consumer, Ecore_Buffer *buffer);
 /**
  * @brief Checks if Queue of Ecore_Buffer is empty.
  *
@@ -272,7 +248,7 @@ EAPI Eina_Bool                 ecore_buffer_consumer_buffer_release(Ecore_Buffer
  *
  * @return @c EINA_TRUE means queue is empty, @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool                 ecore_buffer_consumer_queue_is_empty(Ecore_Buffer_Consumer *consumer);
+ECORE_BUFFER_API Eina_Bool                 ecore_buffer_consumer_queue_is_empty(Ecore_Buffer_Consumer *consumer);
 /**
  * @brief Sets a callback for provider connection events.
  *
@@ -285,7 +261,7 @@ EAPI Eina_Bool                 ecore_buffer_consumer_queue_is_empty(Ecore_Buffer
  * A call to this function will set a callback on an Ecore_Buffer_Consumer, causing
  * @p func to be called whenever @p consumer is connected with provider.
  */
-EAPI void                      ecore_buffer_consumer_provider_add_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Provider_Add_Cb func, void *data);
+ECORE_BUFFER_API void                      ecore_buffer_consumer_provider_add_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Provider_Add_Cb func, void *data);
 /**
  * @brief Sets a callback for provider disconnection events.
  *
@@ -298,7 +274,7 @@ EAPI void                      ecore_buffer_consumer_provider_add_cb_set(Ecore_B
  * A call to this function will set a callback on an Ecore_Buffer_Consumer, causing
  * @p func to be called whenever @p consumer is disconnected with provider.
  */
-EAPI void                      ecore_buffer_consumer_provider_del_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Provider_Del_Cb func, void *data);
+ECORE_BUFFER_API void                      ecore_buffer_consumer_provider_del_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Provider_Del_Cb func, void *data);
 /**
  * @brief Sets a callback for enqueued buffer events.
  *
@@ -313,7 +289,7 @@ EAPI void                      ecore_buffer_consumer_provider_del_cb_set(Ecore_B
  *
  * You may success acquire Ecore_Buffer after this callback called.
  */
-EAPI void                      ecore_buffer_consumer_buffer_enqueued_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Enqueue_Cb func, void *data);
+ECORE_BUFFER_API void                      ecore_buffer_consumer_buffer_enqueued_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Enqueue_Cb func, void *data);
 
 /**
  * @}
@@ -333,7 +309,7 @@ EAPI void                      ecore_buffer_consumer_buffer_enqueued_cb_set(Ecor
  *
  * @return Ecore_Buffer_Provider instance or @c NULL if creation failed.
  */
-EAPI Ecore_Buffer_Provider    *ecore_buffer_provider_new(const char *name);
+ECORE_BUFFER_API Ecore_Buffer_Provider    *ecore_buffer_provider_new(const char *name);
 /**
  * @brief Frees an Ecore_Buffer_Provider.
  *
@@ -343,7 +319,7 @@ EAPI Ecore_Buffer_Provider    *ecore_buffer_provider_new(const char *name);
  *
  * This frees up any memory used by the Ecore_Buffer_Provider.
  */
-EAPI void                      ecore_buffer_provider_free(Ecore_Buffer_Provider *provider);
+ECORE_BUFFER_API void                      ecore_buffer_provider_free(Ecore_Buffer_Provider *provider);
 /**
  * @brief Returns the Ecore_Buffer released by consumer or State of Queue.
  *
@@ -365,7 +341,7 @@ EAPI void                      ecore_buffer_provider_free(Ecore_Buffer_Provider 
  *
  * @see ecore_buffer_new(), ecore_buffer_provider_buffer_enqueue()
  */
-EAPI Ecore_Buffer_Return       ecore_buffer_provider_buffer_acquire(Ecore_Buffer_Provider *provider, Ecore_Buffer **ret_buf);
+ECORE_BUFFER_API Ecore_Buffer_Return       ecore_buffer_provider_buffer_acquire(Ecore_Buffer_Provider *provider, Ecore_Buffer **ret_buf);
 /**
  * @brief Submits the Ecore_Buffer to Consumer to request compositing.
  *
@@ -382,7 +358,7 @@ EAPI Ecore_Buffer_Return       ecore_buffer_provider_buffer_acquire(Ecore_Buffer
  *
  * @see ecore_buffer_new(), ecore_buffer_provider_buffer_dequeue()
  */
-EAPI Eina_Bool                 ecore_buffer_provider_buffer_enqueue(Ecore_Buffer_Provider *provider, Ecore_Buffer *buffer);
+ECORE_BUFFER_API Eina_Bool                 ecore_buffer_provider_buffer_enqueue(Ecore_Buffer_Provider *provider, Ecore_Buffer *buffer);
 /**
  * @brief Checks if state of queue.
  *
@@ -398,7 +374,7 @@ EAPI Eina_Bool                 ecore_buffer_provider_buffer_enqueue(Ecore_Buffer
  *
  * @return @c EINA_TRUE means queue is empty, @c EINA_FALSE otherwise.
  */
-EAPI Ecore_Buffer_Return       ecore_buffer_provider_buffer_acquirable_check(Ecore_Buffer_Provider *provider);
+ECORE_BUFFER_API Ecore_Buffer_Return       ecore_buffer_provider_buffer_acquirable_check(Ecore_Buffer_Provider *provider);
 /**
  * @brief Sets a callback for consumer connection events.
  *
@@ -411,7 +387,7 @@ EAPI Ecore_Buffer_Return       ecore_buffer_provider_buffer_acquirable_check(Eco
  * A call to this function will set a callback on an Ecore_Buffer_Provider, causing
  * @p func to be called whenever @p provider is connected with consumer.
  */
-EAPI void                      ecore_buffer_provider_consumer_add_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Consumer_Add_Cb func, void *data);
+ECORE_BUFFER_API void                      ecore_buffer_provider_consumer_add_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Consumer_Add_Cb func, void *data);
 /**
  * @brief Sets a callback for consumer disconnection events.
  *
@@ -424,7 +400,7 @@ EAPI void                      ecore_buffer_provider_consumer_add_cb_set(Ecore_B
  * A call to this function will set a callback on an Ecore_Buffer_Provider, causing
  * @p func to be called whenever @p provider is disconnected with consumer.
  */
-EAPI void                      ecore_buffer_provider_consumer_del_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Consumer_Del_Cb func, void *data);
+ECORE_BUFFER_API void                      ecore_buffer_provider_consumer_del_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Consumer_Del_Cb func, void *data);
 /**
  * @brief Sets a callback for released buffer events.
  *
@@ -439,7 +415,7 @@ EAPI void                      ecore_buffer_provider_consumer_del_cb_set(Ecore_B
  *
  * You may success dequeue the Ecore_Buffer after this callback called.
  */
-EAPI void                      ecore_buffer_provider_buffer_released_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Enqueue_Cb func, void *data);
+ECORE_BUFFER_API void                      ecore_buffer_provider_buffer_released_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Enqueue_Cb func, void *data);
 
 /**
  * @}
@@ -448,8 +424,5 @@ EAPI void                      ecore_buffer_provider_buffer_released_cb_set(Ecor
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif /* _ECORE_BUFFER_QUEUE_H_ */

--- a/src/lib/ecore_buffer/ecore_buffer.c
+++ b/src/lib/ecore_buffer/ecore_buffer.c
@@ -110,7 +110,7 @@ _ecore_buffer_backends_free(const Eina_Hash *hash EINA_UNUSED, const void *key E
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ECORE_BUFFER_API Eina_Bool
 ecore_buffer_register(Ecore_Buffer_Backend *be)
 {
    Ecore_Buffer_Module *bm;
@@ -127,7 +127,7 @@ ecore_buffer_register(Ecore_Buffer_Backend *be)
    return eina_hash_add(_backends, be->name, bm);
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_unregister(Ecore_Buffer_Backend *be)
 {
    Ecore_Buffer_Module *bm;
@@ -142,7 +142,7 @@ ecore_buffer_unregister(Ecore_Buffer_Backend *be)
    free(bm);
 }
 
-EAPI Eina_Bool
+ECORE_BUFFER_API Eina_Bool
 ecore_buffer_init(void)
 {
    char *path;
@@ -206,7 +206,7 @@ err:
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+ECORE_BUFFER_API Eina_Bool
 ecore_buffer_shutdown(void)
 {
    if (_ecore_buffer_init_count < 1)
@@ -234,7 +234,7 @@ ecore_buffer_shutdown(void)
    return EINA_TRUE;
 }
 
-EAPI Ecore_Buffer*
+ECORE_BUFFER_API Ecore_Buffer*
 ecore_buffer_new(const char *engine, unsigned int width, unsigned int height, Ecore_Buffer_Format format, unsigned int flags)
 {
    Ecore_Buffer_Module *bm;
@@ -277,7 +277,7 @@ ecore_buffer_new(const char *engine, unsigned int width, unsigned int height, Ec
    return bo;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_free(Ecore_Buffer *buf)
 {
    Ecore_Buffer_Cb_Data *free_cb;
@@ -307,7 +307,7 @@ ecore_buffer_free(Ecore_Buffer *buf)
    free(buf);
 }
 
-EAPI void *
+ECORE_BUFFER_API void *
 ecore_buffer_data_get(Ecore_Buffer *buf)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(buf, NULL);
@@ -320,7 +320,7 @@ ecore_buffer_data_get(Ecore_Buffer *buf)
    return buf->bm->be->data_get(buf->bm->data, buf->buffer_data);
 }
 
-EAPI Ecore_Pixmap
+ECORE_BUFFER_API Ecore_Pixmap
 ecore_buffer_pixmap_get(Ecore_Buffer *buf)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(buf, 0);
@@ -333,7 +333,7 @@ ecore_buffer_pixmap_get(Ecore_Buffer *buf)
    return buf->bm->be->pixmap_get(buf->bm->data, buf->buffer_data);
 }
 
-EAPI void *
+ECORE_BUFFER_API void *
 ecore_buffer_tbm_surface_get(Ecore_Buffer *buf)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(buf, NULL);
@@ -349,7 +349,7 @@ ecore_buffer_tbm_surface_get(Ecore_Buffer *buf)
    return buf->bm->be->tbm_surface_get(buf->bm->data, buf->buffer_data);
 }
 
-EAPI Eina_Bool
+ECORE_BUFFER_API Eina_Bool
 ecore_buffer_size_get(Ecore_Buffer *buf, unsigned int *width, unsigned int *height)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(buf, EINA_FALSE);
@@ -360,7 +360,7 @@ ecore_buffer_size_get(Ecore_Buffer *buf, unsigned int *width, unsigned int *heig
    return EINA_TRUE;
 }
 
-EAPI unsigned int
+ECORE_BUFFER_API unsigned int
 ecore_buffer_format_get(Ecore_Buffer *buf)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(buf, 0);
@@ -368,7 +368,7 @@ ecore_buffer_format_get(Ecore_Buffer *buf)
    return buf->format;
 }
 
-EAPI unsigned int
+ECORE_BUFFER_API unsigned int
 ecore_buffer_flags_get(Ecore_Buffer *buf)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(buf, 0);
@@ -376,7 +376,7 @@ ecore_buffer_flags_get(Ecore_Buffer *buf)
    return buf->flags;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_free_callback_add(Ecore_Buffer *buf, Ecore_Buffer_Cb func, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(buf);
@@ -393,7 +393,7 @@ ecore_buffer_free_callback_add(Ecore_Buffer *buf, Ecore_Buffer_Cb func, void *da
    buf->free_callbacks = eina_inlist_append(buf->free_callbacks, EINA_INLIST_GET(free_cb));
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_free_callback_remove(Ecore_Buffer *buf, Ecore_Buffer_Cb func, void *data)
 {
    Ecore_Buffer_Cb_Data *free_cb;

--- a/src/lib/ecore_buffer/ecore_buffer_api.h
+++ b/src/lib/ecore_buffer/ecore_buffer_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_BUFFER_API_H
+#define _EFL_ECORE_BUFFER_API_H
+
+#ifdef ECORE_BUFFER_API
+#error ECORE_BUFFER_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_BUFFER_STATIC
+#  ifdef ECORE_BUFFER_BUILD
+#   define ECORE_BUFFER_API __declspec(dllexport)
+#  else
+#   define ECORE_BUFFER_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_BUFFER_API
+# endif
+# define ECORE_BUFFER_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_BUFFER_API __attribute__ ((visibility("default")))
+#   define ECORE_BUFFER_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_BUFFER_API
+#   define ECORE_BUFFER_API_WEAK
+#  endif
+# else
+#  define ECORE_BUFFER_API
+#  define ECORE_BUFFER_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_buffer/ecore_buffer_consumer.c
+++ b/src/lib/ecore_buffer/ecore_buffer_consumer.c
@@ -45,7 +45,7 @@ struct bq_consumer_listener _ecore_buffer_consumer_listener =
    _ecore_buffer_consumer_cb_add_buffer
 };
 
-EAPI Ecore_Buffer_Consumer *
+ECORE_BUFFER_API Ecore_Buffer_Consumer *
 ecore_buffer_consumer_new(const char *name, int32_t queue_size, int32_t w, int32_t h)
 {
    Ecore_Buffer_Consumer *consumer;
@@ -90,7 +90,7 @@ ecore_buffer_consumer_new(const char *name, int32_t queue_size, int32_t w, int32
    return consumer;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_consumer_free(Ecore_Buffer_Consumer *consumer)
 {
    EINA_SAFETY_ON_NULL_RETURN(consumer);
@@ -106,7 +106,7 @@ ecore_buffer_consumer_free(Ecore_Buffer_Consumer *consumer)
    free(consumer);
 }
 
-EAPI Eina_Bool
+ECORE_BUFFER_API Eina_Bool
 ecore_buffer_consumer_buffer_release(Ecore_Buffer_Consumer *consumer, Ecore_Buffer *buffer)
 {
    Shared_Buffer *sb;
@@ -151,7 +151,7 @@ ecore_buffer_consumer_buffer_release(Ecore_Buffer_Consumer *consumer, Ecore_Buff
    return EINA_TRUE;
 }
 
-EAPI Ecore_Buffer *
+ECORE_BUFFER_API Ecore_Buffer *
 ecore_buffer_consumer_buffer_dequeue(Ecore_Buffer_Consumer *consumer)
 {
    Shared_Buffer *sb;
@@ -179,7 +179,7 @@ ecore_buffer_consumer_buffer_dequeue(Ecore_Buffer_Consumer *consumer)
    return _shared_buffer_buffer_get(sb);
 }
 
-EAPI Eina_Bool
+ECORE_BUFFER_API Eina_Bool
 ecore_buffer_consumer_queue_is_empty(Ecore_Buffer_Consumer *consumer)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(consumer, EINA_FALSE);
@@ -187,7 +187,7 @@ ecore_buffer_consumer_queue_is_empty(Ecore_Buffer_Consumer *consumer)
    return _ecore_buffer_queue_is_empty(consumer->ebq);
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_consumer_provider_add_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Provider_Add_Cb func, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(consumer);
@@ -196,7 +196,7 @@ ecore_buffer_consumer_provider_add_cb_set(Ecore_Buffer_Consumer *consumer, Ecore
    consumer->cb.data = data;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_consumer_provider_del_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Provider_Del_Cb func, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(consumer);
@@ -205,7 +205,7 @@ ecore_buffer_consumer_provider_del_cb_set(Ecore_Buffer_Consumer *consumer, Ecore
    consumer->cb.data = data;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_consumer_buffer_enqueued_cb_set(Ecore_Buffer_Consumer *consumer, Ecore_Buffer_Consumer_Enqueue_Cb func, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(consumer);

--- a/src/lib/ecore_buffer/ecore_buffer_provider.c
+++ b/src/lib/ecore_buffer/ecore_buffer_provider.c
@@ -39,7 +39,7 @@ struct bq_provider_listener _ecore_buffer_provider_listener =
    _ecore_buffer_provider_cb_add_buffer
 };
 
-EAPI Ecore_Buffer_Provider *
+ECORE_BUFFER_API Ecore_Buffer_Provider *
 ecore_buffer_provider_new(const char *name)
 {
    Ecore_Buffer_Provider *provider;
@@ -71,7 +71,7 @@ ecore_buffer_provider_new(const char *name)
    return provider;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_provider_free(Ecore_Buffer_Provider *provider)
 {
    Eina_List *shared_buffers, *l;
@@ -96,7 +96,7 @@ ecore_buffer_provider_free(Ecore_Buffer_Provider *provider)
    free(provider);
 }
 
-EAPI Ecore_Buffer_Return
+ECORE_BUFFER_API Ecore_Buffer_Return
 ecore_buffer_provider_buffer_acquire(Ecore_Buffer_Provider *provider, Ecore_Buffer **ret_buf)
 {
    Shared_Buffer *sb;
@@ -136,7 +136,7 @@ ecore_buffer_provider_buffer_acquire(Ecore_Buffer_Provider *provider, Ecore_Buff
    return ret_flag;
 }
 
-EAPI Eina_Bool
+ECORE_BUFFER_API Eina_Bool
 ecore_buffer_provider_buffer_enqueue(Ecore_Buffer_Provider *provider, Ecore_Buffer *buffer)
 {
    Shared_Buffer *sb;
@@ -191,7 +191,7 @@ ecore_buffer_provider_buffer_enqueue(Ecore_Buffer_Provider *provider, Ecore_Buff
    return EINA_TRUE;
 }
 
-EAPI Ecore_Buffer_Return
+ECORE_BUFFER_API Ecore_Buffer_Return
 ecore_buffer_provider_buffer_acquirable_check(Ecore_Buffer_Provider *provider)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(provider, EINA_FALSE);
@@ -207,7 +207,7 @@ ecore_buffer_provider_buffer_acquirable_check(Ecore_Buffer_Provider *provider)
    return ECORE_BUFFER_RETURN_NOT_EMPTY;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_provider_consumer_add_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Consumer_Add_Cb func, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(provider);
@@ -216,7 +216,7 @@ ecore_buffer_provider_consumer_add_cb_set(Ecore_Buffer_Provider *provider, Ecore
    provider->cb.data = data;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_provider_consumer_del_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Consumer_Del_Cb func, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(provider);
@@ -225,7 +225,7 @@ ecore_buffer_provider_consumer_del_cb_set(Ecore_Buffer_Provider *provider, Ecore
    provider->cb.data = data;
 }
 
-EAPI void
+ECORE_BUFFER_API void
 ecore_buffer_provider_buffer_released_cb_set(Ecore_Buffer_Provider *provider, Ecore_Buffer_Provider_Enqueue_Cb func, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(provider);

--- a/src/lib/ecore_buffer/ecore_buffer_queue_main.c
+++ b/src/lib/ecore_buffer/ecore_buffer_queue_main.c
@@ -5,7 +5,7 @@
 int _ecore_buffer_queue_log_dom = -1;
 static int _ecore_buffer_queue_init_count = 0;
 
-EAPI int
+ECORE_BUFFER_API int
 ecore_buffer_queue_init(void)
 {
    if (++_ecore_buffer_queue_init_count != 1)
@@ -39,7 +39,7 @@ err:
    return --_ecore_buffer_queue_init_count;
 }
 
-EAPI int
+ECORE_BUFFER_API int
 ecore_buffer_queue_shutdown(void)
 {
    if (--_ecore_buffer_queue_init_count != 0)

--- a/src/lib/ecore_buffer/meson.build
+++ b/src/lib/ecore_buffer/meson.build
@@ -20,7 +20,7 @@ ecore_buffer_src = files([
 
 ecore_buffer_lib = library('ecore_buffer',
     ecore_buffer_src, pub_eo_file_target,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_BUFFER_BUILD'],
     dependencies: ecore_buffer_pub_deps + ecore_buffer_deps + ecore_buffer_ext_deps,
     include_directories : config_dir,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.