### PR TITLE
[ecore_input_evas] Use ECORE_INPUT_EVAS_API instead of EAPI

### DIFF
--- a/src/lib/ecore_input_evas/Ecore_Input_Evas.h
+++ b/src/lib/ecore_input_evas/Ecore_Input_Evas.h
@@ -3,31 +3,7 @@
 
 #include <Evas.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_input_evas_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,41 +13,38 @@ typedef void (*Ecore_Event_Mouse_Move_Cb)(void *window, int x, int y, unsigned i
 typedef void (*Ecore_Event_Multi_Move_Cb)(void *window, int device, int x, int y, double radius, double radius_x, double radius_y, double pressure, double angle, double mx, double my, unsigned int timestamp);
 typedef void (*Ecore_Event_Multi_Down_Cb)(void *window, int device, int x, int y, double radius, double radius_x, double radius_y, double pressure, double angle, double mx, double my, Evas_Button_Flags flags, unsigned int timestamp);
 typedef void (*Ecore_Event_Multi_Up_Cb)(void *window, int device, int x, int y, double radius, double radius_x, double radius_y, double pressure, double angle, double mx, double my, Evas_Button_Flags flags, unsigned int timestamp);
-      
-EAPI int       ecore_event_evas_init(void);
-EAPI int       ecore_event_evas_shutdown(void);
 
-EAPI Eina_Bool ecore_event_evas_key_down(void *data, int type, void *event);
-EAPI Eina_Bool ecore_event_evas_key_up(void *data, int type, void *event);
-EAPI Eina_Bool ecore_event_evas_mouse_button_up(void *data, int type, void *event);
-EAPI Eina_Bool ecore_event_evas_mouse_button_down(void *data, int type, void *event);
-EAPI Eina_Bool ecore_event_evas_mouse_wheel(void *data, int type, void *event);
-EAPI Eina_Bool ecore_event_evas_mouse_move(void *data, int type, void *event);
-EAPI Eina_Bool ecore_event_evas_mouse_in(void *data, int type, void *event);
-EAPI Eina_Bool ecore_event_evas_mouse_out(void *data, int type, void *event);
-EAPI Eina_Bool ecore_event_evas_axis_update(void *data, int type, void *event); /**< @since 1.13 */
-EAPI Eina_Bool ecore_event_evas_mouse_button_cancel(void *data, int type, void *event); /**< @since 1.15 */
+ECORE_INPUT_EVAS_API int       ecore_event_evas_init(void);
+ECORE_INPUT_EVAS_API int       ecore_event_evas_shutdown(void);
 
-EAPI void      ecore_event_window_register(Ecore_Window id, void *window, Evas *evas, Ecore_Event_Mouse_Move_Cb move_mouse, Ecore_Event_Multi_Move_Cb move_multi, Ecore_Event_Multi_Down_Cb down_multi, Ecore_Event_Multi_Up_Cb up_multi);
-EAPI void      ecore_event_window_unregister(Ecore_Window id);
-EAPI void     *ecore_event_window_match(Ecore_Window id);
-EAPI void      ecore_event_window_ignore_events(Ecore_Window id, int ignore_event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_key_down(void *data, int type, void *event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_key_up(void *data, int type, void *event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_mouse_button_up(void *data, int type, void *event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_mouse_button_down(void *data, int type, void *event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_mouse_wheel(void *data, int type, void *event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_mouse_move(void *data, int type, void *event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_mouse_in(void *data, int type, void *event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_mouse_out(void *data, int type, void *event);
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_axis_update(void *data, int type, void *event); /**< @since 1.13 */
+ECORE_INPUT_EVAS_API Eina_Bool ecore_event_evas_mouse_button_cancel(void *data, int type, void *event); /**< @since 1.15 */
 
-EAPI void      ecore_event_evas_modifier_lock_update(Evas *e, unsigned int modifiers);
+ECORE_INPUT_EVAS_API void      ecore_event_window_register(Ecore_Window id, void *window, Evas *evas, Ecore_Event_Mouse_Move_Cb move_mouse, Ecore_Event_Multi_Move_Cb move_multi, Ecore_Event_Multi_Down_Cb down_multi, Ecore_Event_Multi_Up_Cb up_multi);
+ECORE_INPUT_EVAS_API void      ecore_event_window_unregister(Ecore_Window id);
+ECORE_INPUT_EVAS_API void     *ecore_event_window_match(Ecore_Window id);
+ECORE_INPUT_EVAS_API void      ecore_event_window_ignore_events(Ecore_Window id, int ignore_event);
 
-EAPI void ecore_event_evas_seat_modifier_lock_update(Evas *e, unsigned int modifiers,
+ECORE_INPUT_EVAS_API void      ecore_event_evas_modifier_lock_update(Evas *e, unsigned int modifiers);
+
+ECORE_INPUT_EVAS_API void ecore_event_evas_seat_modifier_lock_update(Evas *e, unsigned int modifiers,
                                                      Evas_Device *seat); /**< @since 1.19 */
 
 #ifdef ECORE_EVAS_INTERNAL
 typedef Eina_Bool (*Ecore_Event_Direct_Input_Cb)(void *window, int type, const void *info);
-EAPI void      _ecore_event_window_direct_cb_set(Ecore_Window id, Ecore_Event_Direct_Input_Cb fptr);
+ECORE_INPUT_EVAS_API void      _ecore_event_window_direct_cb_set(Ecore_Window id, Ecore_Event_Direct_Input_Cb fptr);
 #endif
 
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_input_evas/ecore_input_evas.c
+++ b/src/lib/ecore_input_evas/ecore_input_evas.c
@@ -278,7 +278,7 @@ _ecore_event_evas_push_mouse_move(Ecore_Event_Mouse_Move *e)
        }
 }
 
-EAPI void
+ECORE_INPUT_EVAS_API void
 ecore_event_evas_seat_modifier_lock_update(Evas *e, unsigned int modifiers,
                                            Evas_Device *seat)
 {
@@ -326,13 +326,13 @@ ecore_event_evas_seat_modifier_lock_update(Evas *e, unsigned int modifiers,
    else evas_seat_key_lock_off(e, "Shift_Lock", seat);
 }
 
-EAPI void
+ECORE_INPUT_EVAS_API void
 ecore_event_evas_modifier_lock_update(Evas *e, unsigned int modifiers)
 {
    ecore_event_evas_seat_modifier_lock_update(e, modifiers, NULL);
 }
 
-EAPI void
+ECORE_INPUT_EVAS_API void
 ecore_event_window_register(Ecore_Window id, void *window, Evas *evas,
                             Ecore_Event_Mouse_Move_Cb move_mouse,
                             Ecore_Event_Multi_Move_Cb move_multi,
@@ -366,13 +366,13 @@ ecore_event_window_register(Ecore_Window id, void *window, Evas *evas,
    evas_key_lock_add(evas, "Scroll_Lock");
 }
 
-EAPI void
+ECORE_INPUT_EVAS_API void
 ecore_event_window_unregister(Ecore_Window id)
 {
    eina_hash_del(_window_hash, &id, NULL);
 }
 
-EAPI void
+ECORE_INPUT_EVAS_API void
 _ecore_event_window_direct_cb_set(Ecore_Window id, Ecore_Event_Direct_Input_Cb fptr)
 {
    Ecore_Input_Window *lookup;
@@ -382,7 +382,7 @@ _ecore_event_window_direct_cb_set(Ecore_Window id, Ecore_Event_Direct_Input_Cb f
    lookup->direct = fptr;
 }
 
-EAPI void *
+ECORE_INPUT_EVAS_API void *
 ecore_event_window_match(Ecore_Window id)
 {
    Ecore_Input_Window *lookup;
@@ -392,7 +392,7 @@ ecore_event_window_match(Ecore_Window id)
    return NULL;
 }
 
-EAPI void
+ECORE_INPUT_EVAS_API void
 ecore_event_window_ignore_events(Ecore_Window id, int ignore_event)
 {
    Ecore_Input_Window *lookup;
@@ -600,7 +600,7 @@ _ecore_event_evas_mouse_button(Ecore_Event_Mouse_Button *e, Ecore_Event_Press pr
    return ECORE_CALLBACK_PASS_ON;
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_mouse_move(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    Ecore_Event_Mouse_Move *e;
@@ -647,19 +647,19 @@ ecore_event_evas_mouse_move(void *data EINA_UNUSED, int type EINA_UNUSED, void *
    return ECORE_CALLBACK_PASS_ON;
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_mouse_button_down(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    return _ecore_event_evas_mouse_button((Ecore_Event_Mouse_Button *)event, ECORE_DOWN, EINA_FALSE);
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_mouse_button_up(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    return _ecore_event_evas_mouse_button((Ecore_Event_Mouse_Button *)event, ECORE_UP, EINA_FALSE);
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_mouse_button_cancel(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    return _ecore_event_evas_mouse_button_cancel((Ecore_Event_Mouse_Button *)event);
@@ -700,19 +700,19 @@ _ecore_event_evas_mouse_io(Ecore_Event_Mouse_IO *e, Ecore_Event_IO io)
    return ECORE_CALLBACK_PASS_ON;
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_key_down(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    return _ecore_event_evas_key((Ecore_Event_Key *)event, ECORE_DOWN);
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_key_up(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    return _ecore_event_evas_key((Ecore_Event_Key *)event, ECORE_UP);
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_mouse_wheel(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    Ecore_Event_Mouse_Wheel *e;
@@ -733,19 +733,19 @@ ecore_event_evas_mouse_wheel(void *data EINA_UNUSED, int type EINA_UNUSED, void 
    return ECORE_CALLBACK_PASS_ON;
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_mouse_in(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    return _ecore_event_evas_mouse_io((Ecore_Event_Mouse_IO *)event, ECORE_IN);
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_mouse_out(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    return _ecore_event_evas_mouse_io((Ecore_Event_Mouse_IO *)event, ECORE_OUT);
 }
 
-EAPI Eina_Bool
+ECORE_INPUT_EVAS_API Eina_Bool
 ecore_event_evas_axis_update(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
 {
    Ecore_Event_Axis_Update *e;
@@ -765,7 +765,7 @@ ecore_event_evas_axis_update(void *data EINA_UNUSED, int type EINA_UNUSED, void 
    return ECORE_CALLBACK_PASS_ON;
 }
 
-EAPI int
+ECORE_INPUT_EVAS_API int
 ecore_event_evas_init(void)
 {
    if (++_ecore_event_evas_init_count !=  1)
@@ -841,7 +841,7 @@ ecore_event_evas_init(void)
    return --_ecore_event_evas_init_count;
 }
 
-EAPI int
+ECORE_INPUT_EVAS_API int
 ecore_event_evas_shutdown(void)
 {
    size_t i;

--- a/src/lib/ecore_input_evas/ecore_input_evas_api.h
+++ b/src/lib/ecore_input_evas/ecore_input_evas_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_INPUT_EVAS_API_H
+#define _EFL_ECORE_INPUT_EVAS_API_H
+
+#ifdef ECORE_INPUT_EVAS_API
+#error ECORE_INPUT_EVAS_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_INPUT_EVAS_STATIC
+#  ifdef ECORE_INPUT_EVAS_BUILD
+#   define ECORE_INPUT_EVAS_API __declspec(dllexport)
+#  else
+#   define ECORE_INPUT_EVAS_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_INPUT_EVAS_API
+# endif
+# define ECORE_INPUT_EVAS_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_INPUT_EVAS_API __attribute__ ((visibility("default")))
+#   define ECORE_INPUT_EVAS_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_INPUT_EVAS_API
+#   define ECORE_INPUT_EVAS_API_WEAK
+#  endif
+# else
+#  define ECORE_INPUT_EVAS_API
+#  define ECORE_INPUT_EVAS_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_input_evas/meson.build
+++ b/src/lib/ecore_input_evas/meson.build
@@ -15,7 +15,7 @@ ecore_input_evas_src = files([
 
 ecore_input_evas_lib = library('ecore_input_evas',
     ecore_input_evas_src, pub_eo_file_target,
-    c_args : package_c_args,
+    c_args : [package_c_args,, '-DECORE_INPUT_EVAS_BUILD'],
     dependencies: [ecore_input_evas_pub_deps, ecore_input_evas_deps, ecore_input_evas_ext_deps],
     include_directories : config_dir,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.