### PR TITLE
[ecore_file] Use ECORE_FILE_API instead of EAPI

### DIFF
--- a/src/lib/ecore_file/Ecore_File.h
+++ b/src/lib/ecore_file/Ecore_File.h
@@ -8,31 +8,7 @@
 
 #include <Eina.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_file_api.h>
 
 /**
  * @file Ecore_File.h
@@ -92,7 +68,7 @@ typedef void (*Ecore_File_Download_Completion_Cb)(void *data, const char *file, 
 
 /**
  * @typedef _Ecore_File_Progress_Return
- * What to do with the download as a return from the 
+ * What to do with the download as a return from the
  * Ecore_File_Download_Progress_Cb function, if provided.
  */
 typedef enum _Ecore_File_Progress_Return
@@ -127,7 +103,7 @@ typedef int (*Ecore_File_Download_Progress_Cb)(void *data,
  * When Ecore_File is not used anymore, call ecore_file_shutdown()
  * to shut down the Ecore_File library.
  */
-EAPI int            ecore_file_init         (void);
+ECORE_FILE_API int            ecore_file_init         (void);
 
 /**
  * @brief Shuts down the Ecore_File library.
@@ -139,7 +115,7 @@ EAPI int            ecore_file_init         (void);
  * been called the same number of times than ecore_file_init(). In that case
  * it shuts down all the services it uses.
  */
-EAPI int            ecore_file_shutdown     (void);
+ECORE_FILE_API int            ecore_file_shutdown     (void);
 
 /**
  * @brief Gets the time of the last modification to the given file.
@@ -151,7 +127,7 @@ EAPI int            ecore_file_shutdown     (void);
  * This function returns the time of the last modification of
  * @p file. On failure, it returns 0.
  */
-EAPI long long      ecore_file_mod_time     (const char *file);
+ECORE_FILE_API long long      ecore_file_mod_time     (const char *file);
 
 /**
  * @brief Gets the size of the given file.
@@ -162,7 +138,7 @@ EAPI long long      ecore_file_mod_time     (const char *file);
  * This function returns the size of @p file in bytes. On failure, it
  * returns 0.
  */
-EAPI long long      ecore_file_size         (const char *file);
+ECORE_FILE_API long long      ecore_file_size         (const char *file);
 
 /**
  * @brief Checks if the given file exists.
@@ -173,7 +149,7 @@ EAPI long long      ecore_file_size         (const char *file);
  * This function returns @c EINA_TRUE if @p file exists on local filesystem,
  * @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_exists       (const char *file);
+ECORE_FILE_API Eina_Bool      ecore_file_exists       (const char *file);
 
 /**
  * @brief Checks if the given file is a directory.
@@ -185,7 +161,7 @@ EAPI Eina_Bool      ecore_file_exists       (const char *file);
  * This function returns @c EINA_TRUE if @p file exists exists and is a
  * directory on local filesystem, @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_is_dir       (const char *file);
+ECORE_FILE_API Eina_Bool      ecore_file_is_dir       (const char *file);
 
 /**
  * @brief Creates a new directory.
@@ -198,7 +174,7 @@ EAPI Eina_Bool      ecore_file_is_dir       (const char *file);
  * (mode is unused on Windows). On success, it returns @c EINA_TRUE,
  * @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_mkdir        (const char *dir);
+ECORE_FILE_API Eina_Bool      ecore_file_mkdir        (const char *dir);
 
 /**
  * @brief Creates complete directory in a batch.
@@ -213,7 +189,7 @@ EAPI Eina_Bool      ecore_file_mkdir        (const char *dir);
  * @c NULL, otherwise if returns the number of successfully created
  * directories.
  */
-EAPI int            ecore_file_mkdirs       (const char **dirs);
+ECORE_FILE_API int            ecore_file_mkdirs       (const char **dirs);
 
 /**
  * @brief Creates complete list of sub-directories in a batch (optimized).
@@ -233,7 +209,7 @@ EAPI int            ecore_file_mkdirs       (const char **dirs);
  * invalid, or if it can't be created. Otherwise if returns the number
  * of successfully created directories.
  */
-EAPI int            ecore_file_mksubdirs    (const char *base, const char **subdirs);
+ECORE_FILE_API int            ecore_file_mksubdirs    (const char *base, const char **subdirs);
 
 /**
  * @brief Deletes the given empty directory.
@@ -244,7 +220,7 @@ EAPI int            ecore_file_mksubdirs    (const char *base, const char **subd
  * This function deletes @p dir. It returns @c EINA_TRUE on success,
  * @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_rmdir        (const char *dir);
+ECORE_FILE_API Eina_Bool      ecore_file_rmdir        (const char *dir);
 
 /**
  * @brief Deletes the given directory and all its contents.
@@ -256,7 +232,7 @@ EAPI Eina_Bool      ecore_file_rmdir        (const char *dir);
  * link only the link is removed. It returns @c EINA_TRUE on success,
  * @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_recursive_rm (const char *dir);
+ECORE_FILE_API Eina_Bool      ecore_file_recursive_rm (const char *dir);
 
 /**
  * @brief Creates a complete path.
@@ -269,7 +245,7 @@ EAPI Eina_Bool      ecore_file_recursive_rm (const char *dir);
  * function returns @c EINA_TRUE immediately. It returns @c EINA_TRUE on
  * success, @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_mkpath       (const char *path);
+ECORE_FILE_API Eina_Bool      ecore_file_mkpath       (const char *path);
 
 /**
  * @brief Creates complete paths in a batch.
@@ -284,7 +260,7 @@ EAPI Eina_Bool      ecore_file_mkpath       (const char *path);
  * returns -1 if @p paths is @c NULL. Otherwise if returns the number
  * of successfully created directories.
  */
-EAPI int            ecore_file_mkpaths      (const char **paths);
+ECORE_FILE_API int            ecore_file_mkpaths      (const char **paths);
 
 /**
  * @brief Copies the given file to the given destination.
@@ -298,7 +274,7 @@ EAPI int            ecore_file_mkpaths      (const char **paths);
  * the copy fails, the function returns @c EINA_FALSE, otherwise it
  * returns @c EINA_TRUE.
  */
-EAPI Eina_Bool      ecore_file_cp           (const char *src, const char *dst);
+ECORE_FILE_API Eina_Bool      ecore_file_cp           (const char *src, const char *dst);
 
 /**
  * @brief Moves the given file to the given destination.
@@ -310,7 +286,7 @@ EAPI Eina_Bool      ecore_file_cp           (const char *src, const char *dst);
  * This function moves @p src to @p dst. It returns @c EINA_TRUE on
  * success, @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_mv           (const char *src, const char *dst);
+ECORE_FILE_API Eina_Bool      ecore_file_mv           (const char *src, const char *dst);
 
 /**
  * @brief Creates a symbolic link.
@@ -324,7 +300,7 @@ EAPI Eina_Bool      ecore_file_mv           (const char *src, const char *dst);
  *
  * @note On windows, this function always returns @c EINA_FALSE.
  */
-EAPI Eina_Bool      ecore_file_symlink      (const char *src, const char *dest);
+ECORE_FILE_API Eina_Bool      ecore_file_symlink      (const char *src, const char *dest);
 
 /**
  * @brief Gets the canonicalized absolute path name.
@@ -338,7 +314,7 @@ EAPI Eina_Bool      ecore_file_symlink      (const char *src, const char *dest);
  * returns an empty string. Otherwise, it returns the absolute path
  * name. When not needed anymore, the returned value must be freed.
  */
-EAPI char          *ecore_file_realpath     (const char *file);
+ECORE_FILE_API char          *ecore_file_realpath     (const char *file);
 
 /**
  * @brief Deletes the given file.
@@ -349,7 +325,7 @@ EAPI char          *ecore_file_realpath     (const char *file);
  * This function deletes @p file. It returns @c EINA_TRUE on success,
  * @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_unlink       (const char *file);
+ECORE_FILE_API Eina_Bool      ecore_file_unlink       (const char *file);
 
 /**
  * @brief Removes the given file or directory.
@@ -360,7 +336,7 @@ EAPI Eina_Bool      ecore_file_unlink       (const char *file);
  * This function removes @p file. It returns @c EINA_TRUE on success,
  * @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool      ecore_file_remove       (const char *file);
+ECORE_FILE_API Eina_Bool      ecore_file_remove       (const char *file);
 
 /**
  * @brief Gets the filename from a given path.
@@ -371,7 +347,7 @@ EAPI Eina_Bool      ecore_file_remove       (const char *file);
  * This function returns the file name of @p path. If @p path is
  * @c NULL, the functions returns @c NULL.
  */
-EAPI const char    *ecore_file_file_get     (const char *path);
+ECORE_FILE_API const char    *ecore_file_file_get     (const char *path);
 
 /**
  * @brief Gets the directory where the given file resides.
@@ -384,7 +360,7 @@ EAPI const char    *ecore_file_file_get     (const char *path);
  * returns @c NULL. When not needed anymore, the returned value must
  * be freed.
  */
-EAPI char          *ecore_file_dir_get      (const char *file);
+ECORE_FILE_API char          *ecore_file_dir_get      (const char *file);
 
 /**
  * @brief Checks if the given file can be read.
@@ -395,7 +371,7 @@ EAPI char          *ecore_file_dir_get      (const char *file);
  * This function returns @c EINA_TRUE if @p file can be read, @c EINA_FALSE
  * otherwise.
  */
-EAPI Eina_Bool      ecore_file_can_read     (const char *file);
+ECORE_FILE_API Eina_Bool      ecore_file_can_read     (const char *file);
 
 /**
  * @brief Checks if the given file can be written.
@@ -406,7 +382,7 @@ EAPI Eina_Bool      ecore_file_can_read     (const char *file);
  * This function returns @c EINA_TRUE if @p file can be written, @c EINA_FALSE
  * otherwise.
  */
-EAPI Eina_Bool      ecore_file_can_write    (const char *file);
+ECORE_FILE_API Eina_Bool      ecore_file_can_write    (const char *file);
 
 /**
  * @brief Checks if the given file can be executed.
@@ -418,7 +394,7 @@ EAPI Eina_Bool      ecore_file_can_write    (const char *file);
  * This function returns @c EINA_TRUE if @p file can be executed, @c EINA_FALSE
  * otherwise.
  */
-EAPI Eina_Bool      ecore_file_can_exec     (const char *file);
+ECORE_FILE_API Eina_Bool      ecore_file_can_exec     (const char *file);
 
 /**
  * @brief Gets the path pointed by the given link.
@@ -432,7 +408,7 @@ EAPI Eina_Bool      ecore_file_can_exec     (const char *file);
  *
  * @note On windows, this function always returns @c NULL.
  */
-EAPI char          *ecore_file_readlink     (const char *link);
+ECORE_FILE_API char          *ecore_file_readlink     (const char *link);
 
 /**
  * @brief Gets the list of the files and directories in the given
@@ -451,7 +427,7 @@ EAPI char          *ecore_file_readlink     (const char *link);
  * '.' and '..'. On failure, @c NULL is returned. When not needed
  * anymore, the list elements must be freed.
  */
-EAPI Eina_List     *ecore_file_ls           (const char *dir);
+ECORE_FILE_API Eina_List     *ecore_file_ls           (const char *dir);
 
 /**
  * @brief Returns the executable from the given command.
@@ -462,7 +438,7 @@ EAPI Eina_List     *ecore_file_ls           (const char *dir);
  * on failure, the function returns @c NULL. When not needed anymore, the
  * returned value must be freed.
  */
-EAPI char          *ecore_file_app_exe_get  (const char *app);
+ECORE_FILE_API char          *ecore_file_app_exe_get  (const char *app);
 
 /**
  * @brief Adds the escape sequence ('\\') to the given file name.
@@ -476,7 +452,7 @@ EAPI char          *ecore_file_app_exe_get  (const char *app);
  * failure, @c NULL is returned. When not needed anymore, the returned
  * value must be freed.
  */
-EAPI char          *ecore_file_escape_name  (const char *filename);
+ECORE_FILE_API char          *ecore_file_escape_name  (const char *filename);
 
 /**
  * @brief Removes the extension from the given file name.
@@ -490,7 +466,7 @@ EAPI char          *ecore_file_escape_name  (const char *filename);
  * failure, the function returns @c NULL. When not needed anymore, the
  * returned value must be freed.
  */
-EAPI char          *ecore_file_strip_ext    (const char *path);
+ECORE_FILE_API char          *ecore_file_strip_ext    (const char *path);
 
 /**
  * @brief Checks if the given directory is empty.
@@ -503,7 +479,7 @@ EAPI char          *ecore_file_strip_ext    (const char *path);
  * will be ignored. If @p dir is empty, 1 is returned, if it contains
  * at least one file, @c 0 is returned. On failure, @c -1 is returned.
  */
-EAPI int            ecore_file_dir_is_empty (const char *dir);
+ECORE_FILE_API int            ecore_file_dir_is_empty (const char *dir);
 
 /* Monitoring */
 
@@ -518,13 +494,13 @@ EAPI int            ecore_file_dir_is_empty (const char *dir);
  * This function monitors @p path. If @p path is @c NULL, or is an
  * empty string, or none of the notify methods (Inotify, Windows
  * notification or polling) is available, or if @p path does not exist
- * the function returns @c NULL. Otherwise, it returns a newly 
+ * the function returns @c NULL. Otherwise, it returns a newly
  * allocated Ecore_File_Monitor object and the monitoring begins.
  * When one of the Ecore_File_Event event is notified, @p func is called
  * and @p data is passed to @p func.Call ecore_file_monitor_del() to
  * stop the monitoring.
  */
-EAPI Ecore_File_Monitor *ecore_file_monitor_add(const char *path,
+ECORE_FILE_API Ecore_File_Monitor *ecore_file_monitor_add(const char *path,
                                                 Ecore_File_Monitor_Cb func,
                                                 void *data);
 
@@ -539,7 +515,7 @@ EAPI Ecore_File_Monitor *ecore_file_monitor_add(const char *path,
  * of the notify methods (Inotify, Windows notification or polling) is
  * available this function does nothing.
  */
-EAPI void                ecore_file_monitor_del(Ecore_File_Monitor *em);
+ECORE_FILE_API void                ecore_file_monitor_del(Ecore_File_Monitor *em);
 
 /**
  * @brief Gets the monitored path.
@@ -552,7 +528,7 @@ EAPI void                ecore_file_monitor_del(Ecore_File_Monitor *em);
  * returned by ecore_file_monitor_add(). If @p em is @c NULL, the
  * function returns @c NULL.
  */
-EAPI const char         *ecore_file_monitor_path_get(Ecore_File_Monitor *em);
+ECORE_FILE_API const char         *ecore_file_monitor_path_get(Ecore_File_Monitor *em);
 
 /* Path */
 
@@ -567,7 +543,7 @@ EAPI const char         *ecore_file_monitor_path_get(Ecore_File_Monitor *em);
  * not in PATH, the function returns @c EINA_FALSE, otherwise it returns
  * @c EINA_TRUE.
  */
-EAPI Eina_Bool  ecore_file_path_dir_exists(const char *in_dir);
+ECORE_FILE_API Eina_Bool  ecore_file_path_dir_exists(const char *in_dir);
 
 /**
  * @brief Checks if the given application is installed.
@@ -580,7 +556,7 @@ EAPI Eina_Bool  ecore_file_path_dir_exists(const char *in_dir);
  * @p exe is @c NULL or is not executable, the function returns
  * @c EINA_FALSE, otherwise it returns @c EINA_TRUE.
  */
-EAPI Eina_Bool  ecore_file_app_installed(const char *exe);
+ECORE_FILE_API Eina_Bool  ecore_file_app_installed(const char *exe);
 
 /**
  * @brief Gets a list of all the applications installed on the system.
@@ -593,7 +569,7 @@ EAPI Eina_Bool  ecore_file_app_installed(const char *exe);
  * @c NULL. When not needed anymore, the element of the list must be
  * freed.
  */
-EAPI Eina_List *ecore_file_app_list(void);
+ECORE_FILE_API Eina_List *ecore_file_app_list(void);
 
 /* Download */
 
@@ -626,7 +602,7 @@ EAPI Eina_List *ecore_file_app_list(void);
  * abort all download operations. This function returns @c EINA_TRUE if the
  * download starts, @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool ecore_file_download(const char *url,
+ECORE_FILE_API Eina_Bool ecore_file_download(const char *url,
                                    const char *dst,
                                    Ecore_File_Download_Completion_Cb completion_cb,
                                    Ecore_File_Download_Progress_Cb progress_cb,
@@ -645,7 +621,7 @@ EAPI Eina_Bool ecore_file_download(const char *url,
  * @param  headers pointer of header lists.
  * @return @c EINA_TRUE if the download start or @c EINA_FALSE on failure.
  */
-EAPI Eina_Bool ecore_file_download_full(const char *url,
+ECORE_FILE_API Eina_Bool ecore_file_download_full(const char *url,
                                         const char *dst,
                                         Ecore_File_Download_Completion_Cb completion_cb,
                                         Ecore_File_Download_Progress_Cb progress_cb,
@@ -661,7 +637,7 @@ EAPI Eina_Bool ecore_file_download_full(const char *url,
  * ecore_file_download_abort() for each of them. To abort only one
  * specific download operation, call ecore_file_download_abort().
  */
-EAPI void      ecore_file_download_abort_all(void);
+ECORE_FILE_API void      ecore_file_download_abort_all(void);
 
 /**
  * @brief Aborts the given download job and call the completion_cb
@@ -675,7 +651,7 @@ EAPI void      ecore_file_download_abort_all(void);
  * function does nothing. To abort all the currently downloading
  * operations, call ecore_file_download_abort_all().
  */
-EAPI void      ecore_file_download_abort(Ecore_File_Download_Job *job);
+ECORE_FILE_API void      ecore_file_download_abort(Ecore_File_Download_Job *job);
 
 /**
  * @brief Checks if the given protocol is available.
@@ -688,7 +664,7 @@ EAPI void      ecore_file_download_abort(Ecore_File_Download_Job *job);
  * '%file://'. Ecore_FILE must be compiled with CURL to handle http and
  * ftp protocols.
  */
-EAPI Eina_Bool ecore_file_download_protocol_available(const char *protocol);
+ECORE_FILE_API Eina_Bool ecore_file_download_protocol_available(const char *protocol);
 
 /**
  * @}
@@ -697,8 +673,5 @@ EAPI Eina_Bool ecore_file_download_protocol_available(const char *protocol);
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_file/ecore_file.c
+++ b/src/lib/ecore_file/ecore_file.c
@@ -79,7 +79,7 @@ _ecore_file_stat(const char *file,
    return EINA_TRUE;
 }
 
-EAPI int
+ECORE_FILE_API int
 ecore_file_init()
 {
    if (++_ecore_file_init_count != 1)
@@ -121,7 +121,7 @@ ecore_file_init()
    */
 }
 
-EAPI int
+ECORE_FILE_API int
 ecore_file_shutdown()
 {
    if (--_ecore_file_init_count != 0)
@@ -139,7 +139,7 @@ ecore_file_shutdown()
    return _ecore_file_init_count;
 }
 
-EAPI long long
+ECORE_FILE_API long long
 ecore_file_mod_time(const char *file)
 {
    long long time;
@@ -150,7 +150,7 @@ ecore_file_mod_time(const char *file)
    return time;
 }
 
-EAPI long long
+ECORE_FILE_API long long
 ecore_file_size(const char *file)
 {
    long long size;
@@ -161,7 +161,7 @@ ecore_file_size(const char *file)
    return size;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_exists(const char *file)
 {
 #ifdef _WIN32
@@ -177,7 +177,7 @@ ecore_file_exists(const char *file)
 #endif
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_is_dir(const char *file)
 {
    Eina_Bool is_dir;
@@ -190,13 +190,13 @@ ecore_file_is_dir(const char *file)
 
 static mode_t default_mode = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_mkdir(const char *dir)
 {
    return (mkdir(dir, default_mode) == 0);
 }
 
-EAPI int
+ECORE_FILE_API int
 ecore_file_mkdirs(const char **dirs)
 {
    int i = 0;
@@ -209,7 +209,7 @@ ecore_file_mkdirs(const char **dirs)
    return i;
 }
 
-EAPI int
+ECORE_FILE_API int
 ecore_file_mksubdirs(const char *base, const char **subdirs)
 {
 #ifndef HAVE_ATFILE_SOURCE
@@ -291,28 +291,28 @@ ecore_file_mksubdirs(const char *base, const char **subdirs)
    return i;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_rmdir(const char *dir)
 {
    if (rmdir(dir) < 0) return EINA_FALSE;
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_unlink(const char *file)
 {
    if (unlink(file) < 0) return EINA_FALSE;
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_remove(const char *file)
 {
    if (remove(file) < 0) return EINA_FALSE;
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_recursive_rm(const char *dir)
 {
 #ifndef _WIN32
@@ -378,7 +378,7 @@ _ecore_file_mkpath_if_not_exists(const char *path)
      return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_mkpath(const char *path)
 {
    char ss[PATH_MAX];
@@ -403,7 +403,7 @@ ecore_file_mkpath(const char *path)
    return _ecore_file_mkpath_if_not_exists(ss);
 }
 
-EAPI int
+ECORE_FILE_API int
 ecore_file_mkpaths(const char **paths)
 {
    int i = 0;
@@ -416,7 +416,7 @@ ecore_file_mkpaths(const char **paths)
    return i;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_cp(const char *src, const char *dst)
 {
    FILE *f1, *f2;
@@ -445,7 +445,7 @@ ecore_file_cp(const char *src, const char *dst)
    return ret;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_mv(const char *src, const char *dst)
 {
    char buf[PATH_MAX];
@@ -538,7 +538,7 @@ FAIL:
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_symlink(const char *src, const char *dest)
 {
 #ifndef _WIN32
@@ -550,7 +550,7 @@ ecore_file_symlink(const char *src, const char *dest)
 #endif
 }
 
-EAPI char *
+ECORE_FILE_API char *
 ecore_file_realpath(const char *file)
 {
    char buf[PATH_MAX];
@@ -565,7 +565,7 @@ ecore_file_realpath(const char *file)
    return strdup(buf);
 }
 
-EAPI const char *
+ECORE_FILE_API const char *
 ecore_file_file_get(const char *path)
 {
    char *result = NULL;
@@ -590,7 +590,7 @@ ecore_file_file_get(const char *path)
    return result;
 }
 
-EAPI char *
+ECORE_FILE_API char *
 ecore_file_dir_get(const char *file)
 {
    char *p;
@@ -603,7 +603,7 @@ ecore_file_dir_get(const char *file)
    return strdup(p);
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_can_read(const char *file)
 {
    if (!file) return EINA_FALSE;
@@ -611,7 +611,7 @@ ecore_file_can_read(const char *file)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_can_write(const char *file)
 {
    if (!file) return EINA_FALSE;
@@ -619,7 +619,7 @@ ecore_file_can_write(const char *file)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_can_exec(const char *file)
 {
    if (!file) return EINA_FALSE;
@@ -627,7 +627,7 @@ ecore_file_can_exec(const char *file)
    return EINA_FALSE;
 }
 
-EAPI char *
+ECORE_FILE_API char *
 ecore_file_readlink(const char *link)
 {
 #ifndef _WIN32
@@ -643,7 +643,7 @@ ecore_file_readlink(const char *link)
 #endif
 }
 
-EAPI Eina_List *
+ECORE_FILE_API Eina_List *
 ecore_file_ls(const char *dir)
 {
    Eina_File_Direct_Info *info;
@@ -667,7 +667,7 @@ ecore_file_ls(const char *dir)
    return list;
 }
 
-EAPI char *
+ECORE_FILE_API char *
 ecore_file_app_exe_get(const char *app)
 {
    Eina_Strbuf *buf;
@@ -729,7 +729,7 @@ ecore_file_app_exe_get(const char *app)
    return exe;
 }
 
-EAPI char *
+ECORE_FILE_API char *
 ecore_file_escape_name(const char *filename)
 {
    const char *p;
@@ -787,7 +787,7 @@ ecore_file_escape_name(const char *filename)
    return strdup(buf);
 }
 
-EAPI char *
+ECORE_FILE_API char *
 ecore_file_strip_ext(const char *path)
 {
    char *p, *file = NULL;
@@ -811,7 +811,7 @@ ecore_file_strip_ext(const char *path)
    return file;
 }
 
-EAPI int
+ECORE_FILE_API int
 ecore_file_dir_is_empty(const char *dir)
 {
    Eina_File_Direct_Info *info;

--- a/src/lib/ecore_file/ecore_file_api.h
+++ b/src/lib/ecore_file/ecore_file_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_FILE_API_H
+#define _EFL_ECORE_FILE_API_H
+
+#ifdef ECORE_FILE_API
+#error ECORE_FILE_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_FILE_STATIC
+#  ifdef ECORE_FILE_BUILD
+#   define ECORE_FILE_API __declspec(dllexport)
+#  else
+#   define ECORE_FILE_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_FILE_API
+# endif
+# define ECORE_FILE_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_FILE_API __attribute__ ((visibility("default")))
+#   define ECORE_FILE_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_FILE_API
+#   define ECORE_FILE_API_WEAK
+#  endif
+# else
+#  define ECORE_FILE_API
+#  define ECORE_FILE_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_file/ecore_file_download.c
+++ b/src/lib/ecore_file/ecore_file_download.c
@@ -174,7 +174,7 @@ _ecore_file_download_headers_foreach_cb(const Eina_Hash *hash EINA_UNUSED, const
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_download_full(const char *url,
                          const char *dst,
                          Ecore_File_Download_Completion_Cb completion_cb,
@@ -274,7 +274,7 @@ ecore_file_download_full(const char *url,
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_download(const char *url,
                     const char *dst,
                     Ecore_File_Download_Completion_Cb completion_cb,
@@ -285,7 +285,7 @@ ecore_file_download(const char *url,
    return ecore_file_download_full(url, dst, completion_cb, progress_cb, data, job_ret, NULL);
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_download_protocol_available(const char *protocol)
 {
    if (!strncmp(protocol, "file://", 7)) return EINA_TRUE;
@@ -296,7 +296,7 @@ ecore_file_download_protocol_available(const char *protocol)
    return EINA_FALSE;
 }
 
-EAPI void
+ECORE_FILE_API void
 ecore_file_download_abort(Ecore_File_Download_Job *job)
 {
    const char *file;
@@ -331,7 +331,7 @@ ecore_file_download_abort(Ecore_File_Download_Job *job)
    efl_io_closer_close(job->copier);
 }
 
-EAPI void
+ECORE_FILE_API void
 ecore_file_download_abort_all(void)
 {
    Ecore_File_Download_Job *job;

--- a/src/lib/ecore_file/ecore_file_monitor.c
+++ b/src/lib/ecore_file/ecore_file_monitor.c
@@ -18,7 +18,7 @@ ecore_file_monitor_shutdown(void)
    ecore_file_monitor_backend_shutdown();
 }
 
-EAPI Ecore_File_Monitor *
+ECORE_FILE_API Ecore_File_Monitor *
 ecore_file_monitor_add(const char           *path,
                        Ecore_File_Monitor_Cb func,
                        void                 *data)
@@ -30,7 +30,7 @@ ecore_file_monitor_add(const char           *path,
    return ecore_file_monitor_backend_add(path, func, data);
 }
 
-EAPI void
+ECORE_FILE_API void
 ecore_file_monitor_del(Ecore_File_Monitor *em)
 {
    if (!em) return;
@@ -38,7 +38,7 @@ ecore_file_monitor_del(Ecore_File_Monitor *em)
    ecore_file_monitor_backend_del(em);
 }
 
-EAPI const char *
+ECORE_FILE_API const char *
 ecore_file_monitor_path_get(Ecore_File_Monitor *em)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(em, NULL);

--- a/src/lib/ecore_file/ecore_file_path.c
+++ b/src/lib/ecore_file/ecore_file_path.c
@@ -68,7 +68,7 @@ _ecore_file_path_from_env(const char *env)
    return path;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_path_dir_exists(const char *in_dir)
 {
    Eina_List *l;
@@ -87,7 +87,7 @@ ecore_file_path_dir_exists(const char *in_dir)
    return EINA_FALSE;
 }
 
-EAPI Eina_Bool
+ECORE_FILE_API Eina_Bool
 ecore_file_app_installed(const char *exe)
 {
    Eina_List *l;
@@ -110,7 +110,7 @@ ecore_file_app_installed(const char *exe)
    return EINA_FALSE;
 }
 
-EAPI Eina_List *
+ECORE_FILE_API Eina_List *
 ecore_file_app_list(void)
 {
    Eina_List *list = NULL;

--- a/src/lib/ecore_file/meson.build
+++ b/src/lib/ecore_file/meson.build
@@ -23,7 +23,7 @@ ecore_file_header_src = ['Ecore_File.h']
 
 ecore_file_lib = library('ecore_file',
     ecore_file_src,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_FILE_BUILD'],
     dependencies: ecore_file_deps + ecore_file_pub_deps + ecore_file_ext_deps,
     include_directories : config_dir + [include_directories(join_paths('..','..'))],
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.