### PR TITLE
[ecore_ipc] Use ECORE_IPC_API instead of EAPI

### DIFF
--- a/src/lib/ecore_ipc/Ecore_Ipc.h
+++ b/src/lib/ecore_ipc/Ecore_Ipc.h
@@ -3,31 +3,7 @@
 
 #include <Eina.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_ipc_api.h>
 
 /**
  * @defgroup Ecore_IPC_Group Ecore_IPC - Ecore inter-process communication functions.
@@ -45,9 +21,9 @@ extern "C" {
 typedef struct _Ecore_Ipc_Server Ecore_Ipc_Server; /**< An IPC connection handle */
 typedef struct _Ecore_Ipc_Client Ecore_Ipc_Client; /**< An IPC connection handle */
 
-EAPI unsigned short     _ecore_ipc_swap_16(unsigned short v) EINA_DEPRECATED;
-EAPI unsigned int       _ecore_ipc_swap_32(unsigned int v) EINA_DEPRECATED;
-EAPI unsigned long long _ecore_ipc_swap_64(unsigned long long v) EINA_DEPRECATED;
+ECORE_IPC_API unsigned short     _ecore_ipc_swap_16(unsigned short v) EINA_DEPRECATED;
+ECORE_IPC_API unsigned int       _ecore_ipc_swap_32(unsigned int v) EINA_DEPRECATED;
+ECORE_IPC_API unsigned long long _ecore_ipc_swap_64(unsigned long long v) EINA_DEPRECATED;
 
 #ifdef WORDS_BIGENDIAN
 #define ECORE_IPC_SWAP2NET64(x) eina_swap64(x)
@@ -133,7 +109,7 @@ EAPI unsigned long long _ecore_ipc_swap_64(unsigned long long v) EINA_DEPRECATED
                 p->v = (char *)ptr; \
                 ptr += strlen(p->v) + 1; \
             } \
-    } 
+    }
 #define ECORE_IPC_PUTS(v, l)\
     { \
         strcpy((char *)ptr, p->v); \
@@ -234,7 +210,7 @@ typedef enum _Ecore_Ipc_Type
    ECORE_IPC_USE_SSL = (1 << 4),
    ECORE_IPC_NO_PROXY = (1 << 5)
 } Ecore_Ipc_Type;
-   
+
 typedef struct _Ecore_Ipc_Event_Client_Add  Ecore_Ipc_Event_Client_Add;
 typedef struct _Ecore_Ipc_Event_Client_Del  Ecore_Ipc_Event_Client_Del;
 typedef struct _Ecore_Ipc_Event_Server_Add  Ecore_Ipc_Event_Server_Add;
@@ -318,13 +294,13 @@ struct _Ecore_Ipc_Event_Server_Data
    void             *data; /**< The message data */
    int               size; /**< The data length (in bytes) */
 };
-   
-EAPI extern int ECORE_IPC_EVENT_CLIENT_ADD;
-EAPI extern int ECORE_IPC_EVENT_CLIENT_DEL;
-EAPI extern int ECORE_IPC_EVENT_SERVER_ADD;
-EAPI extern int ECORE_IPC_EVENT_SERVER_DEL;
-EAPI extern int ECORE_IPC_EVENT_CLIENT_DATA;
-EAPI extern int ECORE_IPC_EVENT_SERVER_DATA;
+
+ECORE_IPC_API extern int ECORE_IPC_EVENT_CLIENT_ADD;
+ECORE_IPC_API extern int ECORE_IPC_EVENT_CLIENT_DEL;
+ECORE_IPC_API extern int ECORE_IPC_EVENT_SERVER_ADD;
+ECORE_IPC_API extern int ECORE_IPC_EVENT_SERVER_DEL;
+ECORE_IPC_API extern int ECORE_IPC_EVENT_CLIENT_DATA;
+ECORE_IPC_API extern int ECORE_IPC_EVENT_SERVER_DATA;
 
 /**
  * @ingroup Ecore_IPC_Group
@@ -332,7 +308,7 @@ EAPI extern int ECORE_IPC_EVENT_SERVER_DATA;
  * @return  Number of times the library has been initialised without
  *          being shut down.
  */
-EAPI int               ecore_ipc_init(void);
+ECORE_IPC_API int               ecore_ipc_init(void);
 
 /**
  * @ingroup Ecore_IPC_Group
@@ -340,7 +316,7 @@ EAPI int               ecore_ipc_init(void);
  * @return  Number of times the library has been initialised without being
  *          shut down.
  */
-EAPI int               ecore_ipc_shutdown(void);
+ECORE_IPC_API int               ecore_ipc_shutdown(void);
 
 /**
  * @defgroup Ecore_IPC_Server_Group IPC Server Functions
@@ -363,7 +339,7 @@ EAPI int               ecore_ipc_shutdown(void);
  * @return  New IPC server.  If there is an error, @c NULL is returned.
  * @todo    Need to add protocol type parameter to this function.
  */
-EAPI Ecore_Ipc_Server *ecore_ipc_server_add(Ecore_Ipc_Type type, const char *name, int port, const void *data);
+ECORE_IPC_API Ecore_Ipc_Server *ecore_ipc_server_add(Ecore_Ipc_Type type, const char *name, int port, const void *data);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -382,7 +358,7 @@ EAPI Ecore_Ipc_Server *ecore_ipc_server_add(Ecore_Ipc_Type type, const char *nam
  * @return  A new IPC server.  @c NULL is returned on error.
  * @todo    Need to add protocol type parameter.
  */
-EAPI Ecore_Ipc_Server *ecore_ipc_server_connect(Ecore_Ipc_Type type, char *name, int port, const void *data);
+ECORE_IPC_API Ecore_Ipc_Server *ecore_ipc_server_connect(Ecore_Ipc_Type type, char *name, int port, const void *data);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -390,7 +366,7 @@ EAPI Ecore_Ipc_Server *ecore_ipc_server_connect(Ecore_Ipc_Type type, char *name,
  * @param   svr The given IPC server.
  * @return  The data associated with the server when it was created.
  */
-EAPI void             *ecore_ipc_server_del(Ecore_Ipc_Server *svr);
+ECORE_IPC_API void             *ecore_ipc_server_del(Ecore_Ipc_Server *svr);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -398,7 +374,7 @@ EAPI void             *ecore_ipc_server_del(Ecore_Ipc_Server *svr);
  * @param   svr The given IPC server.
  * @return  The associated data.
  */
-EAPI void             *ecore_ipc_server_data_get(Ecore_Ipc_Server *svr);
+ECORE_IPC_API void             *ecore_ipc_server_data_get(Ecore_Ipc_Server *svr);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -406,7 +382,7 @@ EAPI void             *ecore_ipc_server_data_get(Ecore_Ipc_Server *svr);
  * @param   svr The given IPC server.
  * @return @c EINA_TRUE if the server is connected, @c EINA_FALSE otherwise.
  */
-EAPI Eina_Bool         ecore_ipc_server_connected_get(Ecore_Ipc_Server *svr);
+ECORE_IPC_API Eina_Bool         ecore_ipc_server_connected_get(Ecore_Ipc_Server *svr);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -414,7 +390,7 @@ EAPI Eina_Bool         ecore_ipc_server_connected_get(Ecore_Ipc_Server *svr);
  * @param   svr The given IPC server.
  * @return  An Eina_List with the clients.
  */
-EAPI Eina_List        *ecore_ipc_server_clients_get(Ecore_Ipc_Server *svr);
+ECORE_IPC_API Eina_List        *ecore_ipc_server_clients_get(Ecore_Ipc_Server *svr);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -435,7 +411,7 @@ EAPI Eina_List        *ecore_ipc_server_clients_get(Ecore_Ipc_Server *svr);
  * @todo    This function needs to become an IPC message.
  * @todo Fix up the documentation: Make sure what ref_to and response are.
  */
-EAPI int               ecore_ipc_server_send(Ecore_Ipc_Server *svr, int major, int minor, int ref, int ref_to, int response, const void *data, int size);
+ECORE_IPC_API int               ecore_ipc_server_send(Ecore_Ipc_Server *svr, int major, int minor, int ref, int ref_to, int response, const void *data, int size);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -459,7 +435,7 @@ EAPI int               ecore_ipc_server_send(Ecore_Ipc_Server *svr, int major, i
  *                        connections (or your kernel's limit, whichever is
  *                        lower).
  */
-EAPI void              ecore_ipc_server_client_limit_set(Ecore_Ipc_Server *svr, int client_limit, char reject_excess_clients);
+ECORE_IPC_API void              ecore_ipc_server_client_limit_set(Ecore_Ipc_Server *svr, int client_limit, char reject_excess_clients);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -468,7 +444,7 @@ EAPI void              ecore_ipc_server_client_limit_set(Ecore_Ipc_Server *svr, 
  * @param   svr           The given server.
  * @param   size          The maximum data payload size in bytes.
  */
-EAPI void              ecore_ipc_server_data_size_max_set(Ecore_Ipc_Server *svr, int size);
+ECORE_IPC_API void              ecore_ipc_server_data_size_max_set(Ecore_Ipc_Server *svr, int size);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -477,7 +453,7 @@ EAPI void              ecore_ipc_server_data_size_max_set(Ecore_Ipc_Server *svr,
  * @param   svr           The given server.
  * @return The maximum data payload in bytes.
  */
-EAPI int               ecore_ipc_server_data_size_max_get(Ecore_Ipc_Server *svr);
+ECORE_IPC_API int               ecore_ipc_server_data_size_max_get(Ecore_Ipc_Server *svr);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -489,7 +465,7 @@ EAPI int               ecore_ipc_server_data_size_max_get(Ecore_Ipc_Server *svr)
  *          This string should not be modified or trusted to stay valid after
  *          deletion for the @p svr object. If no IP is known NULL is returned.
  */
-EAPI const char       *ecore_ipc_server_ip_get(Ecore_Ipc_Server *svr);
+ECORE_IPC_API const char       *ecore_ipc_server_ip_get(Ecore_Ipc_Server *svr);
 
 /**
  * @ingroup Ecore_IPC_Server_Group
@@ -497,7 +473,7 @@ EAPI const char       *ecore_ipc_server_ip_get(Ecore_Ipc_Server *svr);
  *
  * @param   svr           The given server.
  */
-EAPI void              ecore_ipc_server_flush(Ecore_Ipc_Server *svr);
+ECORE_IPC_API void              ecore_ipc_server_flush(Ecore_Ipc_Server *svr);
 
 /**
  * @defgroup Ecore_IPC_Client_Group IPC Client Functions
@@ -523,7 +499,7 @@ EAPI void              ecore_ipc_server_flush(Ecore_Ipc_Server *svr);
  * @todo    This function needs to become an IPC message.
  * @todo    Make sure ref_to and response parameters are described correctly.
  */
-EAPI int               ecore_ipc_client_send(Ecore_Ipc_Client *cl, int major, int minor, int ref, int ref_to, int response, const void *data, int size);
+ECORE_IPC_API int               ecore_ipc_client_send(Ecore_Ipc_Client *cl, int major, int minor, int ref, int ref_to, int response, const void *data, int size);
 
 /**
  * @ingroup Ecore_IPC_Client_Group
@@ -532,7 +508,7 @@ EAPI int               ecore_ipc_client_send(Ecore_Ipc_Client *cl, int major, in
  * @param   cl The given IPC client.
  * @return  The IPC server the IPC client is connected to.
  */
-EAPI Ecore_Ipc_Server *ecore_ipc_client_server_get(Ecore_Ipc_Client *cl);
+ECORE_IPC_API Ecore_Ipc_Server *ecore_ipc_client_server_get(Ecore_Ipc_Client *cl);
 
 /**
  * @ingroup Ecore_IPC_Client_Group
@@ -542,7 +518,7 @@ EAPI Ecore_Ipc_Server *ecore_ipc_client_server_get(Ecore_Ipc_Client *cl);
  * @param   cl The given client.
  * @return  Data associated with the client.
  */
-EAPI void             *ecore_ipc_client_del(Ecore_Ipc_Client *cl);
+ECORE_IPC_API void             *ecore_ipc_client_del(Ecore_Ipc_Client *cl);
 
 /**
  * @ingroup Ecore_IPC_Client_Group
@@ -551,7 +527,7 @@ EAPI void             *ecore_ipc_client_del(Ecore_Ipc_Client *cl);
  * @param   cl   The given IPC client.
  * @param   data The data to associate with the IPC client.
  */
-EAPI void              ecore_ipc_client_data_set(Ecore_Ipc_Client *cl, const void *data);
+ECORE_IPC_API void              ecore_ipc_client_data_set(Ecore_Ipc_Client *cl, const void *data);
 
 /**
  * @ingroup Ecore_IPC_Client_Group
@@ -560,7 +536,7 @@ EAPI void              ecore_ipc_client_data_set(Ecore_Ipc_Client *cl, const voi
  * @param   cl The given client.
  * @return  The data associated with the IPC client.
  */
-EAPI void             *ecore_ipc_client_data_get(Ecore_Ipc_Client *cl);
+ECORE_IPC_API void             *ecore_ipc_client_data_get(Ecore_Ipc_Client *cl);
 
 /**
  * @ingroup Ecore_IPC_Client_Group
@@ -569,7 +545,7 @@ EAPI void             *ecore_ipc_client_data_get(Ecore_Ipc_Client *cl);
  * @param   cl        The given client.
  * @param   size          The maximum data payload size in bytes.
  */
-EAPI void              ecore_ipc_client_data_size_max_set(Ecore_Ipc_Client *cl, int size);
+ECORE_IPC_API void              ecore_ipc_client_data_size_max_set(Ecore_Ipc_Client *cl, int size);
 
 /**
  * @ingroup Ecore_IPC_Client_Group
@@ -578,7 +554,7 @@ EAPI void              ecore_ipc_client_data_size_max_set(Ecore_Ipc_Client *cl, 
  * @param   cl            The given client.
  * @return The maximum data payload size in bytes on success, @c -1 on failure.
  */
-EAPI int               ecore_ipc_client_data_size_max_get(Ecore_Ipc_Client *cl);
+ECORE_IPC_API int               ecore_ipc_client_data_size_max_get(Ecore_Ipc_Client *cl);
 
 /**
  * @ingroup Ecore_IPC_Client_Group
@@ -591,7 +567,7 @@ EAPI int               ecore_ipc_client_data_size_max_get(Ecore_Ipc_Client *cl);
  *          deletion for the @p cl object. If no IP is known @c NULL is
  *          returned.
  */
-EAPI const char       *ecore_ipc_client_ip_get(Ecore_Ipc_Client *cl);
+ECORE_IPC_API const char       *ecore_ipc_client_ip_get(Ecore_Ipc_Client *cl);
 
 /**
  * @ingroup Ecore_IPC_Client_Group
@@ -599,7 +575,7 @@ EAPI const char       *ecore_ipc_client_ip_get(Ecore_Ipc_Client *cl);
  *
  * @param   cl            The given client.
  */
-EAPI void              ecore_ipc_client_flush(Ecore_Ipc_Client *cl);
+ECORE_IPC_API void              ecore_ipc_client_flush(Ecore_Ipc_Client *cl);
 
 /**
  * @ingroup Ecore_Con_Client_Group
@@ -607,16 +583,13 @@ EAPI void              ecore_ipc_client_flush(Ecore_Ipc_Client *cl);
  *
  * @return  1 if SSL is available, 0 if it is not.
  */
-EAPI int               ecore_ipc_ssl_available_get(void);
+ECORE_IPC_API int               ecore_ipc_ssl_available_get(void);
 /* FIXME: need to add a callback to "ok" large ipc messages greater than */
 /*        a certain size (security/DOS attack safety) */
 
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 /**
  * @}

--- a/src/lib/ecore_ipc/ecore_ipc.c
+++ b/src/lib/ecore_ipc/ecore_ipc.c
@@ -37,19 +37,19 @@
 static int _ecore_ipc_log_dom = -1;
 
 /****** This swap function are around just for backward compatibility do not remove *******/
-EAPI unsigned short
+ECORE_IPC_API unsigned short
 _ecore_ipc_swap_16(unsigned short v)
 {
    return eina_swap16(v);
 }
 
-EAPI unsigned int
+ECORE_IPC_API unsigned int
 _ecore_ipc_swap_32(unsigned int v)
 {
    return eina_swap32(v);
 }
 
-EAPI unsigned long long
+ECORE_IPC_API unsigned long long
 _ecore_ipc_swap_64(unsigned long long v)
 {
    return eina_swap64(v);
@@ -213,12 +213,12 @@ static void _ecore_ipc_event_server_add_free(void *data, void *ev);
 static void _ecore_ipc_event_server_del_free(void *data, void *ev);
 static void _ecore_ipc_event_server_data_free(void *data, void *ev);
 
-EAPI int ECORE_IPC_EVENT_CLIENT_ADD = 0;
-EAPI int ECORE_IPC_EVENT_CLIENT_DEL = 0;
-EAPI int ECORE_IPC_EVENT_SERVER_ADD = 0;
-EAPI int ECORE_IPC_EVENT_SERVER_DEL = 0;
-EAPI int ECORE_IPC_EVENT_CLIENT_DATA = 0;
-EAPI int ECORE_IPC_EVENT_SERVER_DATA = 0;
+ECORE_IPC_API int ECORE_IPC_EVENT_CLIENT_ADD = 0;
+ECORE_IPC_API int ECORE_IPC_EVENT_CLIENT_DEL = 0;
+ECORE_IPC_API int ECORE_IPC_EVENT_SERVER_ADD = 0;
+ECORE_IPC_API int ECORE_IPC_EVENT_SERVER_DEL = 0;
+ECORE_IPC_API int ECORE_IPC_EVENT_CLIENT_DATA = 0;
+ECORE_IPC_API int ECORE_IPC_EVENT_SERVER_DATA = 0;
 
 static int                  _ecore_ipc_init_count = 0;
 static Eina_List           *servers = NULL;
@@ -303,7 +303,7 @@ ecore_ipc_client_add(Ecore_Ipc_Server *svr)
    return cl;
 }
 
-EAPI int
+ECORE_IPC_API int
 ecore_ipc_init(void)
 {
    if (++_ecore_ipc_init_count != 1)
@@ -334,7 +334,7 @@ ecore_ipc_init(void)
    return _ecore_ipc_init_count;
 }
 
-EAPI int
+ECORE_IPC_API int
 ecore_ipc_shutdown(void)
 {
    if (--_ecore_ipc_init_count != 0)
@@ -378,7 +378,7 @@ EFL_CALLBACKS_ARRAY_DEFINE(_ecore_ipc_server_cbs,
                            { EFL_NET_SERVER_EVENT_CLIENT_ADD, _ecore_ipc_server_client_add });
 
 /* FIXME: need to add protocol type parameter */
-EAPI Ecore_Ipc_Server *
+ECORE_IPC_API Ecore_Ipc_Server *
 ecore_ipc_server_add(Ecore_Ipc_Type type, const char *name, int port, const void *data)
 {
    Ecore_Ipc_Server *svr;
@@ -655,7 +655,7 @@ EFL_CALLBACKS_ARRAY_DEFINE(_ecore_ipc_dialer_copier_cbs,
                            { EFL_IO_COPIER_EVENT_ERROR, _ecore_ipc_dialer_copier_error });
 
 /* FIXME: need to add protocol type parameter */
-EAPI Ecore_Ipc_Server *
+ECORE_IPC_API Ecore_Ipc_Server *
 ecore_ipc_server_connect(Ecore_Ipc_Type type, char *name, int port, const void *data)
 {
    Ecore_Ipc_Server *svr;
@@ -803,7 +803,7 @@ ecore_ipc_server_connect(Ecore_Ipc_Type type, char *name, int port, const void *
    return NULL;
 }
 
-EAPI void *
+ECORE_IPC_API void *
 ecore_ipc_server_del(Ecore_Ipc_Server *svr)
 {
    void *data;
@@ -844,7 +844,7 @@ ecore_ipc_server_del(Ecore_Ipc_Server *svr)
    return data;
 }
 
-EAPI void *
+ECORE_IPC_API void *
 ecore_ipc_server_data_get(Ecore_Ipc_Server *svr)
 {
    if (!ECORE_MAGIC_CHECK(svr, ECORE_MAGIC_IPC_SERVER))
@@ -856,7 +856,7 @@ ecore_ipc_server_data_get(Ecore_Ipc_Server *svr)
    return svr->data;
 }
 
-EAPI Eina_Bool
+ECORE_IPC_API Eina_Bool
 ecore_ipc_server_connected_get(Ecore_Ipc_Server *svr)
 {
    if (!ECORE_MAGIC_CHECK(svr, ECORE_MAGIC_IPC_SERVER))
@@ -872,7 +872,7 @@ ecore_ipc_server_connected_get(Ecore_Ipc_Server *svr)
    return EINA_FALSE;
 }
 
-EAPI Eina_List *
+ECORE_IPC_API Eina_List *
 ecore_ipc_server_clients_get(Ecore_Ipc_Server *svr)
 {
    if (!ECORE_MAGIC_CHECK(svr, ECORE_MAGIC_IPC_SERVER))
@@ -917,7 +917,7 @@ ecore_ipc_server_clients_get(Ecore_Ipc_Server *svr)
      }
 
 /* FIXME: this needs to become an ipc message */
-EAPI int
+ECORE_IPC_API int
 ecore_ipc_server_send(Ecore_Ipc_Server *svr, int major, int minor, int ref, int ref_to, int response, const void *data, int size)
 {
    Ecore_Ipc_Msg_Head msg;
@@ -1004,7 +1004,7 @@ ecore_ipc_server_send(Ecore_Ipc_Server *svr, int major, int minor, int ref, int 
    return 0;
 }
 
-EAPI void
+ECORE_IPC_API void
 ecore_ipc_server_client_limit_set(Ecore_Ipc_Server *svr, int client_limit, char reject_excess_clients)
 {
    if (!ECORE_MAGIC_CHECK(svr, ECORE_MAGIC_IPC_SERVER))
@@ -1020,7 +1020,7 @@ ecore_ipc_server_client_limit_set(Ecore_Ipc_Server *svr, int client_limit, char 
      }
 }
 
-EAPI void
+ECORE_IPC_API void
 ecore_ipc_server_data_size_max_set(Ecore_Ipc_Server *svr, int size)
 {
    if (!ECORE_MAGIC_CHECK(svr, ECORE_MAGIC_IPC_SERVER))
@@ -1032,7 +1032,7 @@ ecore_ipc_server_data_size_max_set(Ecore_Ipc_Server *svr, int size)
    svr->max_buf_size = size;
 }
 
-EAPI int
+ECORE_IPC_API int
 ecore_ipc_server_data_size_max_get(Ecore_Ipc_Server *svr)
 {
    if (!ECORE_MAGIC_CHECK(svr, ECORE_MAGIC_IPC_SERVER))
@@ -1044,7 +1044,7 @@ ecore_ipc_server_data_size_max_get(Ecore_Ipc_Server *svr)
    return svr->max_buf_size;
 }
 
-EAPI const char *
+ECORE_IPC_API const char *
 ecore_ipc_server_ip_get(Ecore_Ipc_Server *svr)
 {
    if (!ECORE_MAGIC_CHECK(svr, ECORE_MAGIC_IPC_SERVER))
@@ -1073,7 +1073,7 @@ ecore_ipc_server_ip_get(Ecore_Ipc_Server *svr)
    return NULL;
 }
 
-EAPI void
+ECORE_IPC_API void
 ecore_ipc_server_flush(Ecore_Ipc_Server *svr)
 {
    if (!ECORE_MAGIC_CHECK(svr, ECORE_MAGIC_IPC_SERVER))
@@ -1132,7 +1132,7 @@ ecore_ipc_server_flush(Ecore_Ipc_Server *svr)
      }
 
 /* FIXME: this needs to become an ipc message */
-EAPI int
+ECORE_IPC_API int
 ecore_ipc_client_send(Ecore_Ipc_Client *cl, int major, int minor, int ref, int ref_to, int response, const void *data, int size)
 {
    Ecore_Ipc_Msg_Head msg;
@@ -1221,7 +1221,7 @@ ecore_ipc_client_send(Ecore_Ipc_Client *cl, int major, int minor, int ref, int r
    return 0;
 }
 
-EAPI Ecore_Ipc_Server *
+ECORE_IPC_API Ecore_Ipc_Server *
 ecore_ipc_client_server_get(Ecore_Ipc_Client *cl)
 {
    if (!ECORE_MAGIC_CHECK(cl, ECORE_MAGIC_IPC_CLIENT))
@@ -1370,7 +1370,7 @@ _ecore_ipc_server_client_add(void *data, const Efl_Event *event)
    free(cl);
 }
 
-EAPI void *
+ECORE_IPC_API void *
 ecore_ipc_client_del(Ecore_Ipc_Client *cl)
 {
    void *data;
@@ -1399,7 +1399,7 @@ ecore_ipc_client_del(Ecore_Ipc_Client *cl)
    return data;
 }
 
-EAPI void
+ECORE_IPC_API void
 ecore_ipc_client_data_set(Ecore_Ipc_Client *cl, const void *data)
 {
    if (!ECORE_MAGIC_CHECK(cl, ECORE_MAGIC_IPC_CLIENT))
@@ -1411,7 +1411,7 @@ ecore_ipc_client_data_set(Ecore_Ipc_Client *cl, const void *data)
    cl->data = (void *)data;
 }
 
-EAPI void *
+ECORE_IPC_API void *
 ecore_ipc_client_data_get(Ecore_Ipc_Client *cl)
 {
    if (!ECORE_MAGIC_CHECK(cl, ECORE_MAGIC_IPC_CLIENT))
@@ -1423,7 +1423,7 @@ ecore_ipc_client_data_get(Ecore_Ipc_Client *cl)
    return cl->data;
 }
 
-EAPI void
+ECORE_IPC_API void
 ecore_ipc_client_data_size_max_set(Ecore_Ipc_Client *cl, int size)
 {
    if (!ECORE_MAGIC_CHECK(cl, ECORE_MAGIC_IPC_CLIENT))
@@ -1435,7 +1435,7 @@ ecore_ipc_client_data_size_max_set(Ecore_Ipc_Client *cl, int size)
    cl->max_buf_size = size;
 }
 
-EAPI int
+ECORE_IPC_API int
 ecore_ipc_client_data_size_max_get(Ecore_Ipc_Client *cl)
 {
    if (!ECORE_MAGIC_CHECK(cl, ECORE_MAGIC_IPC_CLIENT))
@@ -1447,7 +1447,7 @@ ecore_ipc_client_data_size_max_get(Ecore_Ipc_Client *cl)
    return cl->max_buf_size;
 }
 
-EAPI const char *
+ECORE_IPC_API const char *
 ecore_ipc_client_ip_get(Ecore_Ipc_Client *cl)
 {
    if (!ECORE_MAGIC_CHECK(cl, ECORE_MAGIC_IPC_CLIENT))
@@ -1469,7 +1469,7 @@ ecore_ipc_client_ip_get(Ecore_Ipc_Client *cl)
    return NULL;
 }
 
-EAPI void
+ECORE_IPC_API void
 ecore_ipc_client_flush(Ecore_Ipc_Client *cl)
 {
    if (!ECORE_MAGIC_CHECK(cl, ECORE_MAGIC_IPC_CLIENT))
@@ -1486,7 +1486,7 @@ ecore_ipc_client_flush(Ecore_Ipc_Client *cl)
      }
 }
 
-EAPI int
+ECORE_IPC_API int
 ecore_ipc_ssl_available_get(void)
 {
    return ecore_con_ssl_available_get();

--- a/src/lib/ecore_ipc/ecore_ipc_api.h
+++ b/src/lib/ecore_ipc/ecore_ipc_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_IPC_API_H
+#define _EFL_ECORE_IPC_API_H
+
+#ifdef ECORE_IPC_API
+#error ECORE_IPC_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_IPC_STATIC
+#  ifdef ECORE_IPC_BUILD
+#   define ECORE_IPC_API __declspec(dllexport)
+#  else
+#   define ECORE_IPC_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_IPC_API
+# endif
+# define ECORE_IPC_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_IPC_API __attribute__ ((visibility("default")))
+#   define ECORE_IPC_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_IPC_API
+#   define ECORE_IPC_API_WEAK
+#  endif
+# else
+#  define ECORE_IPC_API
+#  define ECORE_IPC_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_ipc/meson.build
+++ b/src/lib/ecore_ipc/meson.build
@@ -12,7 +12,7 @@ ecore_ipc_src = files([
 
 ecore_ipc_lib = library('ecore_ipc',
     ecore_ipc_src, pub_eo_file_target,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_IPC_BUILD'],
     dependencies: [ecore_ipc_deps, ecore_ipc_pub_deps, ecore_ipc_ext_deps],
     include_directories : config_dir,
     install: true,


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.