### PR TITLE
[ecore_drm2] Use ECORE_DRM2_API instead of EAPI

### DIFF
--- a/src/lib/ecore_drm2/Ecore_Drm2.h
+++ b/src/lib/ecore_drm2/Ecore_Drm2.h
@@ -3,19 +3,7 @@
 
 # include <Ecore.h>
 
-# ifdef EAPI
-#  undef EAPI
-# endif
-
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else // if __GNUC__ >= 4
-#   define EAPI
-#  endif // if __GNUC__ >= 4
-# else // ifdef __GNUC__
-#  define EAPI
-# endif // ifdef __GNUC__
+# include <ecore_drm2_api.h>
 
 # ifdef EFL_BETA_API_SUPPORT
 
@@ -96,8 +84,8 @@ typedef struct _Ecore_Drm2_Context
                               unsigned int tv_usec, unsigned int crtc_id, void *user_data);
 } Ecore_Drm2_Context;
 
-EAPI extern int ECORE_DRM2_EVENT_OUTPUT_CHANGED;
-EAPI extern int ECORE_DRM2_EVENT_ACTIVATE;
+ECORE_DRM2_API extern int ECORE_DRM2_EVENT_OUTPUT_CHANGED;
+ECORE_DRM2_API extern int ECORE_DRM2_EVENT_ACTIVATE;
 
 typedef void (*Ecore_Drm2_Release_Handler)(void *data, Ecore_Drm2_Fb *b);
 typedef void (*Ecore_Drm2_Fb_Status_Handler)(Ecore_Drm2_Fb *b, Ecore_Drm2_Fb_Status status, void *data);
@@ -133,7 +121,7 @@ typedef void (*Ecore_Drm2_Fb_Status_Handler)(Ecore_Drm2_Fb *b, Ecore_Drm2_Fb_Sta
  * @ingroup Ecore_Drm2_Init_Group
  * @since 1.18
  */
-EAPI int ecore_drm2_init(void);
+ECORE_DRM2_API int ecore_drm2_init(void);
 
 /**
  * Shutdown the Ecore_Drm2 library
@@ -144,7 +132,7 @@ EAPI int ecore_drm2_init(void);
  * @ingroup Ecore_Drm2_Init_Group
  * @since 1.18
  */
-EAPI int ecore_drm2_shutdown(void);
+ECORE_DRM2_API int ecore_drm2_shutdown(void);
 
 /**
  * Read and process pending Drm events
@@ -161,7 +149,7 @@ EAPI int ecore_drm2_shutdown(void);
  * @ingroup Ecore_Drm_Init_Group
  * @since 1.19
  */
-EAPI int ecore_drm2_event_handle(Ecore_Drm2_Device *dev, Ecore_Drm2_Context *drmctx);
+ECORE_DRM2_API int ecore_drm2_event_handle(Ecore_Drm2_Device *dev, Ecore_Drm2_Context *drmctx);
 
 /**
  * @defgroup Ecore_Drm2_Device_Group Drm device functions
@@ -181,7 +169,7 @@ EAPI int ecore_drm2_event_handle(Ecore_Drm2_Device *dev, Ecore_Drm2_Context *drm
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI Ecore_Drm2_Device *ecore_drm2_device_open(const char *seat, unsigned int tty);
+ECORE_DRM2_API Ecore_Drm2_Device *ecore_drm2_device_open(const char *seat, unsigned int tty);
 
 /**
  * Close an open Ecore_Drm2_Device
@@ -191,7 +179,7 @@ EAPI Ecore_Drm2_Device *ecore_drm2_device_open(const char *seat, unsigned int tt
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_device_close(Ecore_Drm2_Device *device);
+ECORE_DRM2_API void ecore_drm2_device_close(Ecore_Drm2_Device *device);
 
 /**
  * Get the type of clock used by a given Ecore_Drm2_Device
@@ -203,7 +191,7 @@ EAPI void ecore_drm2_device_close(Ecore_Drm2_Device *device);
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI int ecore_drm2_device_clock_id_get(Ecore_Drm2_Device *device);
+ECORE_DRM2_API int ecore_drm2_device_clock_id_get(Ecore_Drm2_Device *device);
 
 /**
  * Get the size of the cursor supported by a given Ecore_Drm2_Device
@@ -215,7 +203,7 @@ EAPI int ecore_drm2_device_clock_id_get(Ecore_Drm2_Device *device);
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_device_cursor_size_get(Ecore_Drm2_Device *device, int *width, int *height);
+ECORE_DRM2_API void ecore_drm2_device_cursor_size_get(Ecore_Drm2_Device *device, int *width, int *height);
 
 /**
  * Get the current pointer position
@@ -227,7 +215,7 @@ EAPI void ecore_drm2_device_cursor_size_get(Ecore_Drm2_Device *device, int *widt
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_device_pointer_xy_get(Ecore_Drm2_Device *device, int *x, int *y);
+ECORE_DRM2_API void ecore_drm2_device_pointer_xy_get(Ecore_Drm2_Device *device, int *x, int *y);
 
 /**
  * Warp the pointer position to given coordinates
@@ -239,7 +227,7 @@ EAPI void ecore_drm2_device_pointer_xy_get(Ecore_Drm2_Device *device, int *x, in
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_device_pointer_warp(Ecore_Drm2_Device *device, int x, int y);
+ECORE_DRM2_API void ecore_drm2_device_pointer_warp(Ecore_Drm2_Device *device, int x, int y);
 
 /**
  * Set a left handed mode for the given device
@@ -252,7 +240,7 @@ EAPI void ecore_drm2_device_pointer_warp(Ecore_Drm2_Device *device, int x, int y
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_device_pointer_left_handed_set(Ecore_Drm2_Device *device, Eina_Bool left);
+ECORE_DRM2_API Eina_Bool ecore_drm2_device_pointer_left_handed_set(Ecore_Drm2_Device *device, Eina_Bool left);
 
 /**
  * Set which window is to be used for input events
@@ -263,7 +251,7 @@ EAPI Eina_Bool ecore_drm2_device_pointer_left_handed_set(Ecore_Drm2_Device *devi
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_device_window_set(Ecore_Drm2_Device *device, unsigned int window);
+ECORE_DRM2_API void ecore_drm2_device_window_set(Ecore_Drm2_Device *device, unsigned int window);
 
 /**
  * Set maximium position that pointer device is allowed to move
@@ -275,7 +263,7 @@ EAPI void ecore_drm2_device_window_set(Ecore_Drm2_Device *device, unsigned int w
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_device_pointer_max_set(Ecore_Drm2_Device *device, int w, int h);
+ECORE_DRM2_API void ecore_drm2_device_pointer_max_set(Ecore_Drm2_Device *device, int w, int h);
 
 /**
  * Set pointer acceleration speed
@@ -286,7 +274,7 @@ EAPI void ecore_drm2_device_pointer_max_set(Ecore_Drm2_Device *device, int w, in
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.21
  */
-EAPI void ecore_drm2_device_pointer_accel_speed_set(Ecore_Drm2_Device *device, double speed);
+ECORE_DRM2_API void ecore_drm2_device_pointer_accel_speed_set(Ecore_Drm2_Device *device, double speed);
 
 /**
  * Set pointer acceleration profile
@@ -297,7 +285,7 @@ EAPI void ecore_drm2_device_pointer_accel_speed_set(Ecore_Drm2_Device *device, d
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.21
  */
-EAPI void ecore_drm2_device_pointer_accel_profile_set(Ecore_Drm2_Device *device, uint32_t profile);
+ECORE_DRM2_API void ecore_drm2_device_pointer_accel_profile_set(Ecore_Drm2_Device *device, uint32_t profile);
 
 /**
  * Set pointer value rotation
@@ -310,7 +298,7 @@ EAPI void ecore_drm2_device_pointer_accel_profile_set(Ecore_Drm2_Device *device,
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.20
  */
-EAPI Eina_Bool ecore_drm2_device_pointer_rotation_set(Ecore_Drm2_Device *device, int rotation);
+ECORE_DRM2_API Eina_Bool ecore_drm2_device_pointer_rotation_set(Ecore_Drm2_Device *device, int rotation);
 
 /**
  * Enable or disable pointer tap-to-click
@@ -321,7 +309,7 @@ EAPI Eina_Bool ecore_drm2_device_pointer_rotation_set(Ecore_Drm2_Device *device,
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.22
  */
-EAPI void ecore_drm2_device_touch_tap_to_click_enabled_set(Ecore_Drm2_Device *device, Eina_Bool enabled);
+ECORE_DRM2_API void ecore_drm2_device_touch_tap_to_click_enabled_set(Ecore_Drm2_Device *device, Eina_Bool enabled);
 
 /**
  * Set info to be used on keyboards
@@ -334,7 +322,7 @@ EAPI void ecore_drm2_device_touch_tap_to_click_enabled_set(Ecore_Drm2_Device *de
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.20
  */
-EAPI void ecore_drm2_device_keyboard_info_set(Ecore_Drm2_Device *device, void *context, void *keymap, int group);
+ECORE_DRM2_API void ecore_drm2_device_keyboard_info_set(Ecore_Drm2_Device *device, void *context, void *keymap, int group);
 
 /**
  * Set a group layout to be used on keyboards
@@ -345,7 +333,7 @@ EAPI void ecore_drm2_device_keyboard_info_set(Ecore_Drm2_Device *device, void *c
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.20
  */
-EAPI void ecore_drm2_device_keyboard_group_set(Ecore_Drm2_Device *device, int group);
+ECORE_DRM2_API void ecore_drm2_device_keyboard_group_set(Ecore_Drm2_Device *device, int group);
 
 /**
  * Get the crtcs of a given device
@@ -358,7 +346,7 @@ EAPI void ecore_drm2_device_keyboard_group_set(Ecore_Drm2_Device *device, int gr
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI unsigned int *ecore_drm2_device_crtcs_get(Ecore_Drm2_Device *device, int *num);
+ECORE_DRM2_API unsigned int *ecore_drm2_device_crtcs_get(Ecore_Drm2_Device *device, int *num);
 
 /**
  * Get the minimum and maximum screen size range
@@ -372,7 +360,7 @@ EAPI unsigned int *ecore_drm2_device_crtcs_get(Ecore_Drm2_Device *device, int *n
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_device_screen_size_range_get(Ecore_Drm2_Device *device, int *minw, int *minh, int *maxw, int *maxh);
+ECORE_DRM2_API void ecore_drm2_device_screen_size_range_get(Ecore_Drm2_Device *device, int *minw, int *minh, int *maxw, int *maxh);
 
 /**
  * Calibrate any input devices for given screen size
@@ -384,7 +372,7 @@ EAPI void ecore_drm2_device_screen_size_range_get(Ecore_Drm2_Device *device, int
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_device_calibrate(Ecore_Drm2_Device *device, int w, int h);
+ECORE_DRM2_API void ecore_drm2_device_calibrate(Ecore_Drm2_Device *device, int w, int h);
 
 /**
  * Try to switch to a given virtual terminal
@@ -397,7 +385,7 @@ EAPI void ecore_drm2_device_calibrate(Ecore_Drm2_Device *device, int w, int h);
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_device_vt_set(Ecore_Drm2_Device *device, int vt);
+ECORE_DRM2_API Eina_Bool ecore_drm2_device_vt_set(Ecore_Drm2_Device *device, int vt);
 
 /**
  * Get if a given device prefers the use of shadow buffers
@@ -409,7 +397,7 @@ EAPI Eina_Bool ecore_drm2_device_vt_set(Ecore_Drm2_Device *device, int vt);
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.19
  */
-EAPI Eina_Bool ecore_drm2_device_prefer_shadow(Ecore_Drm2_Device *device);
+ECORE_DRM2_API Eina_Bool ecore_drm2_device_prefer_shadow(Ecore_Drm2_Device *device);
 
 /**
  * Get the default depth & bpp from a given device
@@ -421,7 +409,7 @@ EAPI Eina_Bool ecore_drm2_device_prefer_shadow(Ecore_Drm2_Device *device);
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.25
  */
-EAPI void ecore_drm2_device_preferred_depth_get(Ecore_Drm2_Device *device, int *depth, int *bpp);
+ECORE_DRM2_API void ecore_drm2_device_preferred_depth_get(Ecore_Drm2_Device *device, int *depth, int *bpp);
 
 /**
  * @defgroup Ecore_Drm2_Output_Group Drm output functions
@@ -439,7 +427,7 @@ EAPI void ecore_drm2_device_preferred_depth_get(Ecore_Drm2_Device *device, int *
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_outputs_create(Ecore_Drm2_Device *device);
+ECORE_DRM2_API Eina_Bool ecore_drm2_outputs_create(Ecore_Drm2_Device *device);
 
 /**
  * Destroy any created outputs
@@ -449,7 +437,7 @@ EAPI Eina_Bool ecore_drm2_outputs_create(Ecore_Drm2_Device *device);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_outputs_destroy(Ecore_Drm2_Device *device);
+ECORE_DRM2_API void ecore_drm2_outputs_destroy(Ecore_Drm2_Device *device);
 
 /**
  * Get the list of outputs from a drm device
@@ -461,7 +449,7 @@ EAPI void ecore_drm2_outputs_destroy(Ecore_Drm2_Device *device);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI const Eina_List *ecore_drm2_outputs_get(Ecore_Drm2_Device *device);
+ECORE_DRM2_API const Eina_List *ecore_drm2_outputs_get(Ecore_Drm2_Device *device);
 
 /**
  * Get the dpms level of a given output
@@ -474,7 +462,7 @@ EAPI const Eina_List *ecore_drm2_outputs_get(Ecore_Drm2_Device *device);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI int ecore_drm2_output_dpms_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API int ecore_drm2_output_dpms_get(Ecore_Drm2_Output *output);
 
 /**
  * Set the dpms level of a given output
@@ -485,7 +473,7 @@ EAPI int ecore_drm2_output_dpms_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_output_dpms_set(Ecore_Drm2_Output *output, int level);
+ECORE_DRM2_API void ecore_drm2_output_dpms_set(Ecore_Drm2_Output *output, int level);
 
 /**
  * Get the edid of a given output
@@ -497,7 +485,7 @@ EAPI void ecore_drm2_output_dpms_set(Ecore_Drm2_Output *output, int level);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI char *ecore_drm2_output_edid_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API char *ecore_drm2_output_edid_get(Ecore_Drm2_Output *output);
 
 /**
  * Get if a given output has a backlight
@@ -509,7 +497,7 @@ EAPI char *ecore_drm2_output_edid_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_output_backlight_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_backlight_get(Ecore_Drm2_Output *output);
 
 /**
  * Find an output at the given position
@@ -523,7 +511,7 @@ EAPI Eina_Bool ecore_drm2_output_backlight_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Ecore_Drm2_Output *ecore_drm2_output_find(Ecore_Drm2_Device *device, int x, int y);
+ECORE_DRM2_API Ecore_Drm2_Output *ecore_drm2_output_find(Ecore_Drm2_Device *device, int x, int y);
 
 /**
  * Get the dpi of a given output
@@ -535,7 +523,7 @@ EAPI Ecore_Drm2_Output *ecore_drm2_output_find(Ecore_Drm2_Device *device, int x,
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.19
  */
-EAPI void ecore_drm2_output_dpi_get(Ecore_Drm2_Output *output, int *xdpi, int *ydpi);
+ECORE_DRM2_API void ecore_drm2_output_dpi_get(Ecore_Drm2_Output *output, int *xdpi, int *ydpi);
 
 /**
  * Get the id of the crtc that an output is using
@@ -547,7 +535,7 @@ EAPI void ecore_drm2_output_dpi_get(Ecore_Drm2_Output *output, int *xdpi, int *y
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI unsigned int ecore_drm2_output_crtc_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API unsigned int ecore_drm2_output_crtc_get(Ecore_Drm2_Output *output);
 
 /**
  * Return the most recently set Ecore_Drm2_Fb for a given output
@@ -563,7 +551,7 @@ EAPI unsigned int ecore_drm2_output_crtc_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.19
  */
-EAPI Ecore_Drm2_Fb *ecore_drm2_output_latest_fb_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Ecore_Drm2_Fb *ecore_drm2_output_latest_fb_get(Ecore_Drm2_Output *output);
 
 /**
  * Get if a given output is marked as the primary output
@@ -575,7 +563,7 @@ EAPI Ecore_Drm2_Fb *ecore_drm2_output_latest_fb_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_output_primary_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_primary_get(Ecore_Drm2_Output *output);
 
 /**
  * Set a given output to be primary
@@ -586,7 +574,7 @@ EAPI Eina_Bool ecore_drm2_output_primary_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_output_primary_set(Ecore_Drm2_Output *output, Eina_Bool primary);
+ECORE_DRM2_API void ecore_drm2_output_primary_set(Ecore_Drm2_Output *output, Eina_Bool primary);
 
 /**
  * Get if a given output is enabled
@@ -598,7 +586,7 @@ EAPI void ecore_drm2_output_primary_set(Ecore_Drm2_Output *output, Eina_Bool pri
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_output_enabled_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_enabled_get(Ecore_Drm2_Output *output);
 
 /**
  * Set if a given output is enabled
@@ -609,7 +597,7 @@ EAPI Eina_Bool ecore_drm2_output_enabled_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_output_enabled_set(Ecore_Drm2_Output *output, Eina_Bool enabled);
+ECORE_DRM2_API void ecore_drm2_output_enabled_set(Ecore_Drm2_Output *output, Eina_Bool enabled);
 
 /**
  * Get the physical size of a given output
@@ -623,7 +611,7 @@ EAPI void ecore_drm2_output_enabled_set(Ecore_Drm2_Output *output, Eina_Bool ena
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_output_physical_size_get(Ecore_Drm2_Output *output, int *w, int *h);
+ECORE_DRM2_API void ecore_drm2_output_physical_size_get(Ecore_Drm2_Output *output, int *w, int *h);
 
 /**
  * Get a list of the modes supported on a given output
@@ -637,7 +625,7 @@ EAPI void ecore_drm2_output_physical_size_get(Ecore_Drm2_Output *output, int *w,
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI const Eina_List *ecore_drm2_output_modes_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API const Eina_List *ecore_drm2_output_modes_get(Ecore_Drm2_Output *output);
 
 /**
  * Get information from an existing output mode
@@ -651,7 +639,7 @@ EAPI const Eina_List *ecore_drm2_output_modes_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_output_mode_info_get(Ecore_Drm2_Output_Mode *mode, int *w, int *h, unsigned int *refresh, unsigned int *flags);
+ECORE_DRM2_API void ecore_drm2_output_mode_info_get(Ecore_Drm2_Output_Mode *mode, int *w, int *h, unsigned int *refresh, unsigned int *flags);
 
 /**
  * Set a given mode to be used on a given output
@@ -666,7 +654,7 @@ EAPI void ecore_drm2_output_mode_info_get(Ecore_Drm2_Output_Mode *mode, int *w, 
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_output_mode_set(Ecore_Drm2_Output *output, Ecore_Drm2_Output_Mode *mode, int x, int y);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_mode_set(Ecore_Drm2_Output *output, Ecore_Drm2_Output_Mode *mode, int x, int y);
 
 /**
  * Get the name of a given output
@@ -678,7 +666,7 @@ EAPI Eina_Bool ecore_drm2_output_mode_set(Ecore_Drm2_Output *output, Ecore_Drm2_
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI char *ecore_drm2_output_name_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API char *ecore_drm2_output_name_get(Ecore_Drm2_Output *output);
 
 /**
  * Get the model of a given output
@@ -690,7 +678,7 @@ EAPI char *ecore_drm2_output_name_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI char *ecore_drm2_output_model_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API char *ecore_drm2_output_model_get(Ecore_Drm2_Output *output);
 
 /**
  * Get if a given output is connected
@@ -702,7 +690,7 @@ EAPI char *ecore_drm2_output_model_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_output_connected_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_connected_get(Ecore_Drm2_Output *output);
 
 /**
  * Get if a given output is cloned
@@ -714,7 +702,7 @@ EAPI Eina_Bool ecore_drm2_output_connected_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_output_cloned_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_cloned_get(Ecore_Drm2_Output *output);
 
 /**
  * Get the connector type of a given output
@@ -726,7 +714,7 @@ EAPI Eina_Bool ecore_drm2_output_cloned_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI unsigned int ecore_drm2_output_connector_type_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API unsigned int ecore_drm2_output_connector_type_get(Ecore_Drm2_Output *output);
 
 /**
  * Get the geometry and refresh rate for a given output
@@ -741,7 +729,7 @@ EAPI unsigned int ecore_drm2_output_connector_type_get(Ecore_Drm2_Output *output
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.21
  */
-EAPI void ecore_drm2_output_info_get(Ecore_Drm2_Output *output, int *x, int *y, int *w, int *h, unsigned int *refresh);
+ECORE_DRM2_API void ecore_drm2_output_info_get(Ecore_Drm2_Output *output, int *x, int *y, int *w, int *h, unsigned int *refresh);
 
 /**
  * Get if an output can be used on a given crtc
@@ -757,7 +745,7 @@ EAPI void ecore_drm2_output_info_get(Ecore_Drm2_Output *output, int *x, int *y, 
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_output_possible_crtc_get(Ecore_Drm2_Output *output, unsigned int crtc);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_possible_crtc_get(Ecore_Drm2_Output *output, unsigned int crtc);
 
 /**
  * Set the gamma level of an Ecore_Drm_Output
@@ -773,7 +761,7 @@ EAPI Eina_Bool ecore_drm2_output_possible_crtc_get(Ecore_Drm2_Output *output, un
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.19
  */
-EAPI void ecore_drm2_output_gamma_set(Ecore_Drm2_Output *output, uint16_t size, uint16_t *red, uint16_t *green, uint16_t *blue);
+ECORE_DRM2_API void ecore_drm2_output_gamma_set(Ecore_Drm2_Output *output, uint16_t size, uint16_t *red, uint16_t *green, uint16_t *blue);
 
 /**
  * Get the supported rotations of a given output
@@ -788,7 +776,7 @@ EAPI void ecore_drm2_output_gamma_set(Ecore_Drm2_Output *output, uint16_t size, 
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.19
  */
-EAPI int ecore_drm2_output_supported_rotations_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API int ecore_drm2_output_supported_rotations_get(Ecore_Drm2_Output *output);
 
 /**
  * Set a rotation on a given output
@@ -804,7 +792,7 @@ EAPI int ecore_drm2_output_supported_rotations_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.19
  */
-EAPI Eina_Bool ecore_drm2_output_rotation_set(Ecore_Drm2_Output *output, int rotation);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_rotation_set(Ecore_Drm2_Output *output, int rotation);
 
 /**
  * Get current output rotation
@@ -816,7 +804,7 @@ EAPI Eina_Bool ecore_drm2_output_rotation_set(Ecore_Drm2_Output *output, int rot
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.22
  */
-EAPI int ecore_drm2_output_rotation_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API int ecore_drm2_output_rotation_get(Ecore_Drm2_Output *output);
 
 /**
  * Set the user data for the output's page flip handler
@@ -827,7 +815,7 @@ EAPI int ecore_drm2_output_rotation_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.19
  */
-EAPI void ecore_drm2_output_user_data_set(Ecore_Drm2_Output *o, void *data);
+ECORE_DRM2_API void ecore_drm2_output_user_data_set(Ecore_Drm2_Output *o, void *data);
 
 /**
  * Get the user data for a given output
@@ -839,7 +827,7 @@ EAPI void ecore_drm2_output_user_data_set(Ecore_Drm2_Output *o, void *data);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.21
  */
-EAPI void *ecore_drm2_output_user_data_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API void *ecore_drm2_output_user_data_get(Ecore_Drm2_Output *output);
 
 /**
  * Get the subpixel state of the output
@@ -848,7 +836,7 @@ EAPI void *ecore_drm2_output_user_data_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.20
  */
-EAPI unsigned int ecore_drm2_output_subpixel_get(const Ecore_Drm2_Output *output);
+ECORE_DRM2_API unsigned int ecore_drm2_output_subpixel_get(const Ecore_Drm2_Output *output);
 
 /**
  * Set the relative mode for an output
@@ -859,7 +847,7 @@ EAPI unsigned int ecore_drm2_output_subpixel_get(const Ecore_Drm2_Output *output
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.21
  */
-EAPI void ecore_drm2_output_relative_mode_set(Ecore_Drm2_Output *output, Ecore_Drm2_Relative_Mode mode);
+ECORE_DRM2_API void ecore_drm2_output_relative_mode_set(Ecore_Drm2_Output *output, Ecore_Drm2_Relative_Mode mode);
 
 /**
  * Get the relative mode of an output
@@ -871,7 +859,7 @@ EAPI void ecore_drm2_output_relative_mode_set(Ecore_Drm2_Output *output, Ecore_D
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.21
  */
-EAPI Ecore_Drm2_Relative_Mode ecore_drm2_output_relative_mode_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Ecore_Drm2_Relative_Mode ecore_drm2_output_relative_mode_get(Ecore_Drm2_Output *output);
 
 /**
  * Set which output a given output is relative to
@@ -882,7 +870,7 @@ EAPI Ecore_Drm2_Relative_Mode ecore_drm2_output_relative_mode_get(Ecore_Drm2_Out
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.21
  */
-EAPI void ecore_drm2_output_relative_to_set(Ecore_Drm2_Output *output, const char *relative);
+ECORE_DRM2_API void ecore_drm2_output_relative_to_set(Ecore_Drm2_Output *output, const char *relative);
 
 /**
  * Get which output is relative to a given output
@@ -894,7 +882,7 @@ EAPI void ecore_drm2_output_relative_to_set(Ecore_Drm2_Output *output, const cha
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.21
  */
-EAPI const char *ecore_drm2_output_relative_to_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API const char *ecore_drm2_output_relative_to_get(Ecore_Drm2_Output *output);
 
 /**
  * @defgroup Ecore_Drm2_Fb_Group Drm framebuffer functions
@@ -917,9 +905,9 @@ EAPI const char *ecore_drm2_output_relative_to_get(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.18
  */
-EAPI Ecore_Drm2_Fb *ecore_drm2_fb_create(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format);
+ECORE_DRM2_API Ecore_Drm2_Fb *ecore_drm2_fb_create(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format);
 
-EAPI Ecore_Drm2_Fb *ecore_drm2_fb_gbm_create(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format, unsigned int handle, unsigned int stride, void *bo);
+ECORE_DRM2_API Ecore_Drm2_Fb *ecore_drm2_fb_gbm_create(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format, unsigned int handle, unsigned int stride, void *bo);
 
 /**
  * Get a framebuffer's mmap'd data
@@ -931,7 +919,7 @@ EAPI Ecore_Drm2_Fb *ecore_drm2_fb_gbm_create(Ecore_Drm2_Device *dev, int width, 
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.18
  */
-EAPI void *ecore_drm2_fb_data_get(Ecore_Drm2_Fb *fb);
+ECORE_DRM2_API void *ecore_drm2_fb_data_get(Ecore_Drm2_Fb *fb);
 
 /**
  * Get a framebuffer's size
@@ -943,7 +931,7 @@ EAPI void *ecore_drm2_fb_data_get(Ecore_Drm2_Fb *fb);
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.18
  */
-EAPI unsigned int ecore_drm2_fb_size_get(Ecore_Drm2_Fb *fb);
+ECORE_DRM2_API unsigned int ecore_drm2_fb_size_get(Ecore_Drm2_Fb *fb);
 
 /**
  * Get a framebuffer's stride
@@ -955,7 +943,7 @@ EAPI unsigned int ecore_drm2_fb_size_get(Ecore_Drm2_Fb *fb);
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.18
  */
-EAPI unsigned int ecore_drm2_fb_stride_get(Ecore_Drm2_Fb *fb);
+ECORE_DRM2_API unsigned int ecore_drm2_fb_stride_get(Ecore_Drm2_Fb *fb);
 
 /**
  * Mark regions of a framebuffer as dirty
@@ -967,7 +955,7 @@ EAPI unsigned int ecore_drm2_fb_stride_get(Ecore_Drm2_Fb *fb);
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.18
  */
-EAPI void ecore_drm2_fb_dirty(Ecore_Drm2_Fb *fb, Eina_Rectangle *rects, unsigned int count);
+ECORE_DRM2_API void ecore_drm2_fb_dirty(Ecore_Drm2_Fb *fb, Eina_Rectangle *rects, unsigned int count);
 
 /**
  * Schedule a pageflip to the given Ecore_Drm2_Fb
@@ -983,7 +971,7 @@ EAPI void ecore_drm2_fb_dirty(Ecore_Drm2_Fb *fb, Eina_Rectangle *rects, unsigned
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.18
  */
-EAPI int ecore_drm2_fb_flip(Ecore_Drm2_Fb *fb, Ecore_Drm2_Output *output);
+ECORE_DRM2_API int ecore_drm2_fb_flip(Ecore_Drm2_Fb *fb, Ecore_Drm2_Output *output);
 
 /**
  * Must be called by a page flip handler when the flip completes.
@@ -995,7 +983,7 @@ EAPI int ecore_drm2_fb_flip(Ecore_Drm2_Fb *fb, Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.18
  */
-EAPI Eina_Bool ecore_drm2_fb_flip_complete(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Eina_Bool ecore_drm2_fb_flip_complete(Ecore_Drm2_Output *output);
 
 /**
  * Return the Ecore_Drm2_Fb's busy status
@@ -1007,7 +995,7 @@ EAPI Eina_Bool ecore_drm2_fb_flip_complete(Ecore_Drm2_Output *output);
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.19
  */
-EAPI Eina_Bool ecore_drm2_fb_busy_get(Ecore_Drm2_Fb *fb);
+ECORE_DRM2_API Eina_Bool ecore_drm2_fb_busy_get(Ecore_Drm2_Fb *fb);
 
 /**
  * Try to force a framebuffer release for an output
@@ -1027,7 +1015,7 @@ EAPI Eina_Bool ecore_drm2_fb_busy_get(Ecore_Drm2_Fb *fb);
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.19
  */
-EAPI Eina_Bool ecore_drm2_fb_release(Ecore_Drm2_Output *o, Eina_Bool panic);
+ECORE_DRM2_API Eina_Bool ecore_drm2_fb_release(Ecore_Drm2_Output *o, Eina_Bool panic);
 
 /**
  * Get the Framebuffer's gbm buffer object
@@ -1039,7 +1027,7 @@ EAPI Eina_Bool ecore_drm2_fb_release(Ecore_Drm2_Output *o, Eina_Bool panic);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.19
  */
-EAPI void *ecore_drm2_fb_bo_get(Ecore_Drm2_Fb *fb);
+ECORE_DRM2_API void *ecore_drm2_fb_bo_get(Ecore_Drm2_Fb *fb);
 
 /**
  * Import a dmabuf object as a Framebuffer
@@ -1060,7 +1048,7 @@ EAPI void *ecore_drm2_fb_bo_get(Ecore_Drm2_Fb *fb);
  * @since 1.20
  *
  */
-EAPI Ecore_Drm2_Fb *ecore_drm2_fb_dmabuf_import(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format, unsigned int strides[4], int dmabuf_fd[4], int dmabuf_fd_count);
+ECORE_DRM2_API Ecore_Drm2_Fb *ecore_drm2_fb_dmabuf_import(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format, unsigned int strides[4], int dmabuf_fd[4], int dmabuf_fd_count);
 
 /**
  * Discard a framebuffer object
@@ -1073,7 +1061,7 @@ EAPI Ecore_Drm2_Fb *ecore_drm2_fb_dmabuf_import(Ecore_Drm2_Device *dev, int widt
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.20
  */
-EAPI void ecore_drm2_fb_discard(Ecore_Drm2_Fb *fb);
+ECORE_DRM2_API void ecore_drm2_fb_discard(Ecore_Drm2_Fb *fb);
 
 /**
  * @defgroup Ecore_Drm2_Plane_Group Functions that deal with hardware planes
@@ -1092,7 +1080,7 @@ EAPI void ecore_drm2_fb_discard(Ecore_Drm2_Fb *fb);
  * @ingroup Ecore_Drm2_Plane_Group
  * @since 1.20
  */
-EAPI Ecore_Drm2_Plane *ecore_drm2_plane_assign(Ecore_Drm2_Output *output, Ecore_Drm2_Fb *fb, int x, int y);
+ECORE_DRM2_API Ecore_Drm2_Plane *ecore_drm2_plane_assign(Ecore_Drm2_Output *output, Ecore_Drm2_Fb *fb, int x, int y);
 
 /**
  * Remove a hardware plane from display
@@ -1102,7 +1090,7 @@ EAPI Ecore_Drm2_Plane *ecore_drm2_plane_assign(Ecore_Drm2_Output *output, Ecore_
  * @ingroup Ecore_Drm2_Plane_Group
  * @since 1.20
  */
-EAPI void ecore_drm2_plane_release(Ecore_Drm2_Plane *plane);
+ECORE_DRM2_API void ecore_drm2_plane_release(Ecore_Drm2_Plane *plane);
 
 /**
  * Set plane destination values
@@ -1116,7 +1104,7 @@ EAPI void ecore_drm2_plane_release(Ecore_Drm2_Plane *plane);
  * @ingroup Ecore_Drm2_Plane_Group
  * @since 1.20
  */
-EAPI void ecore_drm2_plane_destination_set(Ecore_Drm2_Plane *plane, int x, int y, int w, int h);
+ECORE_DRM2_API void ecore_drm2_plane_destination_set(Ecore_Drm2_Plane *plane, int x, int y, int w, int h);
 
 /**
  * Set plane frame buffer
@@ -1129,7 +1117,7 @@ EAPI void ecore_drm2_plane_destination_set(Ecore_Drm2_Plane *plane, int x, int y
  * @ingroup Ecore_Drm2_Plane_Group
  * @since 1.20
  */
-EAPI Eina_Bool ecore_drm2_plane_fb_set(Ecore_Drm2_Plane *plane, Ecore_Drm2_Fb *fb);
+ECORE_DRM2_API Eina_Bool ecore_drm2_plane_fb_set(Ecore_Drm2_Plane *plane, Ecore_Drm2_Fb *fb);
 
 /**
  * Register a callback for buffer status updates
@@ -1147,7 +1135,7 @@ EAPI Eina_Bool ecore_drm2_plane_fb_set(Ecore_Drm2_Plane *plane, Ecore_Drm2_Fb *f
  * @ingroup Ecore_Drm2_Fb_Group
  * @since 1.20
  */
-EAPI void ecore_drm2_fb_status_handler_set(Ecore_Drm2_Fb *fb, Ecore_Drm2_Fb_Status_Handler handler, void *data);
+ECORE_DRM2_API void ecore_drm2_fb_status_handler_set(Ecore_Drm2_Fb *fb, Ecore_Drm2_Fb_Status_Handler handler, void *data);
 
 /**
  * Get the time of the last vblank
@@ -1166,7 +1154,7 @@ EAPI void ecore_drm2_fb_status_handler_set(Ecore_Drm2_Fb *fb, Ecore_Drm2_Fb_Stat
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.20
  */
-EAPI Eina_Bool ecore_drm2_output_blanktime_get(Ecore_Drm2_Output *output, int sequence, long *sec, long *usec);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_blanktime_get(Ecore_Drm2_Output *output, int sequence, long *sec, long *usec);
 
 /**
  * Get the fd of an Ecore_Drm2_Device
@@ -1178,7 +1166,7 @@ EAPI Eina_Bool ecore_drm2_output_blanktime_get(Ecore_Drm2_Output *output, int se
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.20
  */
-EAPI int ecore_drm2_device_fd_get(Ecore_Drm2_Device *device);
+ECORE_DRM2_API int ecore_drm2_device_fd_get(Ecore_Drm2_Device *device);
 
 /**
  * Check if there's a pageflip in progress for an output
@@ -1191,7 +1179,7 @@ EAPI int ecore_drm2_device_fd_get(Ecore_Drm2_Device *device);
  * @ingroup Ecore_Drm2_Output_Group
  * @since 1.20
  */
-EAPI Eina_Bool ecore_drm2_output_pending_get(Ecore_Drm2_Output *output);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_pending_get(Ecore_Drm2_Output *output);
 
 /**
  * Set the background color of an output's crtc
@@ -1208,7 +1196,7 @@ EAPI Eina_Bool ecore_drm2_output_pending_get(Ecore_Drm2_Output *output);
  *
  * @since 1.23
  */
-EAPI Eina_Bool ecore_drm2_output_background_color_set(Ecore_Drm2_Output *output, uint64_t r, uint64_t g, uint64_t b, uint64_t a);
+ECORE_DRM2_API Eina_Bool ecore_drm2_output_background_color_set(Ecore_Drm2_Output *output, uint64_t r, uint64_t g, uint64_t b, uint64_t a);
 
 /**
  * Check if vblank is supported by the current video driver
@@ -1219,7 +1207,7 @@ EAPI Eina_Bool ecore_drm2_output_background_color_set(Ecore_Drm2_Output *output,
  *
  * @ingroup Ecore_Drm2_Device_Group
  * @since 1.23 */
-EAPI Eina_Bool ecore_drm2_vblank_supported(Ecore_Drm2_Device *dev);
+ECORE_DRM2_API Eina_Bool ecore_drm2_vblank_supported(Ecore_Drm2_Device *dev);
 
 # endif
 

--- a/src/lib/ecore_drm2/ecore_drm2.c
+++ b/src/lib/ecore_drm2/ecore_drm2.c
@@ -48,8 +48,8 @@ int (*sym_drmModeCrtcSetGamma)(int fd, uint32_t crtc_id, uint32_t size, uint16_t
 int (*sym_drmPrimeFDToHandle)(int fd, int prime_fd, uint32_t *handle) = NULL;
 int (*sym_drmWaitVBlank)(int fd, drmVBlank *vbl) = NULL;
 
-EAPI int ECORE_DRM2_EVENT_OUTPUT_CHANGED = -1;
-EAPI int ECORE_DRM2_EVENT_ACTIVATE = -1;
+ECORE_DRM2_API int ECORE_DRM2_EVENT_OUTPUT_CHANGED = -1;
+ECORE_DRM2_API int ECORE_DRM2_EVENT_ACTIVATE = -1;
 
 static Eina_Bool
 _ecore_drm2_link(void)
@@ -138,7 +138,7 @@ _ecore_drm2_link(void)
    return EINA_TRUE;
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_init(void)
 {
    if (++_ecore_drm2_init_count != 1) return _ecore_drm2_init_count;
@@ -193,7 +193,7 @@ eina_err:
    return --_ecore_drm2_init_count;
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_shutdown(void)
 {
    if (_ecore_drm2_init_count < 1)
@@ -218,7 +218,7 @@ ecore_drm2_shutdown(void)
    return _ecore_drm2_init_count;
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_event_handle(Ecore_Drm2_Device *dev, Ecore_Drm2_Context *drmctx)
 {
    drmEventContext ctx;

--- a/src/lib/ecore_drm2/ecore_drm2_api.h
+++ b/src/lib/ecore_drm2/ecore_drm2_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_DRM2_API_H
+#define _EFL_ECORE_DRM2_API_H
+
+#ifdef ECORE_DRM2_API
+#error ECORE_DRM2_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_DRM2_STATIC
+#  ifdef ECORE_DRM2_BUILD
+#   define ECORE_DRM2_API __declspec(dllexport)
+#  else
+#   define ECORE_DRM2_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_DRM2_API
+# endif
+# define ECORE_DRM2_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_DRM2_API __attribute__ ((visibility("default")))
+#   define ECORE_DRM2_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_DRM2_API
+#   define ECORE_DRM2_API_WEAK
+#  endif
+# else
+#  define ECORE_DRM2_API
+#  define ECORE_DRM2_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_drm2/ecore_drm2_device.c
+++ b/src/lib/ecore_drm2/ecore_drm2_device.c
@@ -592,7 +592,7 @@ _drm2_atomic_state_free(Ecore_Drm2_Atomic_State *state)
    free(state);
 }
 
-EAPI Ecore_Drm2_Device *
+ECORE_DRM2_API Ecore_Drm2_Device *
 ecore_drm2_device_open(const char *seat, unsigned int tty)
 {
    Ecore_Drm2_Device *device;
@@ -678,7 +678,7 @@ man_err:
    return NULL;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_close(Ecore_Drm2_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -694,7 +694,7 @@ ecore_drm2_device_close(Ecore_Drm2_Device *device)
    free(device);
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_device_clock_id_get(Ecore_Drm2_Device *device)
 {
    uint64_t caps;
@@ -709,7 +709,7 @@ ecore_drm2_device_clock_id_get(Ecore_Drm2_Device *device)
      return CLOCK_REALTIME;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_cursor_size_get(Ecore_Drm2_Device *device, int *width, int *height)
 {
    uint64_t caps;
@@ -739,7 +739,7 @@ ecore_drm2_device_cursor_size_get(Ecore_Drm2_Device *device, int *width, int *he
      }
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_pointer_xy_get(Ecore_Drm2_Device *device, int *x, int *y)
 {
    if (x) *x = 0;
@@ -750,7 +750,7 @@ ecore_drm2_device_pointer_xy_get(Ecore_Drm2_Device *device, int *x, int *y)
    elput_input_pointer_xy_get(device->em, NULL, x, y);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_pointer_warp(Ecore_Drm2_Device *device, int x, int y)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -758,7 +758,7 @@ ecore_drm2_device_pointer_warp(Ecore_Drm2_Device *device, int x, int y)
    elput_input_pointer_xy_set(device->em, NULL, x, y);
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_device_pointer_left_handed_set(Ecore_Drm2_Device *device, Eina_Bool left)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);
@@ -766,7 +766,7 @@ ecore_drm2_device_pointer_left_handed_set(Ecore_Drm2_Device *device, Eina_Bool l
    return elput_input_pointer_left_handed_set(device->em, NULL, left);
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_device_pointer_rotation_set(Ecore_Drm2_Device *device, int rotation)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);
@@ -774,7 +774,7 @@ ecore_drm2_device_pointer_rotation_set(Ecore_Drm2_Device *device, int rotation)
    return elput_input_pointer_rotation_set(device->em, rotation);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_pointer_accel_speed_set(Ecore_Drm2_Device *device, double speed)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -782,7 +782,7 @@ ecore_drm2_device_pointer_accel_speed_set(Ecore_Drm2_Device *device, double spee
    elput_input_pointer_accel_speed_set(device->em, NULL, speed);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_pointer_accel_profile_set(Ecore_Drm2_Device *device, uint32_t profile)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -790,7 +790,7 @@ ecore_drm2_device_pointer_accel_profile_set(Ecore_Drm2_Device *device, uint32_t 
    elput_input_pointer_accel_profile_set(device->em, NULL, profile);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_touch_tap_to_click_enabled_set(Ecore_Drm2_Device *device, Eina_Bool enabled)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -798,7 +798,7 @@ ecore_drm2_device_touch_tap_to_click_enabled_set(Ecore_Drm2_Device *device, Eina
    elput_input_touch_tap_to_click_enabled_set(device->em, NULL, enabled);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_window_set(Ecore_Drm2_Device *device, unsigned int window)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -806,7 +806,7 @@ ecore_drm2_device_window_set(Ecore_Drm2_Device *device, unsigned int window)
    elput_manager_window_set(device->em, window);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_pointer_max_set(Ecore_Drm2_Device *device, int w, int h)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -815,7 +815,7 @@ ecore_drm2_device_pointer_max_set(Ecore_Drm2_Device *device, int w, int h)
    elput_input_pointer_max_set(device->em, w, h);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_keyboard_info_set(Ecore_Drm2_Device *device, void *context, void *keymap, int group)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -823,7 +823,7 @@ ecore_drm2_device_keyboard_info_set(Ecore_Drm2_Device *device, void *context, vo
    elput_input_keyboard_info_set(device->em, context, keymap, group);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_keyboard_group_set(Ecore_Drm2_Device *device, int group)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -831,7 +831,7 @@ ecore_drm2_device_keyboard_group_set(Ecore_Drm2_Device *device, int group)
    elput_input_keyboard_group_set(device->em, group);
 }
 
-EAPI unsigned int *
+ECORE_DRM2_API unsigned int *
 ecore_drm2_device_crtcs_get(Ecore_Drm2_Device *device, int *num)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, NULL);
@@ -840,7 +840,7 @@ ecore_drm2_device_crtcs_get(Ecore_Drm2_Device *device, int *num)
    return device->crtcs;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_screen_size_range_get(Ecore_Drm2_Device *device, int *minw, int *minh, int *maxw, int *maxh)
 {
    if (minw) *minw = 0;
@@ -856,7 +856,7 @@ ecore_drm2_device_screen_size_range_get(Ecore_Drm2_Device *device, int *minw, in
    if (maxh) *maxh = device->max.height;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_calibrate(Ecore_Drm2_Device *device, int w, int h)
 {
    EINA_SAFETY_ON_NULL_RETURN(device);
@@ -864,7 +864,7 @@ ecore_drm2_device_calibrate(Ecore_Drm2_Device *device, int w, int h)
    elput_input_devices_calibrate(device->em, w, h);
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_device_vt_set(Ecore_Drm2_Device *device, int vt)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, EINA_FALSE);
@@ -872,7 +872,7 @@ ecore_drm2_device_vt_set(Ecore_Drm2_Device *device, int vt)
    return elput_manager_vt_set(device->em, vt);
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_device_prefer_shadow(Ecore_Drm2_Device *device)
 {
    uint64_t caps;
@@ -887,7 +887,7 @@ ecore_drm2_device_prefer_shadow(Ecore_Drm2_Device *device)
      return EINA_FALSE;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_device_preferred_depth_get(Ecore_Drm2_Device *device, int *depth, int *bpp)
 {
    uint64_t caps;
@@ -903,7 +903,7 @@ ecore_drm2_device_preferred_depth_get(Ecore_Drm2_Device *device, int *depth, int
      }
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_device_fd_get(Ecore_Drm2_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, -1);
@@ -911,7 +911,7 @@ ecore_drm2_device_fd_get(Ecore_Drm2_Device *device)
    return device->fd;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_vblank_supported(Ecore_Drm2_Device *dev)
 {
    drmVBlank tmp;
@@ -929,5 +929,5 @@ ecore_drm2_vblank_supported(Ecore_Drm2_Device *dev)
 }
 
 /* prevent crashing with old apps compiled against these functions */
-EAPI void ecore_drm2_device_keyboard_cached_context_set(){};
-EAPI void ecore_drm2_device_keyboard_cached_keymap_set(){};
+ECORE_DRM2_API void ecore_drm2_device_keyboard_cached_context_set(){};
+ECORE_DRM2_API void ecore_drm2_device_keyboard_cached_keymap_set(){};

--- a/src/lib/ecore_drm2/ecore_drm2_fb.c
+++ b/src/lib/ecore_drm2/ecore_drm2_fb.c
@@ -17,7 +17,7 @@ _fb2_create(Ecore_Drm2_Fb *fb)
    return EINA_TRUE;
 }
 
-EAPI Ecore_Drm2_Fb *
+ECORE_DRM2_API Ecore_Drm2_Fb *
 ecore_drm2_fb_create(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format)
 {
    Ecore_Drm2_Fb *fb;
@@ -92,7 +92,7 @@ err:
    return NULL;
 }
 
-EAPI Ecore_Drm2_Fb *
+ECORE_DRM2_API Ecore_Drm2_Fb *
 ecore_drm2_fb_gbm_create(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format, unsigned int handle, unsigned int stride, void *bo)
 {
    Ecore_Drm2_Fb *fb;
@@ -176,7 +176,7 @@ _ecore_drm2_fb_deref(Ecore_Drm2_Fb *fb)
    _ecore_drm2_fb_destroy(fb);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_fb_discard(Ecore_Drm2_Fb *fb)
 {
    EINA_SAFETY_ON_NULL_RETURN(fb);
@@ -186,7 +186,7 @@ ecore_drm2_fb_discard(Ecore_Drm2_Fb *fb)
    _ecore_drm2_fb_deref(fb);
 }
 
-EAPI void *
+ECORE_DRM2_API void *
 ecore_drm2_fb_data_get(Ecore_Drm2_Fb *fb)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fb, NULL);
@@ -194,7 +194,7 @@ ecore_drm2_fb_data_get(Ecore_Drm2_Fb *fb)
    return fb->mmap;
 }
 
-EAPI unsigned int
+ECORE_DRM2_API unsigned int
 ecore_drm2_fb_size_get(Ecore_Drm2_Fb *fb)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fb, 0);
@@ -202,7 +202,7 @@ ecore_drm2_fb_size_get(Ecore_Drm2_Fb *fb)
    return fb->sizes[0];
 }
 
-EAPI unsigned int
+ECORE_DRM2_API unsigned int
 ecore_drm2_fb_stride_get(Ecore_Drm2_Fb *fb)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fb, 0);
@@ -211,7 +211,7 @@ ecore_drm2_fb_stride_get(Ecore_Drm2_Fb *fb)
    return fb->strides[0];
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_fb_dirty(Ecore_Drm2_Fb *fb, Eina_Rectangle *rects, unsigned int count)
 {
    EINA_SAFETY_ON_NULL_RETURN(fb);
@@ -266,7 +266,7 @@ _cb_mainloop_async_timer_del(void *data)
    output->flip_timeout = NULL;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_fb_flip_complete(Ecore_Drm2_Output *output)
 {
    Eina_Bool plane_scanout;
@@ -647,7 +647,7 @@ _fb_flip(Ecore_Drm2_Output *output)
    return 0;
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_fb_flip(Ecore_Drm2_Fb *fb, Ecore_Drm2_Output *output)
 {
    int ret = -1;
@@ -706,7 +706,7 @@ ecore_drm2_fb_flip(Ecore_Drm2_Fb *fb, Ecore_Drm2_Output *output)
    return 0;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_fb_busy_get(Ecore_Drm2_Fb *fb)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fb, EINA_FALSE);
@@ -715,7 +715,7 @@ ecore_drm2_fb_busy_get(Ecore_Drm2_Fb *fb)
    return !!(fb->ref - 1);
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_fb_release(Ecore_Drm2_Output *o, Eina_Bool panic)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(o, EINA_FALSE);
@@ -750,7 +750,7 @@ ecore_drm2_fb_release(Ecore_Drm2_Output *o, Eina_Bool panic)
    return EINA_FALSE;
 }
 
-EAPI void *
+ECORE_DRM2_API void *
 ecore_drm2_fb_bo_get(Ecore_Drm2_Fb *fb)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(fb, NULL);
@@ -759,7 +759,7 @@ ecore_drm2_fb_bo_get(Ecore_Drm2_Fb *fb)
    return fb->gbm_bo;
 }
 
-EAPI Ecore_Drm2_Fb *
+ECORE_DRM2_API Ecore_Drm2_Fb *
 ecore_drm2_fb_dmabuf_import(Ecore_Drm2_Device *dev, int width, int height, int depth, int bpp, unsigned int format, unsigned int strides[4], int dmabuf_fd[4], int dmabuf_fd_count)
 {
    int i;
@@ -791,7 +791,7 @@ fail:
    return NULL;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_fb_status_handler_set(Ecore_Drm2_Fb *fb, Ecore_Drm2_Fb_Status_Handler handler, void *data)
 {
    fb->status_handler = handler;

--- a/src/lib/ecore_drm2/ecore_drm2_outputs.c
+++ b/src/lib/ecore_drm2/ecore_drm2_outputs.c
@@ -938,7 +938,7 @@ _output_vblank_pipe(Ecore_Drm2_Output *output)
      return 0;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_outputs_create(Ecore_Drm2_Device *device)
 {
    drmModeConnector *conn;
@@ -994,7 +994,7 @@ err:
    return EINA_FALSE;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_outputs_destroy(Ecore_Drm2_Device *device)
 {
    Ecore_Drm2_Output *output;
@@ -1005,14 +1005,14 @@ ecore_drm2_outputs_destroy(Ecore_Drm2_Device *device)
      _output_destroy(device, output);
 }
 
-EAPI const Eina_List *
+ECORE_DRM2_API const Eina_List *
 ecore_drm2_outputs_get(Ecore_Drm2_Device *device)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(device, NULL);
    return device->outputs;
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_output_dpms_get(Ecore_Drm2_Output *output)
 {
    drmModeObjectProperties *props;
@@ -1043,7 +1043,7 @@ ecore_drm2_output_dpms_get(Ecore_Drm2_Output *output)
    return val;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_dpms_set(Ecore_Drm2_Output *output, int level)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1056,7 +1056,7 @@ ecore_drm2_output_dpms_set(Ecore_Drm2_Output *output, int level)
      ecore_drm2_fb_flip(NULL, output);
 }
 
-EAPI char *
+ECORE_DRM2_API char *
 ecore_drm2_output_edid_get(Ecore_Drm2_Output *output)
 {
    char *edid_str = NULL;
@@ -1096,14 +1096,14 @@ ecore_drm2_output_edid_get(Ecore_Drm2_Output *output)
    return edid_str;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_backlight_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
    return (output->backlight.path != NULL);
 }
 
-EAPI Ecore_Drm2_Output *
+ECORE_DRM2_API Ecore_Drm2_Output *
 ecore_drm2_output_find(Ecore_Drm2_Device *device, int x, int y)
 {
    Eina_List *l;
@@ -1129,7 +1129,7 @@ ecore_drm2_output_find(Ecore_Drm2_Device *device, int x, int y)
    return NULL;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_dpi_get(Ecore_Drm2_Output *output, int *xdpi, int *ydpi)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1142,14 +1142,14 @@ ecore_drm2_output_dpi_get(Ecore_Drm2_Output *output, int *xdpi, int *ydpi)
      *ydpi = ((25.4 * (output->current_mode->height)) / output->ph);
 }
 
-EAPI unsigned int
+ECORE_DRM2_API unsigned int
 ecore_drm2_output_crtc_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, 0);
    return output->crtc_id;
 }
 
-EAPI Ecore_Drm2_Fb *
+ECORE_DRM2_API Ecore_Drm2_Fb *
 ecore_drm2_output_latest_fb_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
@@ -1158,28 +1158,28 @@ ecore_drm2_output_latest_fb_get(Ecore_Drm2_Output *output)
    return output->next.fb;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_primary_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
    return output->primary;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_primary_set(Ecore_Drm2_Output *output, Eina_Bool primary)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
    output->primary = primary;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_enabled_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
    return output->enabled;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_enabled_set(Ecore_Drm2_Output *output, Eina_Bool enabled)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1213,7 +1213,7 @@ ecore_drm2_output_enabled_set(Ecore_Drm2_Output *output, Eina_Bool enabled)
    _output_event_send(output);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_physical_size_get(Ecore_Drm2_Output *output, int *w, int *h)
 {
    if (w) *w = 0;
@@ -1225,14 +1225,14 @@ ecore_drm2_output_physical_size_get(Ecore_Drm2_Output *output, int *w, int *h)
    if (h) *h = output->ph;
 }
 
-EAPI const Eina_List *
+ECORE_DRM2_API const Eina_List *
 ecore_drm2_output_modes_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
    return output->modes;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_mode_info_get(Ecore_Drm2_Output_Mode *mode, int *w, int *h, unsigned int *refresh, unsigned int *flags)
 {
    if (w) *w = 0;
@@ -1333,7 +1333,7 @@ err:
    return ret;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_mode_set(Ecore_Drm2_Output *output, Ecore_Drm2_Output_Mode *mode, int x, int y)
 {
    Eina_Bool ret = EINA_TRUE;
@@ -1382,7 +1382,7 @@ ecore_drm2_output_mode_set(Ecore_Drm2_Output *output, Ecore_Drm2_Output_Mode *mo
    return ret;
 }
 
-EAPI char *
+ECORE_DRM2_API char *
 ecore_drm2_output_name_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
@@ -1390,7 +1390,7 @@ ecore_drm2_output_name_get(Ecore_Drm2_Output *output)
    return strdup(output->name);
 }
 
-EAPI char *
+ECORE_DRM2_API char *
 ecore_drm2_output_model_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
@@ -1398,14 +1398,14 @@ ecore_drm2_output_model_get(Ecore_Drm2_Output *output)
    return strdup(output->model);
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_connected_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
    return output->connected;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_cloned_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
@@ -1413,14 +1413,14 @@ ecore_drm2_output_cloned_get(Ecore_Drm2_Output *output)
            output->relative.mode == ECORE_DRM2_RELATIVE_MODE_CLONE);
 }
 
-EAPI unsigned int
+ECORE_DRM2_API unsigned int
 ecore_drm2_output_connector_type_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, 0);
    return output->conn_type;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_possible_crtc_get(Ecore_Drm2_Output *output, unsigned int crtc)
 {
    drmModeRes *res;
@@ -1475,7 +1475,7 @@ next:
    return ret;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_user_data_set(Ecore_Drm2_Output *o, void *data)
 {
    EINA_SAFETY_ON_NULL_RETURN(o);
@@ -1483,14 +1483,14 @@ ecore_drm2_output_user_data_set(Ecore_Drm2_Output *o, void *data)
    o->user_data = data;
 }
 
-EAPI void *
+ECORE_DRM2_API void *
 ecore_drm2_output_user_data_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
    return output->user_data;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_gamma_set(Ecore_Drm2_Output *output, uint16_t size, uint16_t *red, uint16_t *green, uint16_t *blue)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
@@ -1503,7 +1503,7 @@ ecore_drm2_output_gamma_set(Ecore_Drm2_Output *output, uint16_t size, uint16_t *
      ERR("Failed to set gamma for Output %s: %m", output->name);
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_output_supported_rotations_get(Ecore_Drm2_Output *output)
 {
    int ret = -1;
@@ -1529,7 +1529,7 @@ ecore_drm2_output_supported_rotations_get(Ecore_Drm2_Output *output)
    return ret;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_rotation_set(Ecore_Drm2_Output *output, int rotation)
 {
    Eina_Bool ret = EINA_TRUE;
@@ -1590,14 +1590,14 @@ err:
    return ret;
 }
 
-EAPI int
+ECORE_DRM2_API int
 ecore_drm2_output_rotation_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, -1);
    return output->rotation;
 }
 
-EAPI unsigned int
+ECORE_DRM2_API unsigned int
 ecore_drm2_output_subpixel_get(const Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, 0);
@@ -1648,7 +1648,7 @@ _blanktime_fallback(Ecore_Drm2_Output *output, int sequence, long *sec, long *us
    return 0;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_blanktime_get(Ecore_Drm2_Output *output, int sequence, long *sec, long *usec)
 {
    drmVBlank v;
@@ -1677,7 +1677,7 @@ ecore_drm2_output_blanktime_get(Ecore_Drm2_Output *output, int sequence, long *s
    return EINA_TRUE;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_info_get(Ecore_Drm2_Output *output, int *x, int *y, int *w, int *h, unsigned int *refresh)
 {
    if (x) *x = 0;
@@ -1709,7 +1709,7 @@ ecore_drm2_output_info_get(Ecore_Drm2_Output *output, int *x, int *y, int *w, in
    if (y) *y = output->y;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_pending_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, EINA_FALSE);
@@ -1719,35 +1719,35 @@ ecore_drm2_output_pending_get(Ecore_Drm2_Output *output)
    return EINA_FALSE;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_relative_mode_set(Ecore_Drm2_Output *output, Ecore_Drm2_Relative_Mode mode)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
    output->relative.mode = mode;
 }
 
-EAPI Ecore_Drm2_Relative_Mode
+ECORE_DRM2_API Ecore_Drm2_Relative_Mode
 ecore_drm2_output_relative_mode_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, ECORE_DRM2_RELATIVE_MODE_UNKNOWN);
    return output->relative.mode;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_output_relative_to_set(Ecore_Drm2_Output *output, const char *relative)
 {
    EINA_SAFETY_ON_NULL_RETURN(output);
    eina_stringshare_replace(&output->relative.to, relative);
 }
 
-EAPI const char *
+ECORE_DRM2_API const char *
 ecore_drm2_output_relative_to_get(Ecore_Drm2_Output *output)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(output, NULL);
    return output->relative.to;
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_output_background_color_set(Ecore_Drm2_Output *output, uint64_t r, uint64_t g, uint64_t b, uint64_t a)
 {
    Ecore_Drm2_Crtc_State *cstate;

--- a/src/lib/ecore_drm2/ecore_drm2_plane.c
+++ b/src/lib/ecore_drm2/ecore_drm2_plane.c
@@ -38,7 +38,7 @@ _plane_cursor_size_get(int fd, int *width, int *height)
      }
 }
 
-EAPI Ecore_Drm2_Plane *
+ECORE_DRM2_API Ecore_Drm2_Plane *
 ecore_drm2_plane_assign(Ecore_Drm2_Output *output, Ecore_Drm2_Fb *fb, int x, int y)
 {
    Eina_List *l;
@@ -133,7 +133,7 @@ out:
    return plane;
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_plane_release(Ecore_Drm2_Plane *plane)
 {
    Ecore_Drm2_Fb *fb;
@@ -156,7 +156,7 @@ ecore_drm2_plane_release(Ecore_Drm2_Plane *plane)
                         fb->status_data);
 }
 
-EAPI void
+ECORE_DRM2_API void
 ecore_drm2_plane_destination_set(Ecore_Drm2_Plane *plane, int x, int y, int w, int h)
 {
    EINA_SAFETY_ON_NULL_RETURN(plane);
@@ -170,7 +170,7 @@ ecore_drm2_plane_destination_set(Ecore_Drm2_Plane *plane, int x, int y, int w, i
    _fb_atomic_flip_test(plane->output);
 }
 
-EAPI Eina_Bool
+ECORE_DRM2_API Eina_Bool
 ecore_drm2_plane_fb_set(Ecore_Drm2_Plane *plane, Ecore_Drm2_Fb *fb)
 {
    uint32_t fallback_id;

--- a/src/lib/ecore_drm2/meson.build
+++ b/src/lib/ecore_drm2/meson.build
@@ -17,7 +17,7 @@ ecore_drm2_src = files([
 
 ecore_drm2_lib = library('ecore_drm2',
     ecore_drm2_src, pub_eo_file_target,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_DRM2_BUILD'],
     dependencies: ecore_drm2_pub_deps + ecore_drm2_deps + ecore_drm2_ext_deps,
     include_directories : config_dir,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.