### PR TITLE
build: Disable pkgconfig operations for MSVC (Fixes #150)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,10 +8,6 @@ if host_machine.system() == 'darwin'
   add_languages('objc')
 endif
 
-if host_machine.system() != 'windows'
-  pkgconfig = import('pkgconfig')
-endif
-
 test_env = environment()
 test_env.set('EFL_RUN_IN_TREE', '1')
 
@@ -63,6 +59,12 @@ sys_linux = linux.contains(host_machine.system())
 sys_bsd = bsd.contains(host_machine.system())
 sys_windows = windows.contains(host_machine.system())
 sys_osx = osx.contains(host_machine.system())
+
+if sys_windows and cc.get_id() in ['msvc', 'clang-cl']
+  pkgconfig = disabler()
+else
+  pkgconfig = import('pkgconfig')
+endif
 
 module_files = []
 evas_loader_map = []
@@ -864,21 +866,19 @@ if not sys_windows and get_option('dbus')
   subdir(join_paths('dbus-services'))
 endif
 
-if not sys_windows
-  #output the three new efl-* .pc files
-  efl_20_pc_files = [
-    ['efl-ui', ['elementary']],
-    ['efl-core', ['ecore', 'efl', 'emile']],
-    ['efl-net', ['ecore', 'ecore-con', 'emile']],
-  ]
+#output the three new efl-* .pc files
+efl_20_pc_files = [
+  ['efl-ui', ['elementary']],
+  ['efl-core', ['ecore', 'efl', 'emile']],
+  ['efl-net', ['ecore', 'ecore-con', 'emile']],
+]
 
-  foreach pc_file : efl_20_pc_files
-    name = pc_file[0]
-    libraries = pc_file[1]
-    pkgconfig.generate(
-      name : '-'.join(name.split('_')),
-      description: name+' configutation file',
-      requires : libraries,
-    )
-  endforeach
-endif
+foreach pc_file : efl_20_pc_files
+  name = pc_file[0]
+  libraries = pc_file[1]
+  pkgconfig.generate(
+    name : '-'.join(name.split('_')),
+    description: name+' configutation file',
+    requires : libraries,
+  )
+endforeach

--- a/src/bindings/cxx/meson.build
+++ b/src/bindings/cxx/meson.build
@@ -119,7 +119,7 @@ foreach lib : cxx_sublibs
   install_headers(cxx_header_src,
     subdir: package_version_name,
   )
-if sys_windows == false
+
   pkgconfig.generate(
     name : '-'.join(package_name.split('_')) + '-cxx',
     description : lib[0]+' cxx bindings',
@@ -129,5 +129,4 @@ if sys_windows == false
     requires : growing_deps + [package_name],
   )
   growing_deps += package_name + '-cxx'
-endif
 endforeach

--- a/src/lib/efreet/meson.build
+++ b/src/lib/efreet/meson.build
@@ -74,7 +74,6 @@ deprecated_efreet_trash_lib = library('efreet_trash',
     version : meson.project_version()
 )
 
-if sys_windows == false
 pkgconfig.generate(efreet_lib,
         name : 'efreet-mime',
         description : 'Deprecated, please just use efreet',
@@ -90,4 +89,3 @@ pkgconfig.generate(efreet_lib,
         version : version_major + '.' + version_minor + '.' + version_micro,
         libraries : efreet_pub_deps,
 )
-endif


### PR DESCRIPTION
Since MSVC builds don't know how to deal with Pkg-config, this commit changes them into a [disabler-object](https://mesonbuild.com/Reference-manual.html#disabler-object), which makes all operations using the variable `pkgconfig` to be disabled (i.e. ignored).
