### PR TITLE
[ecore_fb] Use ECORE_FB_API instead of EAPI

### DIFF
--- a/src/lib/ecore_fb/Ecore_Fb.h
+++ b/src/lib/ecore_fb/Ecore_Fb.h
@@ -3,19 +3,7 @@
 
 #include <Eina.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef __GNUC__
-# if __GNUC__ >= 4
-#  define EAPI __attribute__ ((visibility("default")))
-# else
-#  define EAPI
-# endif
-#else
-# define EAPI
-#endif
+#include <ecore_fb_api.h>
 
 /* FIXME:
  * maybe a new module?
@@ -67,28 +55,28 @@ enum _Ecore_Fb_Input_Device_Cap
 typedef enum   _Ecore_Fb_Input_Device_Cap Ecore_Fb_Input_Device_Cap;
 
 /* ecore_fb_vt.c */
-EAPI void                      ecore_fb_callback_gain_set(void (*func) (void *data), void *data);
-EAPI void                      ecore_fb_callback_lose_set(void (*func) (void *data), void *data);
+ECORE_FB_API void                      ecore_fb_callback_gain_set(void (*func) (void *data), void *data);
+ECORE_FB_API void                      ecore_fb_callback_lose_set(void (*func) (void *data), void *data);
 
 /* ecore_fb_li.c */
-EAPI Ecore_Fb_Input_Device    *ecore_fb_input_device_open(const char *dev);
-EAPI void                      ecore_fb_input_device_close(Ecore_Fb_Input_Device *dev);
-EAPI void                      ecore_fb_input_device_listen(Ecore_Fb_Input_Device *dev, Eina_Bool listen);
-EAPI const char               *ecore_fb_input_device_name_get(Ecore_Fb_Input_Device *dev);
-EAPI Ecore_Fb_Input_Device_Cap ecore_fb_input_device_cap_get(Ecore_Fb_Input_Device *dev);
-EAPI void                      ecore_fb_input_device_axis_size_set(Ecore_Fb_Input_Device *dev, int w, int h);
-EAPI void                      ecore_fb_input_threshold_click_set(Ecore_Fb_Input_Device *dev, double threshold);
-EAPI double                    ecore_fb_input_threshold_click_get(Ecore_Fb_Input_Device *dev);
-EAPI void                      ecore_fb_input_device_window_set(Ecore_Fb_Input_Device *dev, void *window);
+ECORE_FB_API Ecore_Fb_Input_Device    *ecore_fb_input_device_open(const char *dev);
+ECORE_FB_API void                      ecore_fb_input_device_close(Ecore_Fb_Input_Device *dev);
+ECORE_FB_API void                      ecore_fb_input_device_listen(Ecore_Fb_Input_Device *dev, Eina_Bool listen);
+ECORE_FB_API const char               *ecore_fb_input_device_name_get(Ecore_Fb_Input_Device *dev);
+ECORE_FB_API Ecore_Fb_Input_Device_Cap ecore_fb_input_device_cap_get(Ecore_Fb_Input_Device *dev);
+ECORE_FB_API void                      ecore_fb_input_device_axis_size_set(Ecore_Fb_Input_Device *dev, int w, int h);
+ECORE_FB_API void                      ecore_fb_input_threshold_click_set(Ecore_Fb_Input_Device *dev, double threshold);
+ECORE_FB_API double                    ecore_fb_input_threshold_click_get(Ecore_Fb_Input_Device *dev);
+ECORE_FB_API void                      ecore_fb_input_device_window_set(Ecore_Fb_Input_Device *dev, void *window);
 
 /* ecore_fb.c */
 
-EAPI int                       ecore_fb_init(const char *name);
-EAPI int                       ecore_fb_shutdown(void);
-EAPI void                      ecore_fb_size_get(int *w, int *h);
+ECORE_FB_API int                       ecore_fb_init(const char *name);
+ECORE_FB_API int                       ecore_fb_shutdown(void);
+ECORE_FB_API void                      ecore_fb_size_get(int *w, int *h);
 
-EAPI void                      ecore_fb_touch_screen_calibrate_set(int xscale, int xtrans, int yscale, int ytrans, int xyswap);
-EAPI void                      ecore_fb_touch_screen_calibrate_get(int *xscale, int *xtrans, int *yscale, int *ytrans, int *xyswap);
+ECORE_FB_API void                      ecore_fb_touch_screen_calibrate_set(int xscale, int xtrans, int yscale, int ytrans, int xyswap);
+ECORE_FB_API void                      ecore_fb_touch_screen_calibrate_get(int *xscale, int *xtrans, int *yscale, int *ytrans, int *xyswap);
 
 /**
  * @}
@@ -97,8 +85,5 @@ EAPI void                      ecore_fb_touch_screen_calibrate_get(int *xscale, 
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_fb/ecore_fb.c
+++ b/src/lib/ecore_fb/ecore_fb.c
@@ -38,7 +38,7 @@ nosigint(int val EINA_UNUSED)
  * When Ecore_Fb is not used anymore, call ecore_fb_shutdown() to shut down
  * the Ecore_Fb library.
  */
-EAPI int
+ECORE_FB_API int
 ecore_fb_init(const char *name)
 {
    const char *s;
@@ -72,7 +72,7 @@ ecore_fb_init(const char *name)
  * This function shuts down the Ecore_Fb library. It returns 0 when it has
  * been called the same number of times than ecore_fb_init().
  */
-EAPI int
+ECORE_FB_API int
 ecore_fb_shutdown(void)
 {
    const char *s;
@@ -108,7 +108,7 @@ ecore_fb_shutdown(void)
  * corresponding values. If one of them is @c NULL, nothing will be
  * done for that parameter.
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_size_get(int *w, int *h)
 {
    if (w) *w = _ecore_fb_console_w;

--- a/src/lib/ecore_fb/ecore_fb_api.h
+++ b/src/lib/ecore_fb/ecore_fb_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_FB_API_H
+#define _EFL_ECORE_FB_API_H
+
+#ifdef ECORE_FB_API
+#error ECORE_FB_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_FB_STATIC
+#  ifdef ECORE_FB_BUILD
+#   define ECORE_FB_API __declspec(dllexport)
+#  else
+#   define ECORE_FB_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_FB_API
+# endif
+# define ECORE_FB_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_FB_API __attribute__ ((visibility("default")))
+#   define ECORE_FB_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_FB_API
+#   define ECORE_FB_API_WEAK
+#  endif
+# else
+#  define ECORE_FB_API
+#  define ECORE_FB_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_fb/ecore_fb_li.c
+++ b/src/lib/ecore_fb/ecore_fb_li.c
@@ -459,7 +459,7 @@ _ecore_fb_li_device_fd_callback(void *data, Ecore_Fd_Handler *fdh EINA_UNUSED)
  * If @p listen is @c EINA_FALSE, listening mode is disabled, if it is
  * @c EINA_TRUE, it is enabled.
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_input_device_listen(Ecore_Fb_Input_Device *dev, Eina_Bool listen)
 {
    if (!dev) return;
@@ -506,7 +506,7 @@ ecore_fb_input_device_listen(Ecore_Fb_Input_Device *dev, Eina_Bool listen)
  *
  * @since 1.1
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_input_device_window_set(Ecore_Fb_Input_Device *dev, void *window)
 {
    if (!dev) return;
@@ -523,7 +523,7 @@ ecore_fb_input_device_window_set(Ecore_Fb_Input_Device *dev, void *window)
  * This function opens the input device named @p dev and returns the
  * object for it, or returns @c NULL on failure.
  */
-EAPI Ecore_Fb_Input_Device *
+ECORE_FB_API Ecore_Fb_Input_Device *
 ecore_fb_input_device_open(const char *dev)
 {
    Ecore_Fb_Input_Device *device;
@@ -606,7 +606,7 @@ error_open:
  * This function closes the device @p dev. If @p dev is @c NULL, this
  * function does nothing.
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_input_device_close(Ecore_Fb_Input_Device *dev)
 {
    if (!dev || dev->fd < 0) return;
@@ -630,7 +630,7 @@ ecore_fb_input_device_close(Ecore_Fb_Input_Device *dev)
  * height must set for it. If its absolute set the ioctl correctly, if
  * not, unsupported device.
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_input_device_axis_size_set(Ecore_Fb_Input_Device *dev, int w, int h)
 {
    if (!dev) return;
@@ -671,7 +671,7 @@ ecore_fb_input_device_axis_size_set(Ecore_Fb_Input_Device *dev, int w, int h)
  * This function returns the name of the device @p dev. If @p dev is
  * @c NULL, this function returns @c NULL.
  */
-EAPI const char *
+ECORE_FB_API const char *
 ecore_fb_input_device_name_get(Ecore_Fb_Input_Device *dev)
 {
    if (!dev) return NULL;
@@ -687,7 +687,7 @@ ecore_fb_input_device_name_get(Ecore_Fb_Input_Device *dev)
  * This function returns the capability of the device @p dev. If @p dev is
  * @c NULL, this function returns ECORE_FB_INPUT_DEVICE_CAP_NONE.
  */
-EAPI Ecore_Fb_Input_Device_Cap
+ECORE_FB_API Ecore_Fb_Input_Device_Cap
 ecore_fb_input_device_cap_get(Ecore_Fb_Input_Device *dev)
 {
    if (!dev) return ECORE_FB_INPUT_DEVICE_CAP_NONE;
@@ -704,7 +704,7 @@ ecore_fb_input_device_cap_get(Ecore_Fb_Input_Device *dev)
  * @p dev to @p threshold. If @p dev is @c NULL, this function does
  * nothing.
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_input_device_threshold_click_set(Ecore_Fb_Input_Device *dev, double threshold)
 {
    if (!dev) return;
@@ -722,7 +722,7 @@ ecore_fb_input_device_threshold_click_set(Ecore_Fb_Input_Device *dev, double thr
  * This function returns the threshold of mouse clicks of the device
  * @p dev. If @p dev is @c NULL, this function returns 0.0.
  */
-EAPI double
+ECORE_FB_API double
 ecore_fb_input_device_threshold_click_get(Ecore_Fb_Input_Device *dev)
 {
    if (!dev) return 0;

--- a/src/lib/ecore_fb/ecore_fb_private.h
+++ b/src/lib/ecore_fb/ecore_fb_private.h
@@ -18,7 +18,7 @@
 #include <linux/vt.h>
 #include <linux/fb.h>
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,15)) && (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,18))
- #define kernel_ulong_t unsigned long 
+ #define kernel_ulong_t unsigned long
  #define BITS_PER_LONG 32
  #include <linux/input.h>
  #undef kernel_ulong_t
@@ -33,19 +33,7 @@
 
 #include "Ecore_Fb.h"
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef __GNUC__
-# if __GNUC__ >= 4
-#  define EAPI __attribute__ ((visibility("default")))
-# else
-#  define EAPI
-# endif
-#else
-# define EAPI
-#endif
+#include <ecore_fb.h>
 
 /* ecore_fb_li.c */
 struct _Ecore_Fb_Input_Device
@@ -53,7 +41,7 @@ struct _Ecore_Fb_Input_Device
    int fd;
    Ecore_Fd_Handler *handler;
    int listen;
-   struct 
+   struct
      {
         Ecore_Fb_Input_Device_Cap cap;
         char *name;
@@ -88,11 +76,11 @@ struct _Ecore_Fb_Input_Device
 };
 
 /* ecore_fb_ts.c */
-EAPI int    ecore_fb_ts_init(void);
-EAPI void   ecore_fb_ts_shutdown(void);
-EAPI void   ecore_fb_ts_events_window_set(void *window);
-EAPI void  *ecore_fb_ts_events_window_get(void);
-EAPI void   ecore_fb_ts_event_window_set(void *window);
+ECORE_FB_API int    ecore_fb_ts_init(void);
+ECORE_FB_API void   ecore_fb_ts_shutdown(void);
+ECORE_FB_API void   ecore_fb_ts_events_window_set(void *window);
+ECORE_FB_API void  *ecore_fb_ts_events_window_get(void);
+ECORE_FB_API void   ecore_fb_ts_event_window_set(void *window);
 
 /* ecore_fb_vt.c */
 int  ecore_fb_vt_init(void);
@@ -105,8 +93,5 @@ void ecore_fb_vt_shutdown(void);
 #ifndef TS_GET_CAL
 #define TS_GET_CAL 0x8014660a
 #endif
-  
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_fb/ecore_fb_ts.c
+++ b/src/lib/ecore_fb/ecore_fb_ts.c
@@ -78,7 +78,7 @@ struct ts_sample _ecore_fb_tslib_event;
 static double _ecore_fb_double_click_time = 0.25;
 static void *_ecore_fb_ts_event_window = NULL;
 
-EAPI int
+ECORE_FB_API int
 ecore_fb_ts_init(void)
 {
 #ifdef HAVE_TSLIB
@@ -130,7 +130,7 @@ ecore_fb_ts_init(void)
    return 0;
 }
 
-EAPI void
+ECORE_FB_API void
 ecore_fb_ts_shutdown(void)
 {
    if (_ecore_fb_ts_fd_handler_handle)
@@ -141,13 +141,13 @@ ecore_fb_ts_shutdown(void)
    _ecore_fb_ts_event_window = NULL;
 }
 
-EAPI void
+ECORE_FB_API void
 ecore_fb_ts_event_window_set(void *window)
 {
    _ecore_fb_ts_event_window = window;
 }
 
-EAPI void *
+ECORE_FB_API void *
 ecore_fb_ts_event_window_get(void)
 {
     return _ecore_fb_ts_event_window;
@@ -170,7 +170,7 @@ ecore_fb_ts_event_window_get(void)
  * @param   xyswap Swap X & Y flag.
  * @ingroup Ecore_FB_Calibrate_Group
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_touch_screen_calibrate_set(int xscale, int xtrans, int yscale, int ytrans, int xyswap)
 {
    Ecore_Fb_Ts_Calibrate cal;
@@ -198,7 +198,7 @@ ecore_fb_touch_screen_calibrate_set(int xscale, int xtrans, int yscale, int ytra
  * @param   xyswap Pointer to an integer in which to store the Swap X & Y flag.
  * @ingroup Ecore_FB_Calibrate_Group
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_touch_screen_calibrate_get(int *xscale, int *xtrans, int *yscale, int *ytrans, int *xyswap)
 {
    Ecore_Fb_Ts_Calibrate cal;

--- a/src/lib/ecore_fb/ecore_fb_vt.c
+++ b/src/lib/ecore_fb/ecore_fb_vt.c
@@ -241,7 +241,7 @@ ecore_fb_vt_shutdown(void)
  * to vt1 and your app was using vt1). @p data will be pass to @p func if
  * the callback is called.
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_callback_gain_set(void (*func) (void *data), void *data)
 {
    _ecore_fb_func_fb_gain = func;
@@ -259,7 +259,7 @@ ecore_fb_callback_gain_set(void (*func) (void *data), void *data)
  * want to give up that vt). @p data will be pass to @p func if the
  * callback is called.
  */
-EAPI void
+ECORE_FB_API void
 ecore_fb_callback_lose_set(void (*func) (void *data), void *data)
 {
    _ecore_fb_func_fb_lost = func;

--- a/src/lib/ecore_fb/meson.build
+++ b/src/lib/ecore_fb/meson.build
@@ -21,7 +21,7 @@ ecore_fb_src = files([
 
 ecore_fb_lib = library('ecore_fb',
     ecore_fb_src, pub_eo_file_target,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_FB'],
     dependencies: ecore_fb_pub_deps + ecore_fb_deps,
     include_directories : config_dir,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.