### PR TITLE
[ecore_drm] Use ECORE_DRM_API instead of EAPI

### DIFF
--- a/src/lib/ecore_drm/Ecore_Drm.h
+++ b/src/lib/ecore_drm/Ecore_Drm.h
@@ -8,19 +8,7 @@
 # include <Eeze.h>
 # include <xkbcommon/xkbcommon.h>
 
-# ifdef EAPI
-#  undef EAPI
-# endif
-
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else // if __GNUC__ >= 4
-#   define EAPI
-#  endif // if __GNUC__ >= 4
-# else // ifdef __GNUC__
-#  define EAPI
-# endif // ifdef __GNUC__
+# include <ecore_drm_api.h>
 
 # warning The Ecore_Drm library has been deprecated. Please use the Ecore_Drm2 library
 
@@ -202,121 +190,121 @@ typedef struct _Ecore_Drm_Event_Output Ecore_Drm_Event_Output;
 /** @since 1.14 */
 typedef void (*Ecore_Drm_Pageflip_Cb)(void *data);
 
-EAPI extern int ECORE_DRM_EVENT_ACTIVATE;
+ECORE_DRM_API extern int ECORE_DRM_EVENT_ACTIVATE;
 
-EAPI extern int ECORE_DRM_EVENT_OUTPUT; /**< @since 1.14 */
+ECORE_DRM_API extern int ECORE_DRM_EVENT_OUTPUT; /**< @since 1.14 */
 
-EAPI extern int ECORE_DRM_EVENT_SEAT_ADD; /**< @since 1.14 */
+ECORE_DRM_API extern int ECORE_DRM_EVENT_SEAT_ADD; /**< @since 1.14 */
 
 /**
  * @file
  * @defgroup Ecore_Drm_Group Ecore_Drm - Drm Integration
  * @ingroup Ecore
  * @brief Ecore functions for dealing with drm, virtual terminals.
- * 
+ *
  * Ecore_Drm provides a wrapper and functions for using libdrm.
- * 
+ *
  * @li @ref Ecore_Drm_Init_Group
  * @li @ref Ecore_Drm_Device_Group
  * @li @ref Ecore_Drm_Tty_Group
  * @li @ref Ecore_Drm_Output_Group
  * @li @ref Ecore_Drm_Input_Group
  * @li @ref Ecore_Drm_Fb_Group
- * 
+ *
  */
 
-EAPI int ecore_drm_init(void);
-EAPI int ecore_drm_shutdown(void);
+ECORE_DRM_API int ecore_drm_init(void);
+ECORE_DRM_API int ecore_drm_shutdown(void);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Finds a drm device in the system.
  *
- * @param name The name of the device to find. If NULL, this function will 
+ * @param name The name of the device to find. If NULL, this function will
  *             search for the default drm device.
- * @param seat The name of the seat where this device may be found. If NULL, 
+ * @param seat The name of the seat where this device may be found. If NULL,
  *             this function will use a default seat name 'seat0'.
- * 
+ *
  * @return An opaque Ecore_Drm_Device structure representing the card.
- * 
+ *
  */
-EAPI Ecore_Drm_Device *ecore_drm_device_find(const char *name, const char *seat);
+ECORE_DRM_API Ecore_Drm_Device *ecore_drm_device_find(const char *name, const char *seat);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Frees an Ecore_Drm_Device.
  *
  * This function will cleanup and free any previously allocated Ecore_Drm_Device.
- * 
+ *
  * @param dev The Ecore_Drm_Device to free
- * 
+ *
  */
-EAPI void ecore_drm_device_free(Ecore_Drm_Device *dev);
+ECORE_DRM_API void ecore_drm_device_free(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Opens an Ecore_Drm_Device.
  *
  * This function will open an existing Ecore_Drm_Device for use.
- * 
+ *
  * @param dev The Ecore_Drm_Device to try and open
- * 
+ *
  * @return @c EINA_TRUE on success, @c EINA_FALSE on failure
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_device_open(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_device_open(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Closes an Ecore_Drm_Device.
  *
  * This function will close a previously opened Ecore_Drm_Device
- * 
+ *
  * @param dev The Ecore_Drm_Device to free
- * 
+ *
  * @return @c EINA_TRUE on success, @c EINA_FALSE on failure
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_device_close(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_device_close(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Gets if a given Ecore_Drm_Device is master.
- * 
+ *
  * This function will check if the given drm device is set to master
- * 
+ *
  * @param dev The Ecore_Drm_Device to check
- * 
+ *
  * @return @c EINA_TRUE if device is master, @c EINA_FALSE otherwise
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_device_master_get(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_device_master_get(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Sets a given Ecore_Drm_Device to master.
- * 
+ *
  * This function will attempt to set a given drm device to be master
- * 
+ *
  * @param dev The Ecore_Drm_Device to set
- * 
+ *
  * @return @c EINA_TRUE on success, @c EINA_FALSE on failure
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_device_master_set(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_device_master_set(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Tells a given Ecore_Drm_Device to stop being master.
- * 
+ *
  * This function will attempt to ask a drm device to stop being master
- * 
+ *
  * @param dev The Ecore_Drm_Device to set
- * 
+ *
  * @return @c EINA_TRUE on success, @c EINA_FALSE on failure
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_device_master_drop(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_device_master_drop(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -329,7 +317,7 @@ EAPI Eina_Bool ecore_drm_device_master_drop(Ecore_Drm_Device *dev);
  * @return fd Value on success, @c -1 on failure
  *
  */
-EAPI int ecore_drm_device_fd_get(Ecore_Drm_Device *dev);
+ECORE_DRM_API int ecore_drm_device_fd_get(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -342,7 +330,7 @@ EAPI int ecore_drm_device_fd_get(Ecore_Drm_Device *dev);
  *
  * @since 1.10
  */
-EAPI void ecore_drm_device_window_set(Ecore_Drm_Device *dev, unsigned int window);
+ECORE_DRM_API void ecore_drm_device_window_set(Ecore_Drm_Device *dev, unsigned int window);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -357,7 +345,7 @@ EAPI void ecore_drm_device_window_set(Ecore_Drm_Device *dev, unsigned int window
  *
  * @since 1.10
  */
-EAPI const char *ecore_drm_device_name_get(Ecore_Drm_Device *dev);
+ECORE_DRM_API const char *ecore_drm_device_name_get(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -372,7 +360,7 @@ EAPI const char *ecore_drm_device_name_get(Ecore_Drm_Device *dev);
  *
  * @since 1.14
  */
-EAPI Eina_Bool ecore_drm_device_software_setup(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_device_software_setup(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -387,7 +375,7 @@ EAPI Eina_Bool ecore_drm_device_software_setup(Ecore_Drm_Device *dev);
  *
  * @since 1.17
  */
-EAPI Eina_Bool ecore_drm_device_pointer_left_handed_set(Ecore_Drm_Device *dev, Eina_Bool left_handed);
+ECORE_DRM_API Eina_Bool ecore_drm_device_pointer_left_handed_set(Ecore_Drm_Device *dev, Eina_Bool left_handed);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -399,7 +387,7 @@ EAPI Eina_Bool ecore_drm_device_pointer_left_handed_set(Ecore_Drm_Device *dev, E
  *
  * @since 1.17
  */
-EAPI void ecore_drm_device_keyboard_cached_context_set(struct xkb_context *ctx);
+ECORE_DRM_API void ecore_drm_device_keyboard_cached_context_set(struct xkb_context *ctx);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -411,13 +399,13 @@ EAPI void ecore_drm_device_keyboard_cached_context_set(struct xkb_context *ctx);
  *
  * @since 1.17
  */
-EAPI void ecore_drm_device_keyboard_cached_keymap_set(struct xkb_keymap *map);
+ECORE_DRM_API void ecore_drm_device_keyboard_cached_keymap_set(struct xkb_keymap *map);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Finds an Ecore_Drm_Output at the given coordinates.
  *
- * This function will loop all the existing outputs in Ecore_Drm_Device and 
+ * This function will loop all the existing outputs in Ecore_Drm_Device and
  * return an output if one exists that encapsulates the given coordinates.
  *
  * @param dev The Ecore_Drm_Device to search
@@ -428,66 +416,66 @@ EAPI void ecore_drm_device_keyboard_cached_keymap_set(struct xkb_keymap *map);
  *
  * @since 1.14
  */
-EAPI Ecore_Drm_Output *ecore_drm_device_output_find(Ecore_Drm_Device *dev, int x, int y);
+ECORE_DRM_API Ecore_Drm_Output *ecore_drm_device_output_find(Ecore_Drm_Device *dev, int x, int y);
 
 /**
  * @ingroup Ecore_Drm_Tty_Group
  * @brief Opens a tty for use.
- * 
+ *
  * @param dev  The Ecore_Drm_Device that this tty will belong to.
- * @param name The name of the tty to try and open. 
+ * @param name The name of the tty to try and open.
  *             If NULL, /dev/tty0 will be used.
- * 
+ *
  * @return @c EINA_TRUE on success, @c EINA_FALSE on failure
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_tty_open(Ecore_Drm_Device *dev, const char *name);
+ECORE_DRM_API Eina_Bool ecore_drm_tty_open(Ecore_Drm_Device *dev, const char *name);
 
 /**
  * @ingroup Ecore_Drm_Tty_Group
  * @brief Closes an already opened tty.
- * 
+ *
  * @param dev The Ecore_Drm_Device which owns this tty.
- * 
+ *
  * @return @c EINA_TRUE on success, @c EINA_FALSE on failure
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_tty_close(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_tty_close(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Tty_Group
  * @brief Releases a virtual terminal.
- * 
+ *
  * @param dev The Ecore_Drm_Device which owns this tty.
- * 
+ *
  * @return @c EINA_TRUE on success, @c EINA_FALSE on failure
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_tty_release(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_tty_release(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Tty_Group
  * @brief Acquires a virtual terminal.
- * 
+ *
  * @param dev The Ecore_Drm_Device which owns this tty.
- * 
+ *
  * @return @c EINA_TRUE on success, @c EINA_FALSE on failure
- * 
+ *
  */
-EAPI Eina_Bool ecore_drm_tty_acquire(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_tty_acquire(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Tty_Group
  * @brief Gets the opened virtual terminal file descriptor.
  *
  * @param dev The Ecore_Drm_Device which owns this tty.
- * 
+ *
  * @return    The tty fd opened from previous call to ecore_drm_tty_open
- * 
- * 
+ *
+ *
  * @since 1.10
  */
-EAPI int ecore_drm_tty_get(Ecore_Drm_Device *dev);
+ECORE_DRM_API int ecore_drm_tty_get(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -496,12 +484,12 @@ EAPI int ecore_drm_tty_get(Ecore_Drm_Device *dev);
  * This function will create outputs for Ecore_Drm_Device.
  *
  * @param dev The Ecore_Drm_Device device for which outputs
- *            needs to be created   
- * 
+ *            needs to be created
+ *
  * @return EINA_TRUE on success, EINA_FALSE on failure.
  *
  */
-EAPI Eina_Bool ecore_drm_outputs_create(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_outputs_create(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -510,9 +498,9 @@ EAPI Eina_Bool ecore_drm_outputs_create(Ecore_Drm_Device *dev);
  * This function will cleanup and free any previously allocated Ecore_Drm_Output.
  *
  * @param output The Ecore_Drm_Output to free
- * 
+ *
  */
-EAPI void ecore_drm_output_free(Ecore_Drm_Output *output);
+ECORE_DRM_API void ecore_drm_output_free(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -526,7 +514,7 @@ EAPI void ecore_drm_output_free(Ecore_Drm_Output *output);
  * @param h The height of cursor
  *
  */
-EAPI void ecore_drm_output_cursor_size_set(Ecore_Drm_Output *output, int handle, int w, int h);
+ECORE_DRM_API void ecore_drm_output_cursor_size_set(Ecore_Drm_Output *output, int handle, int w, int h);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -538,7 +526,7 @@ EAPI void ecore_drm_output_cursor_size_set(Ecore_Drm_Output *output, int handle,
  *
  * @since 1.14
  */
-EAPI Eina_Bool ecore_drm_output_enable(Ecore_Drm_Output *output);
+ECORE_DRM_API Eina_Bool ecore_drm_output_enable(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -550,13 +538,13 @@ EAPI Eina_Bool ecore_drm_output_enable(Ecore_Drm_Output *output);
  *
  * @since 1.14
  */
-EAPI void ecore_drm_output_disable(Ecore_Drm_Output *output);
+ECORE_DRM_API void ecore_drm_output_disable(Ecore_Drm_Output *output);
 
 /* TODO: Doxy */
-EAPI void ecore_drm_output_fb_release(Ecore_Drm_Output *output, Ecore_Drm_Fb *fb);
+ECORE_DRM_API void ecore_drm_output_fb_release(Ecore_Drm_Output *output, Ecore_Drm_Fb *fb);
 
 /* TODO: Doxy */
-EAPI void ecore_drm_output_repaint(Ecore_Drm_Output *output);
+ECORE_DRM_API void ecore_drm_output_repaint(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -565,18 +553,18 @@ EAPI void ecore_drm_output_repaint(Ecore_Drm_Output *output);
  * This function will give the output size of Ecore_Drm_Device.
  *
  * @param dev The Ecore_Drm_Device to get output size
- * @param output The output id whose information needs to be retrieved 
+ * @param output The output id whose information needs to be retrieved
  * @param *w The parameter in which output width is stored
  * @param *h The parameter in which output height is stored
  *
  */
-EAPI void ecore_drm_output_size_get(Ecore_Drm_Device *dev, int output, int *w, int *h);
+ECORE_DRM_API void ecore_drm_output_size_get(Ecore_Drm_Device *dev, int output, int *w, int *h);
 
 /**
  * TODO: Doxy
  * @since 1.12
  */
-EAPI void ecore_drm_outputs_geometry_get(Ecore_Drm_Device *dev, int *x, int *y, int *w, int *h);
+ECORE_DRM_API void ecore_drm_outputs_geometry_get(Ecore_Drm_Device *dev, int *x, int *y, int *w, int *h);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -590,7 +578,7 @@ EAPI void ecore_drm_outputs_geometry_get(Ecore_Drm_Device *dev, int *x, int *y, 
  *
  * @since 1.14
  */
-EAPI unsigned int ecore_drm_output_crtc_id_get(Ecore_Drm_Output *output);
+ECORE_DRM_API unsigned int ecore_drm_output_crtc_id_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -604,7 +592,7 @@ EAPI unsigned int ecore_drm_output_crtc_id_get(Ecore_Drm_Output *output);
  *
  * @since 1.14
  */
-EAPI unsigned int ecore_drm_output_crtc_buffer_get(Ecore_Drm_Output *output);
+ECORE_DRM_API unsigned int ecore_drm_output_crtc_buffer_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -618,27 +606,27 @@ EAPI unsigned int ecore_drm_output_crtc_buffer_get(Ecore_Drm_Output *output);
  *
  * @since 1.14
  */
-EAPI unsigned int ecore_drm_output_connector_id_get(Ecore_Drm_Output *output);
+ECORE_DRM_API unsigned int ecore_drm_output_connector_id_get(Ecore_Drm_Output *output);
 
 /** @defgroup Ecore_Drm_Input_Group Drm input handling
  *  @{
  */
-EAPI Eina_Bool ecore_drm_inputs_create(Ecore_Drm_Device *dev);
-EAPI void ecore_drm_inputs_destroy(Ecore_Drm_Device *dev);
-EAPI Eina_Bool ecore_drm_inputs_enable(Ecore_Drm_Input *input);
-EAPI void ecore_drm_inputs_disable(Ecore_Drm_Input *input);
-EAPI void ecore_drm_inputs_device_axis_size_set(Ecore_Drm_Evdev *dev, int w, int h);
+ECORE_DRM_API Eina_Bool ecore_drm_inputs_create(Ecore_Drm_Device *dev);
+ECORE_DRM_API void ecore_drm_inputs_destroy(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_inputs_enable(Ecore_Drm_Input *input);
+ECORE_DRM_API void ecore_drm_inputs_disable(Ecore_Drm_Input *input);
+ECORE_DRM_API void ecore_drm_inputs_device_axis_size_set(Ecore_Drm_Evdev *dev, int w, int h);
 /**
  * @}
  */
 
-EAPI Eina_Bool ecore_drm_sprites_create(Ecore_Drm_Device *dev);
-EAPI void ecore_drm_sprites_destroy(Ecore_Drm_Device *dev);
-EAPI void ecore_drm_sprites_fb_set(Ecore_Drm_Sprite *sprite, int fb_id, int flags);
-EAPI Eina_Bool ecore_drm_sprites_crtc_supported(Ecore_Drm_Output *output, unsigned int supported);
+ECORE_DRM_API Eina_Bool ecore_drm_sprites_create(Ecore_Drm_Device *dev);
+ECORE_DRM_API void ecore_drm_sprites_destroy(Ecore_Drm_Device *dev);
+ECORE_DRM_API void ecore_drm_sprites_fb_set(Ecore_Drm_Sprite *sprite, int fb_id, int flags);
+ECORE_DRM_API Eina_Bool ecore_drm_sprites_crtc_supported(Ecore_Drm_Output *output, unsigned int supported);
 
-EAPI Ecore_Drm_Fb *ecore_drm_fb_create(Ecore_Drm_Device *dev, int width, int height);
-EAPI void ecore_drm_fb_destroy(Ecore_Drm_Fb *fb);
+ECORE_DRM_API Ecore_Drm_Fb *ecore_drm_fb_create(Ecore_Drm_Device *dev, int width, int height);
+ECORE_DRM_API void ecore_drm_fb_destroy(Ecore_Drm_Fb *fb);
 
 /**
  * @ingroup Ecore_Drm_Fb_Group
@@ -649,10 +637,10 @@ EAPI void ecore_drm_fb_destroy(Ecore_Drm_Fb *fb);
  * @param fb The Ecore_Drm_Fb to mark as dirty
  * @param rects The regions of the Ecore_Drm_Fb which are dirty
  * @param count The number of regions
- * 
+ *
  * @since 1.14
  */
-EAPI void ecore_drm_fb_dirty(Ecore_Drm_Fb *fb, Eina_Rectangle *rects, unsigned int count);
+ECORE_DRM_API void ecore_drm_fb_dirty(Ecore_Drm_Fb *fb, Eina_Rectangle *rects, unsigned int count);
 
 /**
  * @ingroup Ecore_Drm_Fb_Group
@@ -668,7 +656,7 @@ EAPI void ecore_drm_fb_dirty(Ecore_Drm_Fb *fb, Eina_Rectangle *rects, unsigned i
  *
  * @since 1.14
  */
-EINA_DEPRECATED EAPI void ecore_drm_fb_set(Ecore_Drm_Device *dev, Ecore_Drm_Fb *fb);
+EINA_DEPRECATED ECORE_DRM_API void ecore_drm_fb_set(Ecore_Drm_Device *dev, Ecore_Drm_Fb *fb);
 
 /**
  * @internal
@@ -685,10 +673,10 @@ EINA_DEPRECATED EAPI void ecore_drm_fb_set(Ecore_Drm_Device *dev, Ecore_Drm_Fb *
  *
  * @since 1.14
  */
-EAPI void ecore_drm_fb_send(Ecore_Drm_Device *dev, Ecore_Drm_Fb *fb, Ecore_Drm_Pageflip_Cb func, void *data);
+ECORE_DRM_API void ecore_drm_fb_send(Ecore_Drm_Device *dev, Ecore_Drm_Fb *fb, Ecore_Drm_Pageflip_Cb func, void *data);
 
-EAPI Eina_Bool ecore_drm_launcher_connect(Ecore_Drm_Device *dev);
-EAPI void ecore_drm_launcher_disconnect(Ecore_Drm_Device *dev);
+ECORE_DRM_API Eina_Bool ecore_drm_launcher_connect(Ecore_Drm_Device *dev);
+ECORE_DRM_API void ecore_drm_launcher_disconnect(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -702,7 +690,7 @@ EAPI void ecore_drm_launcher_disconnect(Ecore_Drm_Device *dev);
  *
  * @since 1.14
  */
-EAPI void ecore_drm_output_position_get(Ecore_Drm_Output *output, int *x, int *y);
+ECORE_DRM_API void ecore_drm_output_position_get(Ecore_Drm_Output *output, int *x, int *y);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -717,7 +705,7 @@ EAPI void ecore_drm_output_position_get(Ecore_Drm_Output *output, int *x, int *y
  *
  * @since 1.14
  */
-EAPI void ecore_drm_output_current_resolution_get(Ecore_Drm_Output *output, int *w, int *h, unsigned int *refresh);
+ECORE_DRM_API void ecore_drm_output_current_resolution_get(Ecore_Drm_Output *output, int *w, int *h, unsigned int *refresh);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -731,7 +719,7 @@ EAPI void ecore_drm_output_current_resolution_get(Ecore_Drm_Output *output, int 
  *
  * @since 1.14
  */
-EAPI void ecore_drm_output_physical_size_get(Ecore_Drm_Output *output, int *w, int *h);
+ECORE_DRM_API void ecore_drm_output_physical_size_get(Ecore_Drm_Output *output, int *w, int *h);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -744,7 +732,7 @@ EAPI void ecore_drm_output_physical_size_get(Ecore_Drm_Output *output, int *w, i
  *
  * @since 1.14
  */
-EAPI unsigned int ecore_drm_output_subpixel_order_get(Ecore_Drm_Output *output);
+ECORE_DRM_API unsigned int ecore_drm_output_subpixel_order_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -757,7 +745,7 @@ EAPI unsigned int ecore_drm_output_subpixel_order_get(Ecore_Drm_Output *output);
  *
  * @since 1.14
  */
-EAPI Eina_Stringshare *ecore_drm_output_model_get(Ecore_Drm_Output *output);
+ECORE_DRM_API Eina_Stringshare *ecore_drm_output_model_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -770,7 +758,7 @@ EAPI Eina_Stringshare *ecore_drm_output_model_get(Ecore_Drm_Output *output);
  *
  * @since 1.14
  */
-EAPI Eina_Stringshare *ecore_drm_output_make_get(Ecore_Drm_Output *output);
+ECORE_DRM_API Eina_Stringshare *ecore_drm_output_make_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -783,7 +771,7 @@ EAPI Eina_Stringshare *ecore_drm_output_make_get(Ecore_Drm_Output *output);
  *
  * @since 1.15
  */
-EAPI char *ecore_drm_output_name_get(Ecore_Drm_Output *output);
+ECORE_DRM_API char *ecore_drm_output_name_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -793,10 +781,10 @@ EAPI char *ecore_drm_output_name_get(Ecore_Drm_Output *output);
  *
  * @param output The Ecore_Drm_Output to set the dpms level on
  * @param level The level to set
- * 
+ *
  * @since 1.14
  */
-EAPI void ecore_drm_output_dpms_set(Ecore_Drm_Output *output, int level);
+ECORE_DRM_API void ecore_drm_output_dpms_set(Ecore_Drm_Output *output, int level);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -809,10 +797,10 @@ EAPI void ecore_drm_output_dpms_set(Ecore_Drm_Output *output, int level);
  * @param r The amount to scale the red channel
  * @param g The amount to scale the green channel
  * @param b The amount to scale the blue channel
- * 
+ *
  * @since 1.14
  */
-EAPI void ecore_drm_output_gamma_set(Ecore_Drm_Output *output, uint16_t size, uint16_t *r, uint16_t *g, uint16_t *b);
+ECORE_DRM_API void ecore_drm_output_gamma_set(Ecore_Drm_Output *output, uint16_t size, uint16_t *r, uint16_t *g, uint16_t *b);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -826,7 +814,7 @@ EAPI void ecore_drm_output_gamma_set(Ecore_Drm_Output *output, uint16_t size, ui
  *
  * @since 1.14
  */
-EAPI void ecore_drm_device_pointer_xy_get(Ecore_Drm_Device *dev, int *x, int *y);
+ECORE_DRM_API void ecore_drm_device_pointer_xy_get(Ecore_Drm_Device *dev, int *x, int *y);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -840,7 +828,7 @@ EAPI void ecore_drm_device_pointer_xy_get(Ecore_Drm_Device *dev, int *x, int *y)
  *
  * @since 1.18
  */
-EAPI void ecore_drm_device_pointer_warp(Ecore_Drm_Device *dev, int x, int y);
+ECORE_DRM_API void ecore_drm_device_pointer_warp(Ecore_Drm_Device *dev, int x, int y);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -850,7 +838,7 @@ EAPI void ecore_drm_device_pointer_warp(Ecore_Drm_Device *dev, int x, int y);
  *
  * @since 1.14
  */
-EAPI const Eina_List *ecore_drm_devices_get(void);
+ECORE_DRM_API const Eina_List *ecore_drm_devices_get(void);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
@@ -864,7 +852,7 @@ EAPI const Eina_List *ecore_drm_devices_get(void);
  *
  * @since 1.15
  */
-EAPI void ecore_drm_screen_size_range_get(Ecore_Drm_Device *dev, int *minw, int *minh, int *maxw, int *maxh);
+ECORE_DRM_API void ecore_drm_screen_size_range_get(Ecore_Drm_Device *dev, int *minw, int *minh, int *maxw, int *maxh);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -876,7 +864,7 @@ EAPI void ecore_drm_screen_size_range_get(Ecore_Drm_Device *dev, int *minw, int 
  *
  * @since 1.15
  */
-EAPI Eina_Bool ecore_drm_output_connected_get(Ecore_Drm_Output *output);
+ECORE_DRM_API Eina_Bool ecore_drm_output_connected_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -888,7 +876,7 @@ EAPI Eina_Bool ecore_drm_output_connected_get(Ecore_Drm_Output *output);
  *
  * @since 1.15
  */
-EAPI unsigned int ecore_drm_output_connector_type_get(Ecore_Drm_Output *output);
+ECORE_DRM_API unsigned int ecore_drm_output_connector_type_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -900,7 +888,7 @@ EAPI unsigned int ecore_drm_output_connector_type_get(Ecore_Drm_Output *output);
  *
  * @since 1.15
  */
-EAPI Eina_Bool ecore_drm_output_backlight_get(Ecore_Drm_Output *output);
+ECORE_DRM_API Eina_Bool ecore_drm_output_backlight_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -912,7 +900,7 @@ EAPI Eina_Bool ecore_drm_output_backlight_get(Ecore_Drm_Output *output);
  *
  * @since 1.15
  */
-EAPI char *ecore_drm_output_edid_get(Ecore_Drm_Output *output);
+ECORE_DRM_API char *ecore_drm_output_edid_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -926,7 +914,7 @@ EAPI char *ecore_drm_output_edid_get(Ecore_Drm_Output *output);
  *
  * @since 1.15
  */
-EAPI Eina_List *ecore_drm_output_modes_get(Ecore_Drm_Output *output);
+ECORE_DRM_API Eina_List *ecore_drm_output_modes_get(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -938,7 +926,7 @@ EAPI Eina_List *ecore_drm_output_modes_get(Ecore_Drm_Output *output);
  *
  * @since 1.15
  */
-EAPI Ecore_Drm_Output *ecore_drm_output_primary_get(Ecore_Drm_Device *dev);
+ECORE_DRM_API Ecore_Drm_Output *ecore_drm_output_primary_get(Ecore_Drm_Device *dev);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -948,7 +936,7 @@ EAPI Ecore_Drm_Output *ecore_drm_output_primary_get(Ecore_Drm_Device *dev);
  *
  * @since 1.15
  */
-EAPI void ecore_drm_output_primary_set(Ecore_Drm_Output *output);
+ECORE_DRM_API void ecore_drm_output_primary_set(Ecore_Drm_Output *output);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -960,13 +948,13 @@ EAPI void ecore_drm_output_primary_set(Ecore_Drm_Output *output);
  *
  * @since 1.15
  */
-EAPI void ecore_drm_output_crtc_size_get(Ecore_Drm_Output *output, int *width, int *height);
+ECORE_DRM_API void ecore_drm_output_crtc_size_get(Ecore_Drm_Output *output, int *width, int *height);
 
 /**
  * @ingroup Ecore_Drm_Device_Group
  * @brief Finds an Ecore_Drm_Output which has the given name.
  *
- * This function will loop all the existing outputs in Ecore_Drm_Device and 
+ * This function will loop all the existing outputs in Ecore_Drm_Device and
  * return an output if one exists that matches the given name.
  *
  * @param dev The Ecore_Drm_Device to search
@@ -976,7 +964,7 @@ EAPI void ecore_drm_output_crtc_size_get(Ecore_Drm_Output *output, int *width, i
  *
  * @since 1.15
  */
-EAPI Ecore_Drm_Output *ecore_drm_device_output_name_find(Ecore_Drm_Device *dev, const char *name);
+ECORE_DRM_API Ecore_Drm_Output *ecore_drm_device_output_name_find(Ecore_Drm_Device *dev, const char *name);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -992,7 +980,7 @@ EAPI Ecore_Drm_Output *ecore_drm_device_output_name_find(Ecore_Drm_Device *dev, 
  *
  * @since 1.15
  */
-EAPI Eina_Bool ecore_drm_output_possible_crtc_get(Ecore_Drm_Output *output, unsigned int crtc);
+ECORE_DRM_API Eina_Bool ecore_drm_output_possible_crtc_get(Ecore_Drm_Output *output, unsigned int crtc);
 
 /**
  * @ingroup Ecore_Drm_Output_Group
@@ -1009,15 +997,15 @@ EAPI Eina_Bool ecore_drm_output_possible_crtc_get(Ecore_Drm_Output *output, unsi
  *
  * @since 1.15
  */
-EAPI Eina_Bool ecore_drm_output_mode_set(Ecore_Drm_Output *output, Ecore_Drm_Output_Mode *mode, int x, int y);
+ECORE_DRM_API Eina_Bool ecore_drm_output_mode_set(Ecore_Drm_Output *output, Ecore_Drm_Output_Mode *mode, int x, int y);
 
 /* TODO: doxy */
 /* @since 1.18 */
-EAPI unsigned int ecore_drm_output_supported_rotations_get(Ecore_Drm_Output *output, Ecore_Drm_Plane_Type type);
+ECORE_DRM_API unsigned int ecore_drm_output_supported_rotations_get(Ecore_Drm_Output *output, Ecore_Drm_Plane_Type type);
 
 /* TODO: doxy */
 /* @since 1.18 */
-EAPI Eina_Bool ecore_drm_output_rotation_set(Ecore_Drm_Output *output, Ecore_Drm_Plane_Type type, unsigned int rotation);
+ECORE_DRM_API Eina_Bool ecore_drm_output_rotation_set(Ecore_Drm_Output *output, Ecore_Drm_Plane_Type type, unsigned int rotation);
 
 /**
  * @ingroup Ecore_Drm_Input_Group
@@ -1033,7 +1021,7 @@ EAPI Eina_Bool ecore_drm_output_rotation_set(Ecore_Drm_Output *output, Ecore_Drm
  *
  * @since 1.17
  */
-EAPI Eina_Bool ecore_drm_evdev_key_remap_enable(Ecore_Drm_Evdev *edev, Eina_Bool enable);
+ECORE_DRM_API Eina_Bool ecore_drm_evdev_key_remap_enable(Ecore_Drm_Evdev *edev, Eina_Bool enable);
 
 /**
  * @ingroup Ecore_Drm_Input_Group
@@ -1052,13 +1040,10 @@ EAPI Eina_Bool ecore_drm_evdev_key_remap_enable(Ecore_Drm_Evdev *edev, Eina_Bool
  *
  * @since 1.17
  */
-EAPI Eina_Bool ecore_drm_evdev_key_remap_set(Ecore_Drm_Evdev *edev, int *from_keys, int *to_keys, int num);
+ECORE_DRM_API Eina_Bool ecore_drm_evdev_key_remap_set(Ecore_Drm_Evdev *edev, int *from_keys, int *to_keys, int num);
 
 # ifdef __cplusplus
 }
 # endif
-
-# undef EAPI
-# define EAPI
 
 #endif

--- a/src/lib/ecore_drm/ecore_drm.c
+++ b/src/lib/ecore_drm/ecore_drm.c
@@ -34,7 +34,7 @@ static int _ecore_drm_init_count = 0;
 /* external variables */
 int _ecore_drm_log_dom = -1;
 
-EAPI int ECORE_DRM_EVENT_ACTIVATE = 0;
+ECORE_DRM_API int ECORE_DRM_EVENT_ACTIVATE = 0;
 
 static void
 _ecore_drm_event_activate_free(void *data EINA_UNUSED, void *event)
@@ -68,7 +68,7 @@ _ecore_drm_event_activate_send(Eina_Bool active)
  * 
  * @ingroup Ecore_Drm_Init_Group
  */
-EAPI int 
+ECORE_DRM_API int 
 ecore_drm_init(void)
 {
    /* if we have already initialized, return the count */
@@ -134,7 +134,7 @@ log_err:
  *
  * @ingroup Ecore_Drm_Init_Group
  */
-EAPI int
+ECORE_DRM_API int
 ecore_drm_shutdown(void)
 {
    Eina_List *lists;

--- a/src/lib/ecore_drm/ecore_drm_api.h
+++ b/src/lib/ecore_drm/ecore_drm_api.h
@@ -30,3 +30,5 @@
 #  define ECORE_DRM_API_WEAK
 # endif
 #endif
+
+#endif

--- a/src/lib/ecore_drm/ecore_drm_api.h
+++ b/src/lib/ecore_drm/ecore_drm_api.h
@@ -1,0 +1,32 @@
+#ifndef _EFL_ECORE_DRM_API_H
+#define _EFL_ECORE_DRM_API_H
+
+#ifdef ECORE_DRM_API
+#error ECORE_DRM_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_DRM_STATIC
+#  ifdef ECORE_DRM_BUILD
+#   define ECORE_DRM_API __declspec(dllexport)
+#  else
+#   define ECORE_DRM_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_DRM_API
+# endif
+# define ECORE_DRM_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_DRM_API __attribute__ ((visibility("default")))
+#   define ECORE_DRM_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_DRM_API
+#   define ECORE_DRM_API_WEAK
+#  endif
+# else
+#  define ECORE_DRM_API
+#  define ECORE_DRM_API_WEAK
+# endif
+#endif

--- a/src/lib/ecore_drm/ecore_drm_device.c
+++ b/src/lib/ecore_drm/ecore_drm_device.c
@@ -198,7 +198,7 @@ _ecore_drm_device_cached_keymap_update(struct xkb_keymap *map)
  * the DRM device itself.
  */
 
-EAPI Ecore_Drm_Device *
+ECORE_DRM_API Ecore_Drm_Device *
 ecore_drm_device_find(const char *name, const char *seat)
 {
    Ecore_Drm_Device *dev = NULL;
@@ -297,7 +297,7 @@ out:
    return dev;
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_device_free(Ecore_Drm_Device *dev)
 {
    unsigned int i = 0;
@@ -334,7 +334,7 @@ ecore_drm_device_free(Ecore_Drm_Device *dev)
    free(dev);
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_device_open(Ecore_Drm_Device *dev)
 {
    uint64_t caps;
@@ -423,7 +423,7 @@ ecore_drm_device_open(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_device_close(Ecore_Drm_Device *dev)
 {
    /* check for valid device */
@@ -448,13 +448,13 @@ ecore_drm_device_close(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI const Eina_List *
+ECORE_DRM_API const Eina_List *
 ecore_drm_devices_get(void)
 {
    return drm_devices;
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_device_master_get(Ecore_Drm_Device *dev)
 {
    drm_magic_t mag;
@@ -470,7 +470,7 @@ ecore_drm_device_master_get(Ecore_Drm_Device *dev)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_device_master_set(Ecore_Drm_Device *dev)
 {
    /* check for valid device */
@@ -483,7 +483,7 @@ ecore_drm_device_master_set(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_device_master_drop(Ecore_Drm_Device *dev)
 {
    /* check for valid device */
@@ -496,14 +496,14 @@ ecore_drm_device_master_drop(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI int 
+ECORE_DRM_API int 
 ecore_drm_device_fd_get(Ecore_Drm_Device *dev)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(dev, -1);
    return dev->drm.fd;
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_device_window_set(Ecore_Drm_Device *dev, unsigned int window)
 {
    /* check for valid device */
@@ -512,7 +512,7 @@ ecore_drm_device_window_set(Ecore_Drm_Device *dev, unsigned int window)
    dev->window = window;
 }
 
-EAPI const char *
+ECORE_DRM_API const char *
 ecore_drm_device_name_get(Ecore_Drm_Device *dev)
 {
    /* check for valid device */
@@ -521,7 +521,7 @@ ecore_drm_device_name_get(Ecore_Drm_Device *dev)
    return dev->drm.name;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_device_pointer_xy_get(Ecore_Drm_Device *dev, int *x, int *y)
 {
    Ecore_Drm_Seat *seat;
@@ -550,7 +550,7 @@ ecore_drm_device_pointer_xy_get(Ecore_Drm_Device *dev, int *x, int *y)
      }
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_device_pointer_warp(Ecore_Drm_Device *dev, int x, int y)
 {
    Ecore_Drm_Seat *seat;
@@ -574,7 +574,7 @@ ecore_drm_device_pointer_warp(Ecore_Drm_Device *dev, int x, int y)
      }
 }
 
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_device_software_setup(Ecore_Drm_Device *dev)
 {
    unsigned int i = 0;
@@ -621,7 +621,7 @@ err:
    return EINA_FALSE;
 }
 
-EAPI Ecore_Drm_Output *
+ECORE_DRM_API Ecore_Drm_Output *
 ecore_drm_device_output_find(Ecore_Drm_Device *dev, int x, int y)
 {
    Ecore_Drm_Output *output;
@@ -651,7 +651,7 @@ ecore_drm_device_output_find(Ecore_Drm_Device *dev, int x, int y)
    return NULL;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_screen_size_range_get(Ecore_Drm_Device *dev, int *minw, int *minh, int *maxw, int *maxh)
 {
    EINA_SAFETY_ON_NULL_RETURN(dev);
@@ -662,7 +662,7 @@ ecore_drm_screen_size_range_get(Ecore_Drm_Device *dev, int *minw, int *minh, int
    if (maxh) *maxh = dev->max_height;
 }
 
-EAPI Ecore_Drm_Output *
+ECORE_DRM_API Ecore_Drm_Output *
 ecore_drm_device_output_name_find(Ecore_Drm_Device *dev, const char *name)
 {
    Ecore_Drm_Output *output;
@@ -678,7 +678,7 @@ ecore_drm_device_output_name_find(Ecore_Drm_Device *dev, const char *name)
    return NULL;
 }
 
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_device_pointer_left_handed_set(Ecore_Drm_Device *dev, Eina_Bool left_handed)
 {
    Ecore_Drm_Seat *seat = NULL;
@@ -712,7 +712,7 @@ ecore_drm_device_pointer_left_handed_set(Ecore_Drm_Device *dev, Eina_Bool left_h
    return EINA_TRUE;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_device_keyboard_cached_context_set(struct xkb_context *ctx)
 {
    EINA_SAFETY_ON_NULL_RETURN(ctx);
@@ -725,7 +725,7 @@ ecore_drm_device_keyboard_cached_context_set(struct xkb_context *ctx)
    cached_context = ctx;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_device_keyboard_cached_keymap_set(struct xkb_keymap *map)
 {
    EINA_SAFETY_ON_NULL_RETURN(map);

--- a/src/lib/ecore_drm/ecore_drm_evdev.c
+++ b/src/lib/ecore_drm/ecore_drm_evdev.c
@@ -972,7 +972,7 @@ _ecore_drm_evdev_event_process(struct libinput_event *event)
  * height must set for it. If its absolute set the ioctl correctly, if
  * not, unsupported device.
  */
-EAPI void
+ECORE_DRM_API void
 ecore_drm_inputs_device_axis_size_set(Ecore_Drm_Evdev *edev, int w, int h)
 {
    const char *sysname;
@@ -1029,7 +1029,7 @@ cont:
  * If the given enable value is EINA_FALSE, the key remap functionality wil be disable and
  * the existing hash table for remapping keys will be freed.
  */
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_evdev_key_remap_enable(Ecore_Drm_Evdev *edev, Eina_Bool enable)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(edev, EINA_FALSE);
@@ -1063,7 +1063,7 @@ ecore_drm_evdev_key_remap_enable(Ecore_Drm_Evdev *edev, Eina_Bool enable)
  * the keycode of it can be replaced with the key found in the hash table.
  * If there is no key found, the coming keycode will be used.
  */
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_evdev_key_remap_set(Ecore_Drm_Evdev *edev, int *from_keys, int *to_keys, int num)
 {
    int i;

--- a/src/lib/ecore_drm/ecore_drm_fb.c
+++ b/src/lib/ecore_drm/ecore_drm_fb.c
@@ -74,7 +74,7 @@ _ecore_drm_fb_create2(int fd, Ecore_Drm_Fb *fb)
    return EINA_TRUE;
 }
 
-EAPI Ecore_Drm_Fb *
+ECORE_DRM_API Ecore_Drm_Fb *
 ecore_drm_fb_create(Ecore_Drm_Device *dev, int width, int height)
 {
    Ecore_Drm_Fb *fb;
@@ -148,7 +148,7 @@ create_err:
    return NULL;
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_fb_destroy(Ecore_Drm_Fb *fb)
 {
    struct drm_mode_destroy_dumb darg;
@@ -163,7 +163,7 @@ ecore_drm_fb_destroy(Ecore_Drm_Fb *fb)
    free(fb);
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_fb_dirty(Ecore_Drm_Fb *fb, Eina_Rectangle *rects, unsigned int count)
 {
    EINA_SAFETY_ON_NULL_RETURN(fb);
@@ -193,7 +193,7 @@ ecore_drm_fb_dirty(Ecore_Drm_Fb *fb, Eina_Rectangle *rects, unsigned int count)
 #endif
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_fb_set(Ecore_Drm_Device *dev EINA_UNUSED, Ecore_Drm_Fb *fb EINA_UNUSED)
 {
   /* ecore_drm_fb_set no longer has any functionality distinct from
@@ -253,7 +253,7 @@ _ecore_drm_output_fb_send(Ecore_Drm_Device *dev, Ecore_Drm_Fb *fb, Ecore_Drm_Out
    output->current = fb;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_fb_send(Ecore_Drm_Device *dev, Ecore_Drm_Fb *fb, Ecore_Drm_Pageflip_Cb func EINA_UNUSED, void *data EINA_UNUSED)
 {
    Ecore_Drm_Output *output;

--- a/src/lib/ecore_drm/ecore_drm_inputs.c
+++ b/src/lib/ecore_drm/ecore_drm_inputs.c
@@ -28,7 +28,7 @@
 
 #include "ecore_drm_private.h"
 
-EAPI int ECORE_DRM_EVENT_SEAT_ADD = -1;
+ECORE_DRM_API int ECORE_DRM_EVENT_SEAT_ADD = -1;
 static Eina_Hash *_fd_hash = NULL;
 
 /* local functions */
@@ -230,7 +230,7 @@ const struct libinput_interface _input_interface =
 };
 
 /* public functions */
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_inputs_create(Ecore_Drm_Device *dev)
 {
    Ecore_Drm_Input *input;
@@ -285,7 +285,7 @@ err:
    return EINA_FALSE;
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_inputs_destroy(Ecore_Drm_Device *dev)
 {
    Ecore_Drm_Input *input;
@@ -313,7 +313,7 @@ ecore_drm_inputs_destroy(Ecore_Drm_Device *dev)
      }
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_inputs_enable(Ecore_Drm_Input *input)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(input, EINA_FALSE);
@@ -351,7 +351,7 @@ err:
    return EINA_FALSE;
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_inputs_disable(Ecore_Drm_Input *input)
 {
    EINA_SAFETY_ON_NULL_RETURN(input);

--- a/src/lib/ecore_drm/ecore_drm_launcher.c
+++ b/src/lib/ecore_drm/ecore_drm_launcher.c
@@ -81,7 +81,7 @@ _ecore_drm_launcher_device_flags_set(int fd, int flags)
    return fd;
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_launcher_connect(Ecore_Drm_Device *dev)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(dev, EINA_FALSE);
@@ -113,7 +113,7 @@ ecore_drm_launcher_connect(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_launcher_disconnect(Ecore_Drm_Device *dev)
 {
    EINA_SAFETY_ON_NULL_RETURN(dev);

--- a/src/lib/ecore_drm/ecore_drm_output.c
+++ b/src/lib/ecore_drm/ecore_drm_output.c
@@ -45,7 +45,7 @@ static const char *conn_types[] =
    "DSI",
 };
 
-EAPI int ECORE_DRM_EVENT_OUTPUT = 0;
+ECORE_DRM_API int ECORE_DRM_EVENT_OUTPUT = 0;
 
 static void
 _ecore_drm_output_event_free(void *data EINA_UNUSED, void *event)
@@ -920,7 +920,7 @@ _ecore_drm_output_render_disable(Ecore_Drm_Output *output)
  * 
  */
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_outputs_create(Ecore_Drm_Device *dev)
 {
    Eina_Bool ret = EINA_TRUE;
@@ -993,13 +993,13 @@ next:
    return ret;
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_output_free(Ecore_Drm_Output *output)
 {
    _ecore_drm_output_free(output);
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_output_cursor_size_set(Ecore_Drm_Output *output, int handle, int w, int h)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1007,7 +1007,7 @@ ecore_drm_output_cursor_size_set(Ecore_Drm_Output *output, int handle, int w, in
    drmModeSetCursor(output->dev->drm.fd, output->crtc_id, handle, w, h);
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_output_enable(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
@@ -1020,7 +1020,7 @@ ecore_drm_output_enable(Ecore_Drm_Output *output)
    return EINA_TRUE;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_output_disable(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1031,7 +1031,7 @@ ecore_drm_output_disable(Ecore_Drm_Output *output)
    _ecore_drm_output_event_send(output, EINA_FALSE);
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_output_fb_release(Ecore_Drm_Output *output, Ecore_Drm_Fb *fb)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1039,7 +1039,7 @@ ecore_drm_output_fb_release(Ecore_Drm_Output *output, Ecore_Drm_Fb *fb)
    _ecore_drm_output_fb_release(output, fb);
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_output_repaint(Ecore_Drm_Output *output)
 {
    Ecore_Drm_Device *dev;
@@ -1127,7 +1127,7 @@ err:
      }
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_output_size_get(Ecore_Drm_Device *dev, int output, int *w, int *h)
 {
    drmModeFB *fb;
@@ -1142,7 +1142,7 @@ ecore_drm_output_size_get(Ecore_Drm_Device *dev, int output, int *w, int *h)
    drmModeFreeFB(fb);
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_outputs_geometry_get(Ecore_Drm_Device *dev, int *x, int *y, int *w, int *h)
 {
    Ecore_Drm_Output *output;
@@ -1169,7 +1169,7 @@ ecore_drm_outputs_geometry_get(Ecore_Drm_Device *dev, int *x, int *y, int *w, in
    if (h) *h = oh;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_output_position_get(Ecore_Drm_Output *output, int *x, int *y)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1178,7 +1178,7 @@ ecore_drm_output_position_get(Ecore_Drm_Output *output, int *x, int *y)
    if (y) *y = output->y;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_output_current_resolution_get(Ecore_Drm_Output *output, int *w, int *h, unsigned int *refresh)
 {
    if (w) *w = 0;
@@ -1194,7 +1194,7 @@ ecore_drm_output_current_resolution_get(Ecore_Drm_Output *output, int *w, int *h
    if (refresh) *refresh = output->current_mode->refresh;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_output_physical_size_get(Ecore_Drm_Output *output, int *w, int *h)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1203,7 +1203,7 @@ ecore_drm_output_physical_size_get(Ecore_Drm_Output *output, int *w, int *h)
    if (h) *h = output->phys_height;
 }
 
-EAPI unsigned int
+ECORE_DRM_API unsigned int
 ecore_drm_output_subpixel_order_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, 0);
@@ -1211,7 +1211,7 @@ ecore_drm_output_subpixel_order_get(Ecore_Drm_Output *output)
    return output->subpixel;
 }
 
-EAPI Eina_Stringshare *
+ECORE_DRM_API Eina_Stringshare *
 ecore_drm_output_model_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
@@ -1219,7 +1219,7 @@ ecore_drm_output_model_get(Ecore_Drm_Output *output)
    return output->model;
 }
 
-EAPI Eina_Stringshare *
+ECORE_DRM_API Eina_Stringshare *
 ecore_drm_output_make_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
@@ -1227,7 +1227,7 @@ ecore_drm_output_make_get(Ecore_Drm_Output *output)
    return output->make;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_output_dpms_set(Ecore_Drm_Output *output, int level)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1238,7 +1238,7 @@ ecore_drm_output_dpms_set(Ecore_Drm_Output *output, int level)
                                output->dpms->prop_id, level);
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_output_gamma_set(Ecore_Drm_Output *output, uint16_t size, uint16_t *r, uint16_t *g, uint16_t *b)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1251,7 +1251,7 @@ ecore_drm_output_gamma_set(Ecore_Drm_Output *output, uint16_t size, uint16_t *r,
      ERR("Failed to set output gamma: %m");
 }
 
-EAPI unsigned int
+ECORE_DRM_API unsigned int
 ecore_drm_output_crtc_id_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, 0);
@@ -1259,7 +1259,7 @@ ecore_drm_output_crtc_id_get(Ecore_Drm_Output *output)
    return output->crtc_id;
 }
 
-EAPI unsigned int
+ECORE_DRM_API unsigned int
 ecore_drm_output_crtc_buffer_get(Ecore_Drm_Output *output)
 {
    drmModeCrtc *crtc;
@@ -1278,7 +1278,7 @@ ecore_drm_output_crtc_buffer_get(Ecore_Drm_Output *output)
    return id;
 }
 
-EAPI unsigned int
+ECORE_DRM_API unsigned int
 ecore_drm_output_connector_id_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, 0);
@@ -1286,7 +1286,7 @@ ecore_drm_output_connector_id_get(Ecore_Drm_Output *output)
    return output->conn_id;
 }
 
-EAPI char *
+ECORE_DRM_API char *
 ecore_drm_output_name_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
@@ -1294,7 +1294,7 @@ ecore_drm_output_name_get(Ecore_Drm_Output *output)
    return strdup(output->name);
 }
 
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_output_connected_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
@@ -1302,7 +1302,7 @@ ecore_drm_output_connected_get(Ecore_Drm_Output *output)
    return output->connected;
 }
 
-EAPI unsigned int
+ECORE_DRM_API unsigned int
 ecore_drm_output_connector_type_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, 0);
@@ -1310,14 +1310,14 @@ ecore_drm_output_connector_type_get(Ecore_Drm_Output *output)
    return output->conn_type;
 }
 
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_output_backlight_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
    return (output->backlight != NULL);
 }
 
-EAPI char *
+ECORE_DRM_API char *
 ecore_drm_output_edid_get(Ecore_Drm_Output *output)
 {
    char *edid_str = NULL;
@@ -1343,7 +1343,7 @@ ecore_drm_output_edid_get(Ecore_Drm_Output *output)
    return edid_str;
 }
 
-EAPI Eina_List *
+ECORE_DRM_API Eina_List *
 ecore_drm_output_modes_get(Ecore_Drm_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
@@ -1352,7 +1352,7 @@ ecore_drm_output_modes_get(Ecore_Drm_Output *output)
    return output->modes;
 }
 
-EAPI Ecore_Drm_Output *
+ECORE_DRM_API Ecore_Drm_Output *
 ecore_drm_output_primary_get(Ecore_Drm_Device *dev)
 {
    Ecore_Drm_Output *ret;
@@ -1366,7 +1366,7 @@ ecore_drm_output_primary_get(Ecore_Drm_Device *dev)
    return NULL;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_output_primary_set(Ecore_Drm_Output *output)
 {
    const Eina_List *l;
@@ -1382,7 +1382,7 @@ ecore_drm_output_primary_set(Ecore_Drm_Output *output)
    output->primary = EINA_TRUE;
 }
 
-EAPI void
+ECORE_DRM_API void
 ecore_drm_output_crtc_size_get(Ecore_Drm_Output *output, int *width, int *height)
 {
    if (width) *width = 0;
@@ -1394,7 +1394,7 @@ ecore_drm_output_crtc_size_get(Ecore_Drm_Output *output, int *width, int *height
    if (height) *height = output->crtc->height;
 }
 
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_output_possible_crtc_get(Ecore_Drm_Output *output, unsigned int crtc)
 {
    Ecore_Drm_Device *dev;
@@ -1464,7 +1464,7 @@ next:
    return ret;
 }
 
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_output_mode_set(Ecore_Drm_Output *output, Ecore_Drm_Output_Mode *mode, int x, int y)
 {
    Ecore_Drm_Device *dev;
@@ -1511,7 +1511,7 @@ ecore_drm_output_mode_set(Ecore_Drm_Output *output, Ecore_Drm_Output_Mode *mode,
    return ret;
 }
 
-EAPI unsigned int
+ECORE_DRM_API unsigned int
 ecore_drm_output_supported_rotations_get(Ecore_Drm_Output *output, Ecore_Drm_Plane_Type type)
 {
    Ecore_Drm_Plane *plane;
@@ -1530,7 +1530,7 @@ ecore_drm_output_supported_rotations_get(Ecore_Drm_Output *output, Ecore_Drm_Pla
    return rot;
 }
 
-EAPI Eina_Bool
+ECORE_DRM_API Eina_Bool
 ecore_drm_output_rotation_set(Ecore_Drm_Output *output, Ecore_Drm_Plane_Type type, unsigned int rotation)
 {
    Ecore_Drm_Plane *plane;

--- a/src/lib/ecore_drm/ecore_drm_sprites.c
+++ b/src/lib/ecore_drm/ecore_drm_sprites.c
@@ -37,7 +37,7 @@
 
 /* TODO: DOXY !! */
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_sprites_create(Ecore_Drm_Device *dev)
 {
    drmModePlaneRes *res;
@@ -84,7 +84,7 @@ ecore_drm_sprites_create(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_sprites_destroy(Ecore_Drm_Device *dev)
 {
    Ecore_Drm_Sprite *sprite;
@@ -106,7 +106,7 @@ ecore_drm_sprites_destroy(Ecore_Drm_Device *dev)
      }
 }
 
-EAPI void 
+ECORE_DRM_API void 
 ecore_drm_sprites_fb_set(Ecore_Drm_Sprite *sprite, int fb_id, int flags)
 {
    EINA_SAFETY_ON_TRUE_RETURN((!sprite) || (!sprite->output));
@@ -127,7 +127,7 @@ ecore_drm_sprites_fb_set(Ecore_Drm_Sprite *sprite, int fb_id, int flags)
      }
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_sprites_crtc_supported(Ecore_Drm_Output *output, unsigned int supported)
 {
    Ecore_Drm_Device *dev;

--- a/src/lib/ecore_drm/ecore_drm_tty.c
+++ b/src/lib/ecore_drm/ecore_drm_tty.c
@@ -160,7 +160,7 @@ err_kmode:
  * Functions that deal with opening, closing, and otherwise using a tty
  */
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_tty_open(Ecore_Drm_Device *dev, const char *name)
 {
    char tty[32] = "<stdin>";
@@ -253,7 +253,7 @@ _ecore_drm_tty_restore(Ecore_Drm_Device *dev)
      ERR("Could not reset VT handling\n");
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_tty_close(Ecore_Drm_Device *dev)
 {
    /* check for valid device */
@@ -276,7 +276,7 @@ ecore_drm_tty_close(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_tty_release(Ecore_Drm_Device *dev)
 {
    /* check for valid device */
@@ -293,7 +293,7 @@ ecore_drm_tty_release(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool 
+ECORE_DRM_API Eina_Bool 
 ecore_drm_tty_acquire(Ecore_Drm_Device *dev)
 {
    /* check for valid device */
@@ -310,7 +310,7 @@ ecore_drm_tty_acquire(Ecore_Drm_Device *dev)
    return EINA_TRUE;
 }
 
-EAPI int 
+ECORE_DRM_API int 
 ecore_drm_tty_get(Ecore_Drm_Device *dev)
 {
    /* check for valid device */

--- a/src/lib/ecore_drm/meson.build
+++ b/src/lib/ecore_drm/meson.build
@@ -25,7 +25,7 @@ ecore_drm_lib = library('ecore_drm',
     dependencies: [m] + ecore_drm_deps + ecore_drm_pub_deps,
     include_directories : config_dir + [include_directories(join_paths('..','..'))],
     install: true,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_DRM_BUILD'],
 )
 
 ecore_drm = declare_dependency(


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.