### PR TITLE
[ecore_sdl] Use ECORE_SDL_API instead of EAPI

### DIFF
--- a/src/lib/ecore_sdl/Ecore_Sdl.h
+++ b/src/lib/ecore_sdl/Ecore_Sdl.h
@@ -1,31 +1,7 @@
 #ifndef _ECORE_SDL_H
 #define _ECORE_SDL_H
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#include <ecore_sdl_api.h>
 
 /**
  * @file
@@ -36,10 +12,10 @@
 extern "C" {
 #endif
 
-EAPI extern int ECORE_SDL_EVENT_GOT_FOCUS;
-EAPI extern int ECORE_SDL_EVENT_LOST_FOCUS;
-EAPI extern int ECORE_SDL_EVENT_RESIZE;
-EAPI extern int ECORE_SDL_EVENT_EXPOSE;
+ECORE_SDL_API extern int ECORE_SDL_EVENT_GOT_FOCUS;
+ECORE_SDL_API extern int ECORE_SDL_EVENT_LOST_FOCUS;
+ECORE_SDL_API extern int ECORE_SDL_EVENT_RESIZE;
+ECORE_SDL_API extern int ECORE_SDL_EVENT_EXPOSE;
 
 typedef struct _Ecore_Sdl_Event_Video_Resize Ecore_Sdl_Event_Video_Resize;
 struct _Ecore_Sdl_Event_Video_Resize
@@ -55,9 +31,9 @@ struct _Ecore_Sdl_Event_Window
    unsigned int    windowID;
 };
 
-EAPI int        ecore_sdl_init(const char *name);
-EAPI int        ecore_sdl_shutdown(void);
-EAPI void       ecore_sdl_feed_events(void);
+ECORE_SDL_API int        ecore_sdl_init(const char *name);
+ECORE_SDL_API int        ecore_sdl_shutdown(void);
+ECORE_SDL_API void       ecore_sdl_feed_events(void);
 
   /* The following data structure have been deprecated since a long time */
 
@@ -100,7 +76,7 @@ struct _Ecore_Sdl_Event_Mouse_Button_Up /** SDL Mouse Up event */
 };
 
 typedef struct _Ecore_Sdl_Event_Mouse_Move Ecore_Sdl_Event_Mouse_Move;
-struct _Ecore_Sdl_Event_Mouse_Move /** SDL Mouse Move event */ 
+struct _Ecore_Sdl_Event_Mouse_Move /** SDL Mouse Move event */
 {
    int             x; /**< Mouse co-ordinates where the mouse cursor moved to */
    int             y; /**< Mouse co-ordinates where the mouse cursor moved to */
@@ -119,8 +95,5 @@ struct _Ecore_Sdl_Event_Mouse_Wheel /** SDL Mouse Wheel event */
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_sdl/ecore_sdl.c
+++ b/src/lib/ecore_sdl/ecore_sdl.c
@@ -22,10 +22,10 @@ struct _Ecore_SDL_Pressed
    SDL_Keycode key;
 };
 
-EAPI int ECORE_SDL_EVENT_GOT_FOCUS = 0;
-EAPI int ECORE_SDL_EVENT_LOST_FOCUS = 0;
-EAPI int ECORE_SDL_EVENT_RESIZE = 0;
-EAPI int ECORE_SDL_EVENT_EXPOSE = 0;
+ECORE_SDL_API int ECORE_SDL_EVENT_GOT_FOCUS = 0;
+ECORE_SDL_API int ECORE_SDL_EVENT_LOST_FOCUS = 0;
+ECORE_SDL_API int ECORE_SDL_EVENT_RESIZE = 0;
+ECORE_SDL_API int ECORE_SDL_EVENT_EXPOSE = 0;
 
 static int _ecore_sdl_init_count = 0;
 static Eina_Rbtree *repeat = NULL;
@@ -61,7 +61,7 @@ _ecore_sdl_pressed_node(const Ecore_SDL_Pressed *node,
  *          been initialised without being shut down.
  * @ingroup Ecore_SDL_Library_Group
  */
-EAPI int
+ECORE_SDL_API int
 ecore_sdl_init(const char *name EINA_UNUSED)
 {
    if(++_ecore_sdl_init_count != 1)
@@ -92,7 +92,7 @@ ecore_sdl_init(const char *name EINA_UNUSED)
  *             being shut down.
  * @ingroup Ecore_SDL_Library_Group
  */
-EAPI int
+ECORE_SDL_API int
 ecore_sdl_shutdown(void)
 {
    if (--_ecore_sdl_init_count != 0)
@@ -161,7 +161,7 @@ _ecore_sdl_event_key(SDL_Event *event, double timestamp)
  * Poll SDL for mouse, keyboard, and window events, and add corresponding events to ecore.
  * @ingroup Ecore_SDL_Library_Group
  */
-EAPI void
+ECORE_SDL_API void
 ecore_sdl_feed_events(void)
 {
    SDL_Event    event;

--- a/src/lib/ecore_sdl/ecore_sdl_api.h
+++ b/src/lib/ecore_sdl/ecore_sdl_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_SDL_API_H
+#define _EFL_ECORE_SDL_API_H
+
+#ifdef ECORE_SDL_API
+#error ECORE_SDL_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_SDL_STATIC
+#  ifdef ECORE_SDL_BUILD
+#   define ECORE_SDL_API __declspec(dllexport)
+#  else
+#   define ECORE_SDL_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_SDL_API
+# endif
+# define ECORE_SDL_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_SDL_API __attribute__ ((visibility("default")))
+#   define ECORE_SDL_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_SDL_API
+#   define ECORE_SDL_API_WEAK
+#  endif
+# else
+#  define ECORE_SDL_API
+#  define ECORE_SDL_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_sdl/meson.build
+++ b/src/lib/ecore_sdl/meson.build
@@ -8,6 +8,7 @@ ecore_sdl_src = files([
 
 ecore_sdl_header_src = [
   'Ecore_Sdl.h',
+  'ecore_sdl_api.h',
   'Ecore_Sdl_Keys.h'
 ]
 

--- a/src/lib/ecore_sdl/meson.build
+++ b/src/lib/ecore_sdl/meson.build
@@ -18,7 +18,7 @@ ecore_sdl_lib = library('ecore_sdl',
     dependencies: [ecore_sdl_deps, ecore_sdl_pub_deps, ecore_sdl_ext_deps],
     include_directories : config_dir + [include_directories(join_paths('..','..'))],
     install: true,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_SDL_BUILD'],
 )
 
 ecore_sdl = declare_dependency(


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.