### PR TITLE
extern char **_environ is already defined by ucrt.

### DIFF
--- a/src/lib/ecore/efl_core_proc_env.c
+++ b/src/lib/ecore/efl_core_proc_env.c
@@ -16,7 +16,7 @@
 #if defined (__FreeBSD__) || defined (__OpenBSD__)
 # include <dlfcn.h>
 static char ***_dl_environ;
-#else
+#elif !defined(_MSC_VER)
 extern char **environ;
 #endif
 

--- a/src/lib/evil/evil_stdlib.h
+++ b/src/lib/evil/evil_stdlib.h
@@ -14,6 +14,13 @@
  * @{
  */
 
+/*
+ * Define environ for native windows based on UCRT
+ *
+ */
+#ifdef _MSC_VER
+# define environ _environ
+#endif
 
 /*
  * Environment variable related functions


### PR DESCRIPTION
ref: https://docs.microsoft.com/en-us/cpp/c-runtime-library/environ-wenviron?view=vs-2019