### PR TITLE
[ecore_imf] Use ECORE_IMF_API instead of EAPI

### DIFF
--- a/src/lib/ecore_imf/Ecore_IMF.h
+++ b/src/lib/ecore_imf/Ecore_IMF.h
@@ -3,31 +3,7 @@
 
 #include <Eina.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_imf_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -202,11 +178,11 @@ typedef struct _Ecore_IMF_Context_Info             Ecore_IMF_Context_Info;      
 /* Preedit attribute info */
 typedef struct _Ecore_IMF_Preedit_Attr             Ecore_IMF_Preedit_Attr;
 
-EAPI extern int ECORE_IMF_EVENT_PREEDIT_START;
-EAPI extern int ECORE_IMF_EVENT_PREEDIT_END;
-EAPI extern int ECORE_IMF_EVENT_PREEDIT_CHANGED;
-EAPI extern int ECORE_IMF_EVENT_COMMIT;
-EAPI extern int ECORE_IMF_EVENT_DELETE_SURROUNDING;
+ECORE_IMF_API extern int ECORE_IMF_EVENT_PREEDIT_START;
+ECORE_IMF_API extern int ECORE_IMF_EVENT_PREEDIT_END;
+ECORE_IMF_API extern int ECORE_IMF_EVENT_PREEDIT_CHANGED;
+ECORE_IMF_API extern int ECORE_IMF_EVENT_COMMIT;
+ECORE_IMF_API extern int ECORE_IMF_EVENT_DELETE_SURROUNDING;
 
 /**
  * @typedef Ecore_IMF_Event_Cb
@@ -835,7 +811,7 @@ struct _Ecore_IMF_Context_Info
  * @return  Number of times the library has been initialised without being
  *          shut down.
  */
-EAPI int                           ecore_imf_init(void);
+ECORE_IMF_API int                           ecore_imf_init(void);
 
 /**
  * @ingroup Ecore_IMF_Lib_Group
@@ -843,7 +819,7 @@ EAPI int                           ecore_imf_init(void);
  * @return  Number of times the library has been initialised without being
  *          shut down.
  */
-EAPI int                           ecore_imf_shutdown(void);
+ECORE_IMF_API int                           ecore_imf_shutdown(void);
 
 /**
  * @ingroup Ecore_IMF_Lib_Group
@@ -854,7 +830,7 @@ EAPI int                           ecore_imf_shutdown(void);
  * @param imf_module_exit   A function to call when exiting
  *
  */
-EAPI void                          ecore_imf_module_register(const Ecore_IMF_Context_Info *info, Ecore_IMF_Context *(*imf_module_create)(void), Ecore_IMF_Context *(*imf_module_exit)(void));
+ECORE_IMF_API void                          ecore_imf_module_register(const Ecore_IMF_Context_Info *info, Ecore_IMF_Context *(*imf_module_create)(void), Ecore_IMF_Context *(*imf_module_exit)(void));
 
 /**
  * @ingroup Ecore_IMF_Lib_Group
@@ -863,7 +839,7 @@ EAPI void                          ecore_imf_module_register(const Ecore_IMF_Con
             EINA_FALSE if the input panel is already in hidden state
  * @since 1.8.0
  */
-EAPI Eina_Bool                     ecore_imf_input_panel_hide(void);
+ECORE_IMF_API Eina_Bool                     ecore_imf_input_panel_hide(void);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -875,7 +851,7 @@ EAPI Eina_Bool                     ecore_imf_input_panel_hide(void);
  * @return Return an Eina_List of strings;
  *         on failure it returns NULL.
  */
-EAPI Eina_List                    *ecore_imf_context_available_ids_get(void);
+ECORE_IMF_API Eina_List                    *ecore_imf_context_available_ids_get(void);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -888,7 +864,7 @@ EAPI Eina_List                    *ecore_imf_context_available_ids_get(void);
  * @return Return an Eina_List of strings;
  *         on failure it returns NULL.
  */
-EAPI Eina_List                    *ecore_imf_context_available_ids_by_canvas_type_get(const char *canvas_type);
+ECORE_IMF_API Eina_List                    *ecore_imf_context_available_ids_by_canvas_type_get(const char *canvas_type);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -899,7 +875,7 @@ EAPI Eina_List                    *ecore_imf_context_available_ids_by_canvas_typ
  * @return Return a string containing the id of the default Input
  *         Method Context; on failure it returns NULL.
  */
-EAPI const char                   *ecore_imf_context_default_id_get(void);
+ECORE_IMF_API const char                   *ecore_imf_context_default_id_get(void);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -912,7 +888,7 @@ EAPI const char                   *ecore_imf_context_default_id_get(void);
  * @return Return a string containing the id of the default Input
  *         Method Context; on failure it returns NULL.
  */
-EAPI const char                   *ecore_imf_context_default_id_by_canvas_type_get(const char *canvas_type);
+ECORE_IMF_API const char                   *ecore_imf_context_default_id_by_canvas_type_get(const char *canvas_type);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -948,7 +924,7 @@ EAPI const char                   *ecore_imf_context_default_id_by_canvas_type_g
  *   }
  * @endcode
  */
-EAPI const Ecore_IMF_Context_Info *ecore_imf_context_info_by_id_get(const char *id);
+ECORE_IMF_API const Ecore_IMF_Context_Info *ecore_imf_context_info_by_id_get(const char *id);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -958,7 +934,7 @@ EAPI const Ecore_IMF_Context_Info *ecore_imf_context_info_by_id_get(const char *
  * @return A newly allocated Input Method Context;
  *         on failure it returns NULL.
  */
-EAPI Ecore_IMF_Context            *ecore_imf_context_add(const char *id);
+ECORE_IMF_API Ecore_IMF_Context            *ecore_imf_context_add(const char *id);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -968,7 +944,7 @@ EAPI Ecore_IMF_Context            *ecore_imf_context_add(const char *id);
  * @return Return a #Ecore_IMF_Context_Info for the given Input Method Context;
  *         on failure it returns NULL.
  */
-EAPI const Ecore_IMF_Context_Info *ecore_imf_context_info_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API const Ecore_IMF_Context_Info *ecore_imf_context_info_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -976,7 +952,7 @@ EAPI const Ecore_IMF_Context_Info *ecore_imf_context_info_get(Ecore_IMF_Context 
  *
  * @param ctx An #Ecore_IMF_Context.
  */
-EAPI void                          ecore_imf_context_del(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                          ecore_imf_context_del(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -989,7 +965,7 @@ EAPI void                          ecore_imf_context_del(Ecore_IMF_Context *ctx)
  * @param window The client window. This may be @c NULL to indicate
  *               that the previous client window no longer exists.
  */
-EAPI void                          ecore_imf_context_client_window_set(Ecore_IMF_Context *ctx, void *window);
+ECORE_IMF_API void                          ecore_imf_context_client_window_set(Ecore_IMF_Context *ctx, void *window);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1001,7 +977,7 @@ EAPI void                          ecore_imf_context_client_window_set(Ecore_IMF
  * @return Return the client window.
  * @since 1.1.0
  */
-EAPI void                         *ecore_imf_context_client_window_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                         *ecore_imf_context_client_window_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1016,7 +992,7 @@ EAPI void                         *ecore_imf_context_client_window_get(Ecore_IMF
  * @param canvas The client canvas. This may be @c NULL to indicate
  *               that the previous client canvas no longer exists.
  */
-EAPI void                          ecore_imf_context_client_canvas_set(Ecore_IMF_Context *ctx, void *canvas);
+ECORE_IMF_API void                          ecore_imf_context_client_canvas_set(Ecore_IMF_Context *ctx, void *canvas);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1028,7 +1004,7 @@ EAPI void                          ecore_imf_context_client_canvas_set(Ecore_IMF
  * @return Return the client canvas.
  * @since 1.1.0
  */
-EAPI void                         *ecore_imf_context_client_canvas_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                         *ecore_imf_context_client_canvas_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1038,7 +1014,7 @@ EAPI void                         *ecore_imf_context_client_canvas_get(Ecore_IMF
  *
  * @deprecated use ecore_imf_context_input_panel_show() instead.
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_show(Ecore_IMF_Context *ctx);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_show(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1048,7 +1024,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_show(Ecore_IMF_Context *ctx
  *
  * @deprecated use ecore_imf_context_input_panel_hide() instead.
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_hide(Ecore_IMF_Context *ctx);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_hide(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1061,7 +1037,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_hide(Ecore_IMF_Context *ctx
  * @param cursor_pos Location to store position of cursor (in characters)
  *                   within the preedit string.
  */
-EAPI void                          ecore_imf_context_preedit_string_get(Ecore_IMF_Context *ctx, char **str, int *cursor_pos);
+ECORE_IMF_API void                          ecore_imf_context_preedit_string_get(Ecore_IMF_Context *ctx, char **str, int *cursor_pos);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1116,7 +1092,7 @@ EAPI void                          ecore_imf_context_preedit_string_get(Ecore_IM
  * @endcode
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_preedit_string_with_attributes_get(Ecore_IMF_Context *ctx, char **str, Eina_List **attrs, int *cursor_pos);
+ECORE_IMF_API void                          ecore_imf_context_preedit_string_with_attributes_get(Ecore_IMF_Context *ctx, char **str, Eina_List **attrs, int *cursor_pos);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1137,7 +1113,7 @@ EAPI void                          ecore_imf_context_preedit_string_with_attribu
  * evas_object_event_callback_add(obj, EVAS_CALLBACK_FOCUS_IN, _focus_in_cb, imf_context);
  * @endcode
  */
-EAPI void                          ecore_imf_context_focus_in(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                          ecore_imf_context_focus_in(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1159,7 +1135,7 @@ EAPI void                          ecore_imf_context_focus_in(Ecore_IMF_Context 
  * evas_object_event_callback_add(obj, EVAS_CALLBACK_FOCUS_OUT, _focus_out_cb, ed);
  * @endcode
  */
-EAPI void                          ecore_imf_context_focus_out(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                          ecore_imf_context_focus_out(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1189,7 +1165,7 @@ EAPI void                          ecore_imf_context_focus_out(Ecore_IMF_Context
  * evas_object_event_callback_add(obj, EVAS_CALLBACK_FOCUS_OUT, _focus_out_cb, imf_context);
  * @endcode
  */
-EAPI void                          ecore_imf_context_reset(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                          ecore_imf_context_reset(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1204,7 +1180,7 @@ EAPI void                          ecore_imf_context_reset(Ecore_IMF_Context *ct
  * @param ctx An #Ecore_IMF_Context.
  * @param cursor_pos New cursor position in characters.
  */
-EAPI void                          ecore_imf_context_cursor_position_set(Ecore_IMF_Context *ctx, int cursor_pos);
+ECORE_IMF_API void                          ecore_imf_context_cursor_position_set(Ecore_IMF_Context *ctx, int cursor_pos);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1220,7 +1196,7 @@ EAPI void                          ecore_imf_context_cursor_position_set(Ecore_I
  * @param h cursor height.
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_cursor_location_set(Ecore_IMF_Context *ctx, int x, int y, int w, int h);
+ECORE_IMF_API void                          ecore_imf_context_cursor_location_set(Ecore_IMF_Context *ctx, int x, int y, int w, int h);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1232,7 +1208,7 @@ EAPI void                          ecore_imf_context_cursor_location_set(Ecore_I
  * @param ctx An #Ecore_IMF_Context.
  * @param use_preedit Whether the IM context should use the preedit string.
  */
-EAPI void                          ecore_imf_context_use_preedit_set(Ecore_IMF_Context *ctx, Eina_Bool use_preedit);
+ECORE_IMF_API void                          ecore_imf_context_use_preedit_set(Ecore_IMF_Context *ctx, Eina_Bool use_preedit);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1247,7 +1223,7 @@ EAPI void                          ecore_imf_context_use_preedit_set(Ecore_IMF_C
  * @param func The callback to be called.
  * @param data The data pointer to be passed to @p func
  */
-EAPI void                          ecore_imf_context_retrieve_surrounding_callback_set(Ecore_IMF_Context *ctx, Eina_Bool (*func)(void *data, Ecore_IMF_Context *ctx, char **text, int *cursor_pos), const void *data);
+ECORE_IMF_API void                          ecore_imf_context_retrieve_surrounding_callback_set(Ecore_IMF_Context *ctx, Eina_Bool (*func)(void *data, Ecore_IMF_Context *ctx, char **text, int *cursor_pos), const void *data);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1261,7 +1237,7 @@ EAPI void                          ecore_imf_context_retrieve_surrounding_callba
  * @param data The data pointer to be passed to @p func
  * @since 1.9.0
  */
-EAPI void                          ecore_imf_context_retrieve_selection_callback_set(Ecore_IMF_Context *ctx, Eina_Bool (*func)(void *data, Ecore_IMF_Context *ctx, char **text), const void *data);
+ECORE_IMF_API void                          ecore_imf_context_retrieve_selection_callback_set(Ecore_IMF_Context *ctx, Eina_Bool (*func)(void *data, Ecore_IMF_Context *ctx, char **text), const void *data);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1274,7 +1250,7 @@ EAPI void                          ecore_imf_context_retrieve_selection_callback
  * @param ctx An #Ecore_IMF_Context.
  * @param input_mode The input mode to be used by @p ctx.
  */
-EAPI void                          ecore_imf_context_input_mode_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Mode input_mode);
+ECORE_IMF_API void                          ecore_imf_context_input_mode_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Mode input_mode);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1285,7 +1261,7 @@ EAPI void                          ecore_imf_context_input_mode_set(Ecore_IMF_Co
  * @param ctx An #Ecore_IMF_Context.
  * @return The input mode being used by @p ctx.
  */
-EAPI Ecore_IMF_Input_Mode          ecore_imf_context_input_mode_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_Input_Mode          ecore_imf_context_input_mode_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1324,7 +1300,7 @@ EAPI Ecore_IMF_Input_Mode          ecore_imf_context_input_mode_get(Ecore_IMF_Co
  * evas_object_event_callback_add(obj, EVAS_CALLBACK_KEY_DOWN, _key_down_cb, data);
  * @endcode
  */
-EAPI Eina_Bool                     ecore_imf_context_filter_event(Ecore_IMF_Context *ctx, Ecore_IMF_Event_Type type, Ecore_IMF_Event *event);
+ECORE_IMF_API Eina_Bool                     ecore_imf_context_filter_event(Ecore_IMF_Context *ctx, Ecore_IMF_Event_Type type, Ecore_IMF_Event *event);
 
 /* plugin specific functions */
 
@@ -1345,7 +1321,7 @@ EAPI Eina_Bool                     ecore_imf_context_filter_event(Ecore_IMF_Cont
  * @param ctxc An #Ecore_IMF_Context_Class.
  * @return A new #Ecore_IMF_Context; on failure it returns NULL.
  */
-EAPI Ecore_IMF_Context            *ecore_imf_context_new(const Ecore_IMF_Context_Class *ctxc);
+ECORE_IMF_API Ecore_IMF_Context            *ecore_imf_context_new(const Ecore_IMF_Context_Class *ctxc);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1359,7 +1335,7 @@ EAPI Ecore_IMF_Context            *ecore_imf_context_new(const Ecore_IMF_Context
  * @param data The Input Method Context specific data.
  * @return A new #Ecore_IMF_Context; on failure it returns NULL.
  */
-EAPI void                          ecore_imf_context_data_set(Ecore_IMF_Context *ctx, void *data);
+ECORE_IMF_API void                          ecore_imf_context_data_set(Ecore_IMF_Context *ctx, void *data);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1370,7 +1346,7 @@ EAPI void                          ecore_imf_context_data_set(Ecore_IMF_Context 
  * @param ctx An #Ecore_IMF_Context.
  * @return The Input Method Context specific data.
  */
-EAPI void                         *ecore_imf_context_data_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                         *ecore_imf_context_data_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1397,7 +1373,7 @@ EAPI void                         *ecore_imf_context_data_get(Ecore_IMF_Context 
  * @return @c EINA_TRUE if surrounding text was provided; otherwise
  * @c EINA_FALSE.
  */
-EAPI Eina_Bool                     ecore_imf_context_surrounding_get(Ecore_IMF_Context *ctx, char **text, int *cursor_pos);
+ECORE_IMF_API Eina_Bool                     ecore_imf_context_surrounding_get(Ecore_IMF_Context *ctx, char **text, int *cursor_pos);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1419,7 +1395,7 @@ EAPI Eina_Bool                     ecore_imf_context_surrounding_get(Ecore_IMF_C
  * @c EINA_FALSE.
  * @since 1.9.0
  */
-EAPI Eina_Bool                     ecore_imf_context_selection_get(Ecore_IMF_Context *ctx, char **text);
+ECORE_IMF_API Eina_Bool                     ecore_imf_context_selection_get(Ecore_IMF_Context *ctx, char **text);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1433,7 +1409,7 @@ EAPI Eina_Bool                     ecore_imf_context_selection_get(Ecore_IMF_Con
  *
  * @deprecated use ecore_imf_context_event_callback_call() instead.
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_preedit_start_event_add(Ecore_IMF_Context *ctx);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_preedit_start_event_add(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1447,7 +1423,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_preedit_start_event_add(Eco
  *
  * @deprecated use ecore_imf_context_event_callback_call() instead.
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_preedit_end_event_add(Ecore_IMF_Context *ctx);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_preedit_end_event_add(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1460,7 +1436,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_preedit_end_event_add(Ecore
  *
  * @deprecated use ecore_imf_context_event_callback_call() instead.
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_preedit_changed_event_add(Ecore_IMF_Context *ctx);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_preedit_changed_event_add(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1474,7 +1450,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_preedit_changed_event_add(E
  *
  * @deprecated use ecore_imf_context_event_callback_call() instead.
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_commit_event_add(Ecore_IMF_Context *ctx, const char *str);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_commit_event_add(Ecore_IMF_Context *ctx, const char *str);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1493,7 +1469,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_commit_event_add(Ecore_IMF_
  *
  * @deprecated use ecore_imf_context_event_callback_call() instead.
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_delete_surrounding_event_add(Ecore_IMF_Context *ctx, int offset, int n_chars);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_delete_surrounding_event_add(Ecore_IMF_Context *ctx, int offset, int n_chars);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1554,7 +1530,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_delete_surrounding_event_ad
  * ecore_imf_context_event_callback_add(en->imf_context, ECORE_IMF_CALLBACK_COMMIT_CONTENT, _imf_event_commit_content_cb, data);
  * @endcode
  */
-EAPI void                          ecore_imf_context_event_callback_add(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, Ecore_IMF_Event_Cb func, const void *data);
+ECORE_IMF_API void                          ecore_imf_context_event_callback_add(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, Ecore_IMF_Event_Cb func, const void *data);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1573,7 +1549,7 @@ EAPI void                          ecore_imf_context_event_callback_add(Ecore_IM
  * @return the data pointer
  * @since 1.2.0
  */
-EAPI void                         *ecore_imf_context_event_callback_del(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, Ecore_IMF_Event_Cb func);
+ECORE_IMF_API void                         *ecore_imf_context_event_callback_del(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, Ecore_IMF_Event_Cb func);
 
 /**
  * @ingroup Ecore_IMF_Context_Module_Group
@@ -1592,7 +1568,7 @@ EAPI void                         *ecore_imf_context_event_callback_del(Ecore_IM
  *        pass to the callback functions registered on this event
  * @since 1.2.0
  */
-EAPI void                          ecore_imf_context_event_callback_call(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, void *event_info);
+ECORE_IMF_API void                          ecore_imf_context_event_callback_call(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, void *event_info);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1605,7 +1581,7 @@ EAPI void                          ecore_imf_context_event_callback_call(Ecore_I
  * @note Default value is EINA_TRUE.
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_prediction_allow_set(Ecore_IMF_Context *ctx, Eina_Bool prediction);
+ECORE_IMF_API void                          ecore_imf_context_prediction_allow_set(Ecore_IMF_Context *ctx, Eina_Bool prediction);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1616,7 +1592,7 @@ EAPI void                          ecore_imf_context_prediction_allow_set(Ecore_
  * @c EINA_FALSE.
  * @since 1.1.0
  */
-EAPI Eina_Bool                     ecore_imf_context_prediction_allow_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Eina_Bool                     ecore_imf_context_prediction_allow_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1627,7 +1603,7 @@ EAPI Eina_Bool                     ecore_imf_context_prediction_allow_get(Ecore_
  * @note Default type is ECORE_IMF_AUTOCAPITAL_TYPE_SENTENCE.
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_autocapital_type_set(Ecore_IMF_Context *ctx, Ecore_IMF_Autocapital_Type autocapital_type);
+ECORE_IMF_API void                          ecore_imf_context_autocapital_type_set(Ecore_IMF_Context *ctx, Ecore_IMF_Autocapital_Type autocapital_type);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1637,7 +1613,7 @@ EAPI void                          ecore_imf_context_autocapital_type_set(Ecore_
  * @return The autocapital type being used by @p ctx.
  * @since 1.1.0
  */
-EAPI Ecore_IMF_Autocapital_Type    ecore_imf_context_autocapital_type_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_Autocapital_Type    ecore_imf_context_autocapital_type_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1648,7 +1624,7 @@ EAPI Ecore_IMF_Autocapital_Type    ecore_imf_context_autocapital_type_get(Ecore_
  * @note The default input hint is @c ECORE_IMF_INPUT_HINT_AUTO_COMPLETE.
  * @since 1.12
  */
-EAPI void                          ecore_imf_context_input_hint_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Hints hints);
+ECORE_IMF_API void                          ecore_imf_context_input_hint_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Hints hints);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1658,7 +1634,7 @@ EAPI void                          ecore_imf_context_input_hint_set(Ecore_IMF_Co
  * @return The value of input hint
  * @since 1.12
  */
-EAPI Ecore_IMF_Input_Hints         ecore_imf_context_input_hint_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_Input_Hints         ecore_imf_context_input_hint_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1667,7 +1643,7 @@ EAPI Ecore_IMF_Input_Hints         ecore_imf_context_input_hint_get(Ecore_IMF_Co
  * @param ctx An #Ecore_IMF_Context.
  * @since 1.1.0
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_control_panel_show(Ecore_IMF_Context *ctx);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_control_panel_show(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1676,7 +1652,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_control_panel_show(Ecore_IM
  * @param ctx An #Ecore_IMF_Context.
  * @since 1.1.0
  */
-EINA_DEPRECATED EAPI void          ecore_imf_context_control_panel_hide(Ecore_IMF_Context *ctx);
+EINA_DEPRECATED ECORE_IMF_API void          ecore_imf_context_control_panel_hide(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1685,7 +1661,7 @@ EINA_DEPRECATED EAPI void          ecore_imf_context_control_panel_hide(Ecore_IM
  * @param ctx An #Ecore_IMF_Context.
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_input_panel_show(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_show(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1694,7 +1670,7 @@ EAPI void                          ecore_imf_context_input_panel_show(Ecore_IMF_
  * @param ctx An #Ecore_IMF_Context.
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_input_panel_hide(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_hide(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1705,7 +1681,7 @@ EAPI void                          ecore_imf_context_input_panel_hide(Ecore_IMF_
  * @note Default layout type is ECORE_IMF_INPUT_PANEL_LAYOUT_NORMAL.
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_input_panel_layout_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Layout layout);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_layout_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Layout layout);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1715,7 +1691,7 @@ EAPI void                          ecore_imf_context_input_panel_layout_set(Ecor
  * @return layout see #Ecore_IMF_Input_Panel_Layout
  * @since 1.1.0
  */
-EAPI Ecore_IMF_Input_Panel_Layout  ecore_imf_context_input_panel_layout_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_Input_Panel_Layout  ecore_imf_context_input_panel_layout_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1726,7 +1702,7 @@ EAPI Ecore_IMF_Input_Panel_Layout  ecore_imf_context_input_panel_layout_get(Ecor
  * @note Default layout variation type is NORMAL.
  * @since 1.8.0
  */
-EAPI void                          ecore_imf_context_input_panel_layout_variation_set(Ecore_IMF_Context *ctx, int variation);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_layout_variation_set(Ecore_IMF_Context *ctx, int variation);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1736,7 +1712,7 @@ EAPI void                          ecore_imf_context_input_panel_layout_variatio
  * @return the layout variation
  * @since 1.8.0
  */
-EAPI int                           ecore_imf_context_input_panel_layout_variation_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API int                           ecore_imf_context_input_panel_layout_variation_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1747,7 +1723,7 @@ EAPI int                           ecore_imf_context_input_panel_layout_variatio
  * @param lang the language to be set to the input panel.
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_input_panel_language_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Lang lang);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_language_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Lang lang);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1759,7 +1735,7 @@ EAPI void                          ecore_imf_context_input_panel_language_set(Ec
  * @return Ecore_IMF_Input_Panel_Lang
  * @since 1.1.0
  */
-EAPI Ecore_IMF_Input_Panel_Lang    ecore_imf_context_input_panel_language_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_Input_Panel_Lang    ecore_imf_context_input_panel_language_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1770,7 +1746,7 @@ EAPI Ecore_IMF_Input_Panel_Lang    ecore_imf_context_input_panel_language_get(Ec
  * @param enabled If true, the input panel will be shown when the widget is clicked or has focus.
  * @since 1.1.0
  */
-EAPI void                          ecore_imf_context_input_panel_enabled_set(Ecore_IMF_Context *ctx, Eina_Bool enabled);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_enabled_set(Ecore_IMF_Context *ctx, Eina_Bool enabled);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1780,7 +1756,7 @@ EAPI void                          ecore_imf_context_input_panel_enabled_set(Eco
  * @return Return the attribute to show the input panel automatically
  * @since 1.1.0
  */
-EAPI Eina_Bool                     ecore_imf_context_input_panel_enabled_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Eina_Bool                     ecore_imf_context_input_panel_enabled_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1794,7 +1770,7 @@ EAPI Eina_Bool                     ecore_imf_context_input_panel_enabled_get(Eco
  * @param len the length of data, in bytes, to send to the input panel
  * @since 1.2.0
  */
-EAPI void                          ecore_imf_context_input_panel_imdata_set(Ecore_IMF_Context *ctx, const void *data, int len);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_imdata_set(Ecore_IMF_Context *ctx, const void *data, int len);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1805,7 +1781,7 @@ EAPI void                          ecore_imf_context_input_panel_imdata_set(Ecor
  * @param len The length of data
  * @since 1.2.0
  */
-EAPI void                          ecore_imf_context_input_panel_imdata_get(Ecore_IMF_Context *ctx, void *data, int *len);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_imdata_get(Ecore_IMF_Context *ctx, void *data, int *len);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1819,7 +1795,7 @@ EAPI void                          ecore_imf_context_input_panel_imdata_get(Ecor
  * @note Default type is ECORE_IMF_INPUT_PANEL_RETURN_KEY_TYPE_DEFAULT.
  * @since 1.2.0
  */
-EAPI void                          ecore_imf_context_input_panel_return_key_type_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Return_Key_Type return_key_type);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_return_key_type_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Return_Key_Type return_key_type);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1831,7 +1807,7 @@ EAPI void                          ecore_imf_context_input_panel_return_key_type
  * @return The type of "return" key on the input panel
  * @since 1.2.0
  */
-EAPI Ecore_IMF_Input_Panel_Return_Key_Type ecore_imf_context_input_panel_return_key_type_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_Input_Panel_Return_Key_Type ecore_imf_context_input_panel_return_key_type_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1841,7 +1817,7 @@ EAPI Ecore_IMF_Input_Panel_Return_Key_Type ecore_imf_context_input_panel_return_
  * @param disabled The state
  * @since 1.2.0
  */
-EAPI void                          ecore_imf_context_input_panel_return_key_disabled_set(Ecore_IMF_Context *ctx, Eina_Bool disabled);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_return_key_disabled_set(Ecore_IMF_Context *ctx, Eina_Bool disabled);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1851,7 +1827,7 @@ EAPI void                          ecore_imf_context_input_panel_return_key_disa
  * @return @c EINA_TRUE if it should be disabled.
  * @since 1.2.0
  */
-EAPI Eina_Bool                     ecore_imf_context_input_panel_return_key_disabled_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Eina_Bool                     ecore_imf_context_input_panel_return_key_disabled_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1861,7 +1837,7 @@ EAPI Eina_Bool                     ecore_imf_context_input_panel_return_key_disa
  * @param mode Turn on caps lock on the input panel if @c EINA_TRUE.
  * @since 1.2.0
  */
-EAPI void                          ecore_imf_context_input_panel_caps_lock_mode_set(Ecore_IMF_Context *ctx, Eina_Bool mode);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_caps_lock_mode_set(Ecore_IMF_Context *ctx, Eina_Bool mode);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1871,7 +1847,7 @@ EAPI void                          ecore_imf_context_input_panel_caps_lock_mode_
  * @return @c EINA_TRUE if the caps lock is turned on.
  * @since 1.2.0
  */
-EAPI Eina_Bool                     ecore_imf_context_input_panel_caps_lock_mode_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Eina_Bool                     ecore_imf_context_input_panel_caps_lock_mode_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1884,7 +1860,7 @@ EAPI Eina_Bool                     ecore_imf_context_input_panel_caps_lock_mode_
  * @param h height of the input panel
  * @since 1.3
  */
-EAPI void                          ecore_imf_context_input_panel_geometry_get(Ecore_IMF_Context *ctx, int *x, int *y, int *w, int *h);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_geometry_get(Ecore_IMF_Context *ctx, int *x, int *y, int *w, int *h);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1894,7 +1870,7 @@ EAPI void                          ecore_imf_context_input_panel_geometry_get(Ec
  * @return The state of input panel.
  * @since 1.3
  */
-EAPI Ecore_IMF_Input_Panel_State   ecore_imf_context_input_panel_state_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_Input_Panel_State   ecore_imf_context_input_panel_state_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1908,7 +1884,7 @@ EAPI Ecore_IMF_Input_Panel_State   ecore_imf_context_input_panel_state_get(Ecore
  * @param data application-input panel specific data.
  * @since 1.3
  */
-EAPI void                          ecore_imf_context_input_panel_event_callback_add(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Event type, void (*func) (void *data, Ecore_IMF_Context *ctx, int value), const void *data);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_event_callback_add(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Event type, void (*func) (void *data, Ecore_IMF_Context *ctx, int value), const void *data);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1919,7 +1895,7 @@ EAPI void                          ecore_imf_context_input_panel_event_callback_
  * @param func the callback function
  * @since 1.3
  */
-EAPI void                          ecore_imf_context_input_panel_event_callback_del(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Event type, void (*func) (void *data, Ecore_IMF_Context *ctx, int value));
+ECORE_IMF_API void                          ecore_imf_context_input_panel_event_callback_del(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Event type, void (*func) (void *data, Ecore_IMF_Context *ctx, int value));
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1930,7 +1906,7 @@ EAPI void                          ecore_imf_context_input_panel_event_callback_
  * @param value the event value
  * @since 1.8.0
  */
-EAPI void                          ecore_imf_context_input_panel_event_callback_call(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Event type, int value);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_event_callback_call(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Event type, int value);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1941,7 +1917,7 @@ EAPI void                          ecore_imf_context_input_panel_event_callback_
  * @param ctx Ecore_IMF_Context.
  * @since 1.8.0
  */
-EAPI void                          ecore_imf_context_input_panel_event_callback_clear(Ecore_IMF_Context *ctx);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_event_callback_clear(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1954,7 +1930,7 @@ EAPI void                          ecore_imf_context_input_panel_event_callback_
  *             string retrieved must be freed with free().
  * @since 1.3
  */
-EAPI void                          ecore_imf_context_input_panel_language_locale_get(Ecore_IMF_Context *ctx, char **lang);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_language_locale_get(Ecore_IMF_Context *ctx, char **lang);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1967,7 +1943,7 @@ EAPI void                          ecore_imf_context_input_panel_language_locale
  * @param h height of the candidate panel
  * @since 1.3
  */
-EAPI void                          ecore_imf_context_candidate_panel_geometry_get(Ecore_IMF_Context *ctx, int *x, int *y, int *w, int *h);
+ECORE_IMF_API void                          ecore_imf_context_candidate_panel_geometry_get(Ecore_IMF_Context *ctx, int *x, int *y, int *w, int *h);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1978,7 +1954,7 @@ EAPI void                          ecore_imf_context_candidate_panel_geometry_ge
  * @param ondemand If true, the input panel will be shown in case of only Mouse up event. (Focus event will be ignored.)
  * @since 1.8.0
  */
-EAPI void                          ecore_imf_context_input_panel_show_on_demand_set(Ecore_IMF_Context *ctx, Eina_Bool ondemand);
+ECORE_IMF_API void                          ecore_imf_context_input_panel_show_on_demand_set(Ecore_IMF_Context *ctx, Eina_Bool ondemand);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1988,7 +1964,7 @@ EAPI void                          ecore_imf_context_input_panel_show_on_demand_
  * @return @c EINA_TRUE if the input panel will be shown in case of only Mouse up event.
  * @since 1.8.0
  */
-EAPI Eina_Bool                     ecore_imf_context_input_panel_show_on_demand_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Eina_Bool                     ecore_imf_context_input_panel_show_on_demand_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -1999,7 +1975,7 @@ EAPI Eina_Bool                     ecore_imf_context_input_panel_show_on_demand_
  * @param[in] ctx An #Ecore_IMF_Context
  * @param[in] direction The direction mode
  */
-EAPI void                          ecore_imf_context_bidi_direction_set(Ecore_IMF_Context *ctx, Ecore_IMF_BiDi_Direction direction);
+ECORE_IMF_API void                          ecore_imf_context_bidi_direction_set(Ecore_IMF_Context *ctx, Ecore_IMF_BiDi_Direction direction);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -2010,7 +1986,7 @@ EAPI void                          ecore_imf_context_bidi_direction_set(Ecore_IM
  * @param[in] ctx An #Ecore_IMF_Context
  * @return The direction mode
  */
-EAPI Ecore_IMF_BiDi_Direction      ecore_imf_context_bidi_direction_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_BiDi_Direction      ecore_imf_context_bidi_direction_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -2021,7 +1997,7 @@ EAPI Ecore_IMF_BiDi_Direction      ecore_imf_context_bidi_direction_get(Ecore_IM
  * @param[in] ctx An #Ecore_IMF_Context
  * @return the keyboard mode
  */
-EAPI Ecore_IMF_Input_Panel_Keyboard_Mode ecore_imf_context_keyboard_mode_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API Ecore_IMF_Input_Panel_Keyboard_Mode ecore_imf_context_keyboard_mode_get(Ecore_IMF_Context *ctx);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -2037,7 +2013,7 @@ EAPI Ecore_IMF_Input_Panel_Keyboard_Mode ecore_imf_context_keyboard_mode_get(Eco
  * @param[in] ctx An #Ecore_IMF_Context
  * @param[in] prediction_hint The prediction hint string.
  */
-EAPI void                          ecore_imf_context_prediction_hint_set(Ecore_IMF_Context *ctx, const char *prediction_hint);
+ECORE_IMF_API void                          ecore_imf_context_prediction_hint_set(Ecore_IMF_Context *ctx, const char *prediction_hint);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -2054,7 +2030,7 @@ EAPI void                          ecore_imf_context_prediction_hint_set(Ecore_I
  * ecore_imf_context_mime_type_accept_set(imf_context, mime_type);
  * @endcode
  */
-EAPI void                         ecore_imf_context_mime_type_accept_set(Ecore_IMF_Context *ctx, const char *mime_type);
+ECORE_IMF_API void                         ecore_imf_context_mime_type_accept_set(Ecore_IMF_Context *ctx, const char *mime_type);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -2067,7 +2043,7 @@ EAPI void                         ecore_imf_context_mime_type_accept_set(Ecore_I
  * @param x top-left x coordinate of the input panel
  * @param y top-left y coordinate of the input panel
  */
-EAPI void                         ecore_imf_context_input_panel_position_set(Ecore_IMF_Context *ctx, int x, int y);
+ECORE_IMF_API void                         ecore_imf_context_input_panel_position_set(Ecore_IMF_Context *ctx, int x, int y);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -2085,7 +2061,7 @@ EAPI void                         ecore_imf_context_input_panel_position_set(Eco
  * key @p key. On success this function returns EINA_TRUE,
  * otherwise it returns @c EINA_FALSE.
  */
-EAPI Eina_Bool                    ecore_imf_context_prediction_hint_hash_set(Ecore_IMF_Context *ctx, const char *key, const char *value);
+ECORE_IMF_API Eina_Bool                    ecore_imf_context_prediction_hint_hash_set(Ecore_IMF_Context *ctx, const char *key, const char *value);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -2099,7 +2075,7 @@ EAPI Eina_Bool                    ecore_imf_context_prediction_hint_hash_set(Eco
  *
  * This function removes the entry identified by @p key from the hash associated @p ctx.
  */
-EAPI Eina_Bool                    ecore_imf_context_prediction_hint_hash_del(Ecore_IMF_Context *ctx, const char *key);
+ECORE_IMF_API Eina_Bool                    ecore_imf_context_prediction_hint_hash_del(Ecore_IMF_Context *ctx, const char *key);
 
 /**
  * @ingroup Ecore_IMF_Context_Group
@@ -2110,7 +2086,7 @@ EAPI Eina_Bool                    ecore_imf_context_prediction_hint_hash_del(Eco
  * @param[in] ctx An #Ecore_IMF_Context
  * @return The prediction hint hash table
  */
-EAPI const Eina_Hash             *ecore_imf_context_prediction_hint_hash_get(Ecore_IMF_Context *ctx);
+ECORE_IMF_API const Eina_Hash             *ecore_imf_context_prediction_hint_hash_get(Ecore_IMF_Context *ctx);
 
 /* The following entry points must be exported by each input method module
  */
@@ -2124,8 +2100,5 @@ EAPI const Eina_Hash             *ecore_imf_context_prediction_hint_hash_get(Eco
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_imf/ecore_imf.c
+++ b/src/lib/ecore_imf/ecore_imf.c
@@ -8,17 +8,17 @@
 #include "Ecore_IMF.h"
 #include "ecore_imf_private.h"
 
-EAPI int ECORE_IMF_EVENT_PREEDIT_START = 0;
-EAPI int ECORE_IMF_EVENT_PREEDIT_END = 0;
-EAPI int ECORE_IMF_EVENT_PREEDIT_CHANGED = 0;
-EAPI int ECORE_IMF_EVENT_COMMIT = 0;
-EAPI int ECORE_IMF_EVENT_DELETE_SURROUNDING = 0;
+ECORE_IMF_API int ECORE_IMF_EVENT_PREEDIT_START = 0;
+ECORE_IMF_API int ECORE_IMF_EVENT_PREEDIT_END = 0;
+ECORE_IMF_API int ECORE_IMF_EVENT_PREEDIT_CHANGED = 0;
+ECORE_IMF_API int ECORE_IMF_EVENT_COMMIT = 0;
+ECORE_IMF_API int ECORE_IMF_EVENT_DELETE_SURROUNDING = 0;
 
 int _ecore_imf_log_dom = -1;
 static int _ecore_imf_init_count = 0;
 extern Ecore_IMF_Context *show_req_ctx;
 
-EAPI int
+ECORE_IMF_API int
 ecore_imf_init(void)
 {
    if (++_ecore_imf_init_count != 1) return _ecore_imf_init_count;
@@ -43,7 +43,7 @@ ecore_imf_init(void)
    return _ecore_imf_init_count;
 }
 
-EAPI int
+ECORE_IMF_API int
 ecore_imf_shutdown(void)
 {
    if (--_ecore_imf_init_count != 0) return _ecore_imf_init_count;
@@ -61,7 +61,7 @@ ecore_imf_shutdown(void)
    return _ecore_imf_init_count;
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_input_panel_hide(void)
 {
    if (show_req_ctx)

--- a/src/lib/ecore_imf/ecore_imf_api.h
+++ b/src/lib/ecore_imf/ecore_imf_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_IMF_API_H
+#define _EFL_ECORE_IMF_API_H
+
+#ifdef ECORE_IMF_API
+#error ECORE_IMF_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_IMF_STATIC
+#  ifdef ECORE_IMF_BUILD
+#   define ECORE_IMF_API __declspec(dllexport)
+#  else
+#   define ECORE_IMF_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_IMF_API
+# endif
+# define ECORE_IMF_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_IMF_API __attribute__ ((visibility("default")))
+#   define ECORE_IMF_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_IMF_API
+#   define ECORE_IMF_API_WEAK
+#  endif
+# else
+#  define ECORE_IMF_API
+#  define ECORE_IMF_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_imf/ecore_imf_context.c
+++ b/src/lib/ecore_imf/ecore_imf_context.c
@@ -14,13 +14,13 @@
 
 Ecore_IMF_Context *show_req_ctx = NULL;
 
-EAPI Eina_List *
+ECORE_IMF_API Eina_List *
 ecore_imf_context_available_ids_get(void)
 {
    return ecore_imf_module_context_ids_get();
 }
 
-EAPI Eina_List *
+ECORE_IMF_API Eina_List *
 ecore_imf_context_available_ids_by_canvas_type_get(const char *canvas_type)
 {
    return ecore_imf_module_context_ids_by_canvas_type_get(canvas_type);
@@ -52,13 +52,13 @@ _ecore_imf_context_match_locale(const char *locale, const char *against, int aga
 }
 */
 
-EAPI const char *
+ECORE_IMF_API const char *
 ecore_imf_context_default_id_get(void)
 {
    return ecore_imf_context_default_id_by_canvas_type_get(NULL);
 }
 
-EAPI const char *
+ECORE_IMF_API const char *
 ecore_imf_context_default_id_by_canvas_type_get(const char *canvas_type EINA_UNUSED)
 {
    const char *id = getenv("ECORE_IMF_MODULE");
@@ -131,7 +131,7 @@ ecore_imf_context_default_id_by_canvas_type_get(const char *canvas_type EINA_UNU
  */
 }
 
-EAPI const Ecore_IMF_Context_Info *
+ECORE_IMF_API const Ecore_IMF_Context_Info *
 ecore_imf_context_info_by_id_get(const char *id)
 {
    Ecore_IMF_Module *module;
@@ -142,7 +142,7 @@ ecore_imf_context_info_by_id_get(const char *id)
    return module->info;
 }
 
-EAPI Ecore_IMF_Context *
+ECORE_IMF_API Ecore_IMF_Context *
 ecore_imf_context_add(const char *id)
 {
    Ecore_IMF_Context *ctx;
@@ -183,7 +183,7 @@ ecore_imf_context_add(const char *id)
    return ctx;
 }
 
-EAPI const Ecore_IMF_Context_Info *
+ECORE_IMF_API const Ecore_IMF_Context_Info *
 ecore_imf_context_info_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -195,7 +195,7 @@ ecore_imf_context_info_get(Ecore_IMF_Context *ctx)
    return ctx->module->info;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_del(Ecore_IMF_Context *ctx)
 {
    Ecore_IMF_Func_Node *fn;
@@ -231,7 +231,7 @@ ecore_imf_context_del(Ecore_IMF_Context *ctx)
    free(ctx);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_client_window_set(Ecore_IMF_Context *ctx, void *window)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -245,7 +245,7 @@ ecore_imf_context_client_window_set(Ecore_IMF_Context *ctx, void *window)
    ctx->window = window;
 }
 
-EAPI void *
+ECORE_IMF_API void *
 ecore_imf_context_client_window_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -257,7 +257,7 @@ ecore_imf_context_client_window_get(Ecore_IMF_Context *ctx)
    return ctx->window;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_client_canvas_set(Ecore_IMF_Context *ctx, void *canvas)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -271,7 +271,7 @@ ecore_imf_context_client_canvas_set(Ecore_IMF_Context *ctx, void *canvas)
    ctx->client_canvas = canvas;
 }
 
-EAPI void *
+ECORE_IMF_API void *
 ecore_imf_context_client_canvas_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -283,7 +283,7 @@ ecore_imf_context_client_canvas_get(Ecore_IMF_Context *ctx)
    return ctx->client_canvas;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_show(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -297,7 +297,7 @@ ecore_imf_context_show(Ecore_IMF_Context *ctx)
    if (ctx->klass && ctx->klass->show) ctx->klass->show(ctx);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_hide(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -310,7 +310,7 @@ ecore_imf_context_hide(Ecore_IMF_Context *ctx)
    if (ctx->klass && ctx->klass->hide) ctx->klass->hide(ctx);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_preedit_string_get(Ecore_IMF_Context *ctx, char **str, int *cursor_pos)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -329,7 +329,7 @@ ecore_imf_context_preedit_string_get(Ecore_IMF_Context *ctx, char **str, int *cu
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_preedit_string_with_attributes_get(Ecore_IMF_Context *ctx, char **str, Eina_List **attrs, int *cursor_pos)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -348,7 +348,7 @@ ecore_imf_context_preedit_string_with_attributes_get(Ecore_IMF_Context *ctx, cha
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_focus_in(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -361,7 +361,7 @@ ecore_imf_context_focus_in(Ecore_IMF_Context *ctx)
    if (ctx->klass && ctx->klass->focus_in) ctx->klass->focus_in(ctx);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_focus_out(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -374,7 +374,7 @@ ecore_imf_context_focus_out(Ecore_IMF_Context *ctx)
    if (ctx->klass && ctx->klass->focus_out) ctx->klass->focus_out(ctx);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_reset(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -387,7 +387,7 @@ ecore_imf_context_reset(Ecore_IMF_Context *ctx)
    if (ctx->klass && ctx->klass->reset) ctx->klass->reset(ctx);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_cursor_position_set(Ecore_IMF_Context *ctx, int cursor_pos)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -400,7 +400,7 @@ ecore_imf_context_cursor_position_set(Ecore_IMF_Context *ctx, int cursor_pos)
    if (ctx->klass && ctx->klass->cursor_position_set) ctx->klass->cursor_position_set(ctx, cursor_pos);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_cursor_location_set(Ecore_IMF_Context *ctx, int x, int y, int w, int h)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -412,7 +412,7 @@ ecore_imf_context_cursor_location_set(Ecore_IMF_Context *ctx, int x, int y, int 
    if (ctx->klass && ctx->klass->cursor_location_set) ctx->klass->cursor_location_set(ctx, x, y, w, h);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_use_preedit_set(Ecore_IMF_Context *ctx, Eina_Bool use_preedit)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -424,7 +424,7 @@ ecore_imf_context_use_preedit_set(Ecore_IMF_Context *ctx, Eina_Bool use_preedit)
    if (ctx->klass && ctx->klass->use_preedit_set) ctx->klass->use_preedit_set(ctx, use_preedit);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_prediction_allow_set(Ecore_IMF_Context *ctx, Eina_Bool prediction)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -443,7 +443,7 @@ ecore_imf_context_prediction_allow_set(Ecore_IMF_Context *ctx, Eina_Bool predict
      }
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_prediction_allow_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -456,7 +456,7 @@ ecore_imf_context_prediction_allow_get(Ecore_IMF_Context *ctx)
    return ctx->allow_prediction;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_autocapital_type_set(Ecore_IMF_Context *ctx, Ecore_IMF_Autocapital_Type autocapital_type)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -474,7 +474,7 @@ ecore_imf_context_autocapital_type_set(Ecore_IMF_Context *ctx, Ecore_IMF_Autocap
      }
 }
 
-EAPI Ecore_IMF_Autocapital_Type
+ECORE_IMF_API Ecore_IMF_Autocapital_Type
 ecore_imf_context_autocapital_type_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -487,7 +487,7 @@ ecore_imf_context_autocapital_type_get(Ecore_IMF_Context *ctx)
    return ctx->autocapital_type;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_retrieve_surrounding_callback_set(Ecore_IMF_Context *ctx, Eina_Bool (*func)(void *data, Ecore_IMF_Context *ctx, char **text, int *cursor_pos), const void *data)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -501,7 +501,7 @@ ecore_imf_context_retrieve_surrounding_callback_set(Ecore_IMF_Context *ctx, Eina
    ctx->retrieve_surrounding_data = (void *) data;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_retrieve_selection_callback_set(Ecore_IMF_Context *ctx, Eina_Bool (*func)(void *data, Ecore_IMF_Context *ctx, char **text), const void *data)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -515,7 +515,7 @@ ecore_imf_context_retrieve_selection_callback_set(Ecore_IMF_Context *ctx, Eina_B
    ctx->retrieve_selection_data = (void *) data;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_mode_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Mode input_mode)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -528,7 +528,7 @@ ecore_imf_context_input_mode_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Mode in
    ctx->input_mode = input_mode;
 }
 
-EAPI Ecore_IMF_Input_Mode
+ECORE_IMF_API Ecore_IMF_Input_Mode
 ecore_imf_context_input_mode_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -540,7 +540,7 @@ ecore_imf_context_input_mode_get(Ecore_IMF_Context *ctx)
    return ctx->input_mode;
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_filter_event(Ecore_IMF_Context *ctx, Ecore_IMF_Event_Type type, Ecore_IMF_Event *event)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -553,7 +553,7 @@ ecore_imf_context_filter_event(Ecore_IMF_Context *ctx, Ecore_IMF_Event_Type type
    return EINA_FALSE;
 }
 
-EAPI Ecore_IMF_Context *
+ECORE_IMF_API Ecore_IMF_Context *
 ecore_imf_context_new(const Ecore_IMF_Context_Class *ctxc)
 {
    Ecore_IMF_Context *ctx;
@@ -569,7 +569,7 @@ ecore_imf_context_new(const Ecore_IMF_Context_Class *ctxc)
    return ctx;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_data_set(Ecore_IMF_Context *ctx, void *data)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -581,7 +581,7 @@ ecore_imf_context_data_set(Ecore_IMF_Context *ctx, void *data)
    ctx->data = data;
 }
 
-EAPI void *
+ECORE_IMF_API void *
 ecore_imf_context_data_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -593,7 +593,7 @@ ecore_imf_context_data_get(Ecore_IMF_Context *ctx)
    return ctx->data;
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_surrounding_get(Ecore_IMF_Context *ctx, char **text, int *cursor_pos)
 {
    int result = EINA_FALSE;
@@ -617,7 +617,7 @@ ecore_imf_context_surrounding_get(Ecore_IMF_Context *ctx, char **text, int *curs
    return result;
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_selection_get(Ecore_IMF_Context *ctx, char **text)
 {
    Eina_Bool result = EINA_FALSE;
@@ -646,7 +646,7 @@ _ecore_imf_event_free_preedit(void *data EINA_UNUSED, void *event)
    free(event);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_preedit_start_event_add(Ecore_IMF_Context *ctx)
 {
    Ecore_IMF_Event_Preedit_Start *ev;
@@ -666,7 +666,7 @@ ecore_imf_context_preedit_start_event_add(Ecore_IMF_Context *ctx)
                    ev, _ecore_imf_event_free_preedit, NULL);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_preedit_end_event_add(Ecore_IMF_Context *ctx)
 {
    Ecore_IMF_Event_Preedit_End *ev;
@@ -686,7 +686,7 @@ ecore_imf_context_preedit_end_event_add(Ecore_IMF_Context *ctx)
                    ev, _ecore_imf_event_free_preedit, NULL);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_preedit_changed_event_add(Ecore_IMF_Context *ctx)
 {
    Ecore_IMF_Event_Preedit_Changed *ev;
@@ -716,7 +716,7 @@ _ecore_imf_event_free_commit(void *data EINA_UNUSED, void *event)
    free(ev);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_commit_event_add(Ecore_IMF_Context *ctx, const char *str)
 {
    Ecore_IMF_Event_Commit *ev;
@@ -743,7 +743,7 @@ _ecore_imf_event_free_delete_surrounding(void *data EINA_UNUSED, void *event)
    free(event);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_delete_surrounding_event_add(Ecore_IMF_Context *ctx, int offset, int n_chars)
 {
    Ecore_IMF_Event_Delete_Surrounding *ev;
@@ -763,7 +763,7 @@ ecore_imf_context_delete_surrounding_event_add(Ecore_IMF_Context *ctx, int offse
                    ev, _ecore_imf_event_free_delete_surrounding, NULL);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_event_callback_add(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, Ecore_IMF_Event_Cb func, const void *data)
 {
    Ecore_IMF_Func_Node *fn = NULL;
@@ -787,7 +787,7 @@ ecore_imf_context_event_callback_add(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_
    ctx->callbacks = eina_list_append(ctx->callbacks, fn);
 }
 
-EAPI void *
+ECORE_IMF_API void *
 ecore_imf_context_event_callback_del(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, Ecore_IMF_Event_Cb func)
 {
    Eina_List *l = NULL;
@@ -817,7 +817,7 @@ ecore_imf_context_event_callback_del(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_
    return NULL;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_event_callback_call(Ecore_IMF_Context *ctx, Ecore_IMF_Callback_Type type, void *event_info)
 {
    Ecore_IMF_Func_Node *fn = NULL;
@@ -837,7 +837,7 @@ ecore_imf_context_event_callback_call(Ecore_IMF_Context *ctx, Ecore_IMF_Callback
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_control_panel_show(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -850,7 +850,7 @@ ecore_imf_context_control_panel_show(Ecore_IMF_Context *ctx)
    if (ctx->klass && ctx->klass->control_panel_show) ctx->klass->control_panel_show(ctx);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_control_panel_hide(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -863,7 +863,7 @@ ecore_imf_context_control_panel_hide(Ecore_IMF_Context *ctx)
    if (ctx->klass && ctx->klass->control_panel_hide) ctx->klass->control_panel_hide(ctx);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_hint_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Hints input_hints)
 {
     if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -882,7 +882,7 @@ ecore_imf_context_input_hint_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Hints i
      }
 }
 
-EAPI Ecore_IMF_Input_Hints
+ECORE_IMF_API Ecore_IMF_Input_Hints
 ecore_imf_context_input_hint_get(Ecore_IMF_Context *ctx)
 {
     if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -895,7 +895,7 @@ ecore_imf_context_input_hint_get(Ecore_IMF_Context *ctx)
     return ctx->input_hints;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_show(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -913,7 +913,7 @@ ecore_imf_context_input_panel_show(Ecore_IMF_Context *ctx)
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_hide(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -930,7 +930,7 @@ ecore_imf_context_input_panel_hide(Ecore_IMF_Context *ctx)
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_layout_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Layout layout)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -952,7 +952,7 @@ ecore_imf_context_input_panel_layout_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input
      }
 }
 
-EAPI Ecore_IMF_Input_Panel_Layout
+ECORE_IMF_API Ecore_IMF_Input_Panel_Layout
 ecore_imf_context_input_panel_layout_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -968,7 +968,7 @@ ecore_imf_context_input_panel_layout_get(Ecore_IMF_Context *ctx)
      return ECORE_IMF_INPUT_PANEL_LAYOUT_INVALID;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_layout_variation_set(Ecore_IMF_Context *ctx, int variation)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -981,7 +981,7 @@ ecore_imf_context_input_panel_layout_variation_set(Ecore_IMF_Context *ctx, int v
    ctx->input_panel_layout_variation = variation;
 }
 
-EAPI int
+ECORE_IMF_API int
 ecore_imf_context_input_panel_layout_variation_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -994,7 +994,7 @@ ecore_imf_context_input_panel_layout_variation_get(Ecore_IMF_Context *ctx)
    return ctx->input_panel_layout_variation;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_language_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Lang lang)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1013,7 +1013,7 @@ ecore_imf_context_input_panel_language_set(Ecore_IMF_Context *ctx, Ecore_IMF_Inp
      }
 }
 
-EAPI Ecore_IMF_Input_Panel_Lang
+ECORE_IMF_API Ecore_IMF_Input_Panel_Lang
 ecore_imf_context_input_panel_language_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1026,7 +1026,7 @@ ecore_imf_context_input_panel_language_get(Ecore_IMF_Context *ctx)
    return ctx->input_panel_lang;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_enabled_set(Ecore_IMF_Context *ctx,
                                            Eina_Bool enabled)
 {
@@ -1040,7 +1040,7 @@ ecore_imf_context_input_panel_enabled_set(Ecore_IMF_Context *ctx,
    ctx->input_panel_enabled = enabled;
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_input_panel_enabled_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1053,7 +1053,7 @@ ecore_imf_context_input_panel_enabled_get(Ecore_IMF_Context *ctx)
    return ctx->input_panel_enabled;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_imdata_set(Ecore_IMF_Context *ctx, const void *data, int len)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1069,7 +1069,7 @@ ecore_imf_context_input_panel_imdata_set(Ecore_IMF_Context *ctx, const void *dat
      ctx->klass->input_panel_imdata_set(ctx, data, len);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_imdata_get(Ecore_IMF_Context *ctx, void *data, int *len)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1085,7 +1085,7 @@ ecore_imf_context_input_panel_imdata_get(Ecore_IMF_Context *ctx, void *data, int
      ctx->klass->input_panel_imdata_get(ctx, data, len);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_return_key_type_set(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Return_Key_Type return_key_type)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1103,7 +1103,7 @@ ecore_imf_context_input_panel_return_key_type_set(Ecore_IMF_Context *ctx, Ecore_
      }
 }
 
-EAPI Ecore_IMF_Input_Panel_Return_Key_Type
+ECORE_IMF_API Ecore_IMF_Input_Panel_Return_Key_Type
 ecore_imf_context_input_panel_return_key_type_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1116,7 +1116,7 @@ ecore_imf_context_input_panel_return_key_type_get(Ecore_IMF_Context *ctx)
    return ctx->input_panel_return_key_type;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_return_key_disabled_set(Ecore_IMF_Context *ctx, Eina_Bool disabled)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1134,7 +1134,7 @@ ecore_imf_context_input_panel_return_key_disabled_set(Ecore_IMF_Context *ctx, Ei
      }
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_input_panel_return_key_disabled_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1147,7 +1147,7 @@ ecore_imf_context_input_panel_return_key_disabled_get(Ecore_IMF_Context *ctx)
    return ctx->input_panel_return_key_disabled;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_caps_lock_mode_set(Ecore_IMF_Context *ctx, Eina_Bool mode)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1166,7 +1166,7 @@ ecore_imf_context_input_panel_caps_lock_mode_set(Ecore_IMF_Context *ctx, Eina_Bo
      }
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_input_panel_caps_lock_mode_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1179,7 +1179,7 @@ ecore_imf_context_input_panel_caps_lock_mode_get(Ecore_IMF_Context *ctx)
    return ctx->input_panel_caps_lock_mode;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_geometry_get(Ecore_IMF_Context *ctx, int *x, int *y, int *w, int *h)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1193,7 +1193,7 @@ ecore_imf_context_input_panel_geometry_get(Ecore_IMF_Context *ctx, int *x, int *
      ctx->klass->input_panel_geometry_get(ctx, x, y, w, h);
 }
 
-EAPI Ecore_IMF_Input_Panel_State
+ECORE_IMF_API Ecore_IMF_Input_Panel_State
 ecore_imf_context_input_panel_state_get(Ecore_IMF_Context *ctx)
 {
    Ecore_IMF_Input_Panel_State state = ECORE_IMF_INPUT_PANEL_STATE_HIDE;
@@ -1210,7 +1210,7 @@ ecore_imf_context_input_panel_state_get(Ecore_IMF_Context *ctx)
    return state;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_event_callback_add(Ecore_IMF_Context *ctx,
                                                  Ecore_IMF_Input_Panel_Event type,
                                                  void (*func) (void *data, Ecore_IMF_Context *ctx, int value),
@@ -1237,7 +1237,7 @@ ecore_imf_context_input_panel_event_callback_add(Ecore_IMF_Context *ctx,
    ctx->input_panel_callbacks = eina_list_append(ctx->input_panel_callbacks, fn);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_event_callback_del(Ecore_IMF_Context *ctx,
                                                  Ecore_IMF_Input_Panel_Event type,
                                                  void (*func) (void *data, Ecore_IMF_Context *ctx, int value))
@@ -1267,7 +1267,7 @@ ecore_imf_context_input_panel_event_callback_del(Ecore_IMF_Context *ctx,
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_event_callback_call(Ecore_IMF_Context *ctx, Ecore_IMF_Input_Panel_Event type, int value)
 {
    Ecore_IMF_Input_Panel_Callback_Node *fn = NULL;
@@ -1296,7 +1296,7 @@ ecore_imf_context_input_panel_event_callback_call(Ecore_IMF_Context *ctx, Ecore_
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_event_callback_clear(Ecore_IMF_Context *ctx)
 {
    Ecore_IMF_Input_Panel_Callback_Node *fn = NULL;
@@ -1322,7 +1322,7 @@ ecore_imf_context_input_panel_event_callback_clear(Ecore_IMF_Context *ctx)
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_language_locale_get(Ecore_IMF_Context *ctx, char **lang)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1340,7 +1340,7 @@ ecore_imf_context_input_panel_language_locale_get(Ecore_IMF_Context *ctx, char *
      }
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_candidate_panel_geometry_get(Ecore_IMF_Context *ctx, int *x, int *y, int *w, int *h)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1354,7 +1354,7 @@ ecore_imf_context_candidate_panel_geometry_get(Ecore_IMF_Context *ctx, int *x, i
      ctx->klass->candidate_panel_geometry_get(ctx, x, y, w, h);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_show_on_demand_set(Ecore_IMF_Context *ctx, Eina_Bool ondemand)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1367,7 +1367,7 @@ ecore_imf_context_input_panel_show_on_demand_set(Ecore_IMF_Context *ctx, Eina_Bo
    ctx->input_panel_show_on_demand = ondemand;
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_input_panel_show_on_demand_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1380,7 +1380,7 @@ ecore_imf_context_input_panel_show_on_demand_get(Ecore_IMF_Context *ctx)
    return ctx->input_panel_show_on_demand;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_bidi_direction_set(Ecore_IMF_Context *ctx, Ecore_IMF_BiDi_Direction direction)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1399,7 +1399,7 @@ ecore_imf_context_bidi_direction_set(Ecore_IMF_Context *ctx, Ecore_IMF_BiDi_Dire
      }
 }
 
-EAPI Ecore_IMF_BiDi_Direction
+ECORE_IMF_API Ecore_IMF_BiDi_Direction
 ecore_imf_context_bidi_direction_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1412,7 +1412,7 @@ ecore_imf_context_bidi_direction_get(Ecore_IMF_Context *ctx)
    return ctx->bidi_direction;
 }
 
-EAPI Ecore_IMF_Input_Panel_Keyboard_Mode
+ECORE_IMF_API Ecore_IMF_Input_Panel_Keyboard_Mode
 ecore_imf_context_keyboard_mode_get(Ecore_IMF_Context *ctx)
 {
    Ecore_IMF_Input_Panel_Keyboard_Mode mode = ECORE_IMF_INPUT_PANEL_SW_KEYBOARD_MODE;
@@ -1429,7 +1429,7 @@ ecore_imf_context_keyboard_mode_get(Ecore_IMF_Context *ctx)
    return mode;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_prediction_hint_set(Ecore_IMF_Context *ctx, const char *prediction_hint)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1443,7 +1443,7 @@ ecore_imf_context_prediction_hint_set(Ecore_IMF_Context *ctx, const char *predic
      ctx->klass->prediction_hint_set(ctx, prediction_hint);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_mime_type_accept_set(Ecore_IMF_Context *ctx, const char *mime_type)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1459,7 +1459,7 @@ ecore_imf_context_mime_type_accept_set(Ecore_IMF_Context *ctx, const char *mime_
      ctx->klass->mime_type_accept_set(ctx, mime_type);
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_context_input_panel_position_set(Ecore_IMF_Context *ctx, int x, int y)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1481,7 +1481,7 @@ _prediction_hint_hash_free_cb(void *data)
    free(data);
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_prediction_hint_hash_set(Ecore_IMF_Context *ctx, const char *key, const char *value)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1504,7 +1504,7 @@ ecore_imf_context_prediction_hint_hash_set(Ecore_IMF_Context *ctx, const char *k
    return EINA_TRUE;
 }
 
-EAPI Eina_Bool
+ECORE_IMF_API Eina_Bool
 ecore_imf_context_prediction_hint_hash_del(Ecore_IMF_Context *ctx, const char *key)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))
@@ -1520,7 +1520,7 @@ ecore_imf_context_prediction_hint_hash_del(Ecore_IMF_Context *ctx, const char *k
    return eina_hash_del(ctx->prediction_hint_hash, key, NULL);
 }
 
-EAPI const Eina_Hash *
+ECORE_IMF_API const Eina_Hash *
 ecore_imf_context_prediction_hint_hash_get(Ecore_IMF_Context *ctx)
 {
    if (!ECORE_MAGIC_CHECK(ctx, ECORE_MAGIC_CONTEXT))

--- a/src/lib/ecore_imf/ecore_imf_module.c
+++ b/src/lib/ecore_imf/ecore_imf_module.c
@@ -293,7 +293,7 @@ ecore_imf_module_context_ids_by_canvas_type_get(const char *canvas_type)
    return values;
 }
 
-EAPI void
+ECORE_IMF_API void
 ecore_imf_module_register(const Ecore_IMF_Context_Info *info,
                           Ecore_IMF_Context *(*imf_module_create)(void),
                           Ecore_IMF_Context *(*imf_module_exit)(void))

--- a/src/lib/ecore_imf/meson.build
+++ b/src/lib/ecore_imf/meson.build
@@ -18,7 +18,7 @@ ecore_imf_lib = library('ecore_imf',
     ecore_imf_src, pub_eo_file_target,
     dependencies: [ecore_imf_deps, ecore_imf_pub_deps, ecore_imf_ext_deps],
     include_directories : config_dir,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_IMF_BUILD'],
     install: true,
     version : meson.project_version()
 )


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.