### PR TITLE
[ecore_wayland] Use ECORE_WAYLAND_API instead of EAPI

### DIFF
--- a/src/lib/ecore_wayland/Ecore_Wayland.h
+++ b/src/lib/ecore_wayland/Ecore_Wayland.h
@@ -13,19 +13,7 @@
 # include <wayland-cursor.h>
 # include <xkbcommon/xkbcommon.h>
 
-# ifdef EAPI
-#  undef EAPI
-# endif
-
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
+# include <ecore_wayland_api.h>
 
 # warning The Ecore_Wayland library has been deprecated. Please use the Ecore_Wl2 library
 
@@ -244,22 +232,22 @@ struct _Ecore_Wl_Event_Interfaces_Bound
  * @li @ref Ecore_Wl_Subsurf
  */
 
-EAPI extern int ECORE_WL_EVENT_MOUSE_IN;
-EAPI extern int ECORE_WL_EVENT_MOUSE_OUT;
-EAPI extern int ECORE_WL_EVENT_FOCUS_IN;
-EAPI extern int ECORE_WL_EVENT_FOCUS_OUT;
-EAPI extern int ECORE_WL_EVENT_WINDOW_CONFIGURE;
-EAPI extern int ECORE_WL_EVENT_DND_ENTER;
-EAPI extern int ECORE_WL_EVENT_DND_POSITION;
-EAPI extern int ECORE_WL_EVENT_DND_LEAVE;
-EAPI extern int ECORE_WL_EVENT_DND_DROP;
-EAPI extern int ECORE_WL_EVENT_DND_OFFER; /** @since 1.8 */
-EAPI extern int ECORE_WL_EVENT_DND_END; /** @since 1.8 */
-EAPI extern int ECORE_WL_EVENT_DATA_SOURCE_TARGET; /** @since 1.7 */
-EAPI extern int ECORE_WL_EVENT_DATA_SOURCE_SEND; /** @since 1.7 */
-EAPI extern int ECORE_WL_EVENT_DATA_SOURCE_CANCELLED; /** @since 1.7 */
-EAPI extern int ECORE_WL_EVENT_SELECTION_DATA_READY; /** @since 1.7 */
-EAPI extern int ECORE_WL_EVENT_INTERFACES_BOUND;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_MOUSE_IN;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_MOUSE_OUT;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_FOCUS_IN;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_FOCUS_OUT;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_WINDOW_CONFIGURE;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DND_ENTER;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DND_POSITION;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DND_LEAVE;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DND_DROP;
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DND_OFFER; /** @since 1.8 */
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DND_END; /** @since 1.8 */
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DATA_SOURCE_TARGET; /** @since 1.7 */
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DATA_SOURCE_SEND; /** @since 1.7 */
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_DATA_SOURCE_CANCELLED; /** @since 1.7 */
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_SELECTION_DATA_READY; /** @since 1.7 */
+ECORE_WAYLAND_API extern int ECORE_WL_EVENT_INTERFACES_BOUND;
 
 /**
  * @defgroup Ecore_Wl_Init_Group Wayland Library Init and Shutdown Functions
@@ -278,7 +266,7 @@ EAPI extern int ECORE_WL_EVENT_INTERFACES_BOUND;
  *          shut down. @c 0 is returned if an error occurs.
  *
  */
-EAPI int ecore_wl_init(const char *name);
+ECORE_WAYLAND_API int ecore_wl_init(const char *name);
 
 /**
  * @ingroup Ecore_Wl_Init_Group
@@ -291,7 +279,7 @@ EAPI int ecore_wl_init(const char *name);
  *          being shut down.
  *
  */
-EAPI int ecore_wl_shutdown(void);
+ECORE_WAYLAND_API int ecore_wl_shutdown(void);
 
 /**
  * @defgroup Ecore_Wl_Flush_Group Wayland Synchronization Functions
@@ -307,7 +295,7 @@ EAPI int ecore_wl_shutdown(void);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_flush(void);
+ECORE_WAYLAND_API void ecore_wl_flush(void);
 
 /**
  * @ingroup Ecore_Wl_Flush_Group
@@ -316,7 +304,7 @@ EAPI void ecore_wl_flush(void);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_sync(void);
+ECORE_WAYLAND_API void ecore_wl_sync(void);
 
 /**
  * @defgroup Ecore_Wl_Display_Group Wayland Display Functions
@@ -333,7 +321,7 @@ EAPI void ecore_wl_sync(void);
  *
  * @since 1.2
  */
-EAPI struct wl_shm *ecore_wl_shm_get(void);
+ECORE_WAYLAND_API struct wl_shm *ecore_wl_shm_get(void);
 
 /**
  * @ingroup Ecore_Wl_Display_Group
@@ -343,7 +331,7 @@ EAPI struct wl_shm *ecore_wl_shm_get(void);
  *
  * @since 1.2
  */
-EAPI struct wl_display *ecore_wl_display_get(void);
+ECORE_WAYLAND_API struct wl_display *ecore_wl_display_get(void);
 
 /**
  * @brief Retrieves the Compositor interface.
@@ -364,7 +352,7 @@ EAPI struct wl_display *ecore_wl_display_get(void);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_screen_size_get(int *w, int *h);
+ECORE_WAYLAND_API void ecore_wl_screen_size_get(int *w, int *h);
 
 /**
  * @ingroup Ecore_Wl_Display_Group
@@ -375,7 +363,7 @@ EAPI void ecore_wl_screen_size_get(int *w, int *h);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_pointer_xy_get(int *x, int *y);
+ECORE_WAYLAND_API void ecore_wl_pointer_xy_get(int *x, int *y);
 
 /**
  * @brief Returns the screen DPI.
@@ -388,7 +376,7 @@ EAPI void ecore_wl_pointer_xy_get(int *x, int *y);
  *
  * @since 1.2
  */
-EAPI int ecore_wl_dpi_get(void);
+ECORE_WAYLAND_API int ecore_wl_dpi_get(void);
 
 /**
  * @brief Dispatches Wayland events.
@@ -397,13 +385,13 @@ EAPI int ecore_wl_dpi_get(void);
  * to read from the display fd and queue things up according to the proxy
  * assignment.
  */
-EAPI void ecore_wl_display_iterate(void);
+ECORE_WAYLAND_API void ecore_wl_display_iterate(void);
 
 /*
  * @ingroup Ecore_Wl_Display_Group
  * @since 1.8
  */
-EAPI Eina_Bool ecore_wl_animator_source_set(Ecore_Animator_Source source);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_animator_source_set(Ecore_Animator_Source source);
 
 /**
  * @brief Retrieves the requested cursor from the cursor theme.
@@ -413,7 +401,7 @@ EAPI Eina_Bool ecore_wl_animator_source_set(Ecore_Animator_Source source);
  *
  * @since 1.2
  */
-EAPI struct wl_cursor *ecore_wl_cursor_get(const char *cursor_name);
+ECORE_WAYLAND_API struct wl_cursor *ecore_wl_cursor_get(const char *cursor_name);
 
 /**
  * @defgroup Ecore_Wl_Input_Group Functions dealing with Wayland Input
@@ -426,28 +414,28 @@ EAPI struct wl_cursor *ecore_wl_cursor_get(const char *cursor_name);
  * @ingroup Ecore_Wl_Input_Group
  * @since 1.8
  */
-EAPI Ecore_Wl_Input *ecore_wl_input_get(void);
-EAPI void ecore_wl_input_grab(Ecore_Wl_Input *input, Ecore_Wl_Window *win, unsigned int button);
-EAPI void ecore_wl_input_ungrab(Ecore_Wl_Input *input);
-EAPI void ecore_wl_input_pointer_set(Ecore_Wl_Input *input, struct wl_surface *surface, int hot_x, int hot_y);
-EAPI void ecore_wl_input_cursor_from_name_set(Ecore_Wl_Input *input, const char *cursor_name);
-EAPI void ecore_wl_input_cursor_default_restore(Ecore_Wl_Input *input);
-EAPI struct wl_seat *ecore_wl_input_seat_get(Ecore_Wl_Input *input);
+ECORE_WAYLAND_API Ecore_Wl_Input *ecore_wl_input_get(void);
+ECORE_WAYLAND_API void ecore_wl_input_grab(Ecore_Wl_Input *input, Ecore_Wl_Window *win, unsigned int button);
+ECORE_WAYLAND_API void ecore_wl_input_ungrab(Ecore_Wl_Input *input);
+ECORE_WAYLAND_API void ecore_wl_input_pointer_set(Ecore_Wl_Input *input, struct wl_surface *surface, int hot_x, int hot_y);
+ECORE_WAYLAND_API void ecore_wl_input_cursor_from_name_set(Ecore_Wl_Input *input, const char *cursor_name);
+ECORE_WAYLAND_API void ecore_wl_input_cursor_default_restore(Ecore_Wl_Input *input);
+ECORE_WAYLAND_API struct wl_seat *ecore_wl_input_seat_get(Ecore_Wl_Input *input);
 
-EAPI Eina_Inlist *ecore_wl_outputs_get(void);
+ECORE_WAYLAND_API Eina_Inlist *ecore_wl_outputs_get(void);
 
 /**
  * @ingroup Ecore_Wl_Input_Group
  * @since 1.12
  */
-EAPI void ecore_wl_input_cursor_size_set(Ecore_Wl_Input *input, const int size);
-EAPI void ecore_wl_input_cursor_theme_name_set(Ecore_Wl_Input *input, const char *cursor_theme_name);
+ECORE_WAYLAND_API void ecore_wl_input_cursor_size_set(Ecore_Wl_Input *input, const int size);
+ECORE_WAYLAND_API void ecore_wl_input_cursor_theme_name_set(Ecore_Wl_Input *input, const char *cursor_theme_name);
 
 /**
  * @ingroup Ecore_Wl_Input_Group
  * @since 1.17
  */
-EAPI struct xkb_keymap *ecore_wl_input_keymap_get(Ecore_Wl_Input *input);
+ECORE_WAYLAND_API struct xkb_keymap *ecore_wl_input_keymap_get(Ecore_Wl_Input *input);
 
 
 /**
@@ -467,7 +455,7 @@ EAPI struct xkb_keymap *ecore_wl_input_keymap_get(Ecore_Wl_Input *input);
  *
  * @since 1.7.6
  */
-EAPI Eina_Inlist *ecore_wl_globals_get(void);
+ECORE_WAYLAND_API Eina_Inlist *ecore_wl_globals_get(void);
 
 /**
  * @ingroup Ecore_Wl_Display_Group
@@ -477,7 +465,7 @@ EAPI Eina_Inlist *ecore_wl_globals_get(void);
  *
  * @since 1.7.6
  */
-EAPI struct wl_registry *ecore_wl_registry_get(void);
+ECORE_WAYLAND_API struct wl_registry *ecore_wl_registry_get(void);
 
 /**
  * @defgroup Ecore_Wl_Window_Group Wayland Window functions.
@@ -502,7 +490,7 @@ EAPI struct wl_registry *ecore_wl_registry_get(void);
  *
  * @since 1.2
  */
-EAPI Ecore_Wl_Window *ecore_wl_window_new(Ecore_Wl_Window *parent, int x, int y, int w, int h, int buffer_type);
+ECORE_WAYLAND_API Ecore_Wl_Window *ecore_wl_window_new(Ecore_Wl_Window *parent, int x, int y, int w, int h, int buffer_type);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -512,7 +500,7 @@ EAPI Ecore_Wl_Window *ecore_wl_window_new(Ecore_Wl_Window *parent, int x, int y,
  *
  * @since 1.2
  */
-EAPI void ecore_wl_window_free(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_free(Ecore_Wl_Window *win);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -527,7 +515,7 @@ EAPI void ecore_wl_window_free(Ecore_Wl_Window *win);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_window_move(Ecore_Wl_Window *win, int x, int y);
+ECORE_WAYLAND_API void ecore_wl_window_move(Ecore_Wl_Window *win, int x, int y);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -543,12 +531,12 @@ EAPI void ecore_wl_window_move(Ecore_Wl_Window *win, int x, int y);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_window_resize(Ecore_Wl_Window *win, int w, int h, int location);
-EAPI void ecore_wl_window_damage(Ecore_Wl_Window *win, int x, int y, int w, int h);
-EAPI void ecore_wl_window_buffer_attach(Ecore_Wl_Window *win, struct wl_buffer *buffer, int x, int y);
+ECORE_WAYLAND_API void ecore_wl_window_resize(Ecore_Wl_Window *win, int w, int h, int location);
+ECORE_WAYLAND_API void ecore_wl_window_damage(Ecore_Wl_Window *win, int x, int y, int w, int h);
+ECORE_WAYLAND_API void ecore_wl_window_buffer_attach(Ecore_Wl_Window *win, struct wl_buffer *buffer, int x, int y);
 
 /* @since 1.8 */
-EAPI void ecore_wl_window_commit(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_commit(Ecore_Wl_Window *win);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -560,7 +548,7 @@ EAPI void ecore_wl_window_commit(Ecore_Wl_Window *win);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_window_show(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_show(Ecore_Wl_Window *win);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -572,7 +560,7 @@ EAPI void ecore_wl_window_show(Ecore_Wl_Window *win);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_window_hide(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_hide(Ecore_Wl_Window *win);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -582,24 +570,24 @@ EAPI void ecore_wl_window_hide(Ecore_Wl_Window *win);
  *
  * @since 1.2
  */
-EAPI void ecore_wl_window_raise(Ecore_Wl_Window *win);
-EAPI void ecore_wl_window_maximized_set(Ecore_Wl_Window *win, Eina_Bool maximized);
-EAPI Eina_Bool ecore_wl_window_maximized_get(Ecore_Wl_Window *win);
-EAPI void ecore_wl_window_fullscreen_set(Ecore_Wl_Window *win, Eina_Bool fullscreen);
-EAPI Eina_Bool ecore_wl_window_fullscreen_get(Ecore_Wl_Window *win);
-EAPI void ecore_wl_window_transparent_set(Ecore_Wl_Window *win, Eina_Bool transparent);
-EAPI Eina_Bool ecore_wl_window_transparent_get(Ecore_Wl_Window *win);
-EAPI void ecore_wl_window_update_size(Ecore_Wl_Window *win, int w, int h);
-EAPI void ecore_wl_window_update_location(Ecore_Wl_Window *win, int x, int y);
-EAPI struct wl_surface *ecore_wl_window_surface_get(Ecore_Wl_Window *win);
-EAPI struct wl_shell_surface *ecore_wl_window_shell_surface_get(Ecore_Wl_Window *win);
-EAPI struct xdg_surface *ecore_wl_window_xdg_surface_get(Ecore_Wl_Window *win); /** @since 1.12 */
-EAPI Ecore_Wl_Window *ecore_wl_window_find(unsigned int id);
-EAPI void ecore_wl_window_type_set(Ecore_Wl_Window *win, Ecore_Wl_Window_Type type);
-EAPI void ecore_wl_window_pointer_set(Ecore_Wl_Window *win, struct wl_surface *surface, int hot_x, int hot_y);
-EAPI void ecore_wl_window_cursor_from_name_set(Ecore_Wl_Window *win, const char *cursor_name);
-EAPI void ecore_wl_window_cursor_default_restore(Ecore_Wl_Window *win);
-EAPI void ecore_wl_window_parent_set(Ecore_Wl_Window *win, Ecore_Wl_Window *parent);
+ECORE_WAYLAND_API void ecore_wl_window_raise(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_maximized_set(Ecore_Wl_Window *win, Eina_Bool maximized);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_window_maximized_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_fullscreen_set(Ecore_Wl_Window *win, Eina_Bool fullscreen);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_window_fullscreen_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_transparent_set(Ecore_Wl_Window *win, Eina_Bool transparent);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_window_transparent_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_update_size(Ecore_Wl_Window *win, int w, int h);
+ECORE_WAYLAND_API void ecore_wl_window_update_location(Ecore_Wl_Window *win, int x, int y);
+ECORE_WAYLAND_API struct wl_surface *ecore_wl_window_surface_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API struct wl_shell_surface *ecore_wl_window_shell_surface_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API struct xdg_surface *ecore_wl_window_xdg_surface_get(Ecore_Wl_Window *win); /** @since 1.12 */
+ECORE_WAYLAND_API Ecore_Wl_Window *ecore_wl_window_find(unsigned int id);
+ECORE_WAYLAND_API void ecore_wl_window_type_set(Ecore_Wl_Window *win, Ecore_Wl_Window_Type type);
+ECORE_WAYLAND_API void ecore_wl_window_pointer_set(Ecore_Wl_Window *win, struct wl_surface *surface, int hot_x, int hot_y);
+ECORE_WAYLAND_API void ecore_wl_window_cursor_from_name_set(Ecore_Wl_Window *win, const char *cursor_name);
+ECORE_WAYLAND_API void ecore_wl_window_cursor_default_restore(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_parent_set(Ecore_Wl_Window *win, Ecore_Wl_Window *parent);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -609,16 +597,16 @@ EAPI void ecore_wl_window_parent_set(Ecore_Wl_Window *win, Ecore_Wl_Window *pare
  *
  * @since 1.12
  */
-EAPI void ecore_wl_window_iconified_set(Ecore_Wl_Window *win, Eina_Bool iconified);
-EAPI Eina_Bool ecore_wl_window_iconified_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_iconified_set(Ecore_Wl_Window *win, Eina_Bool iconified);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_window_iconified_get(Ecore_Wl_Window *win);
 
 
-EAPI int ecore_wl_window_id_get(Ecore_Wl_Window *win);
-EAPI void ecore_wl_window_title_set(Ecore_Wl_Window *win, const char *title);
-EAPI void ecore_wl_window_class_name_set(Ecore_Wl_Window *win, const char *class_name);
-EAPI int ecore_wl_window_surface_id_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API int ecore_wl_window_id_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_title_set(Ecore_Wl_Window *win, const char *title);
+ECORE_WAYLAND_API void ecore_wl_window_class_name_set(Ecore_Wl_Window *win, const char *class_name);
+ECORE_WAYLAND_API int ecore_wl_window_surface_id_get(Ecore_Wl_Window *win);
 
-EAPI Ecore_Wl_Input *ecore_wl_window_keyboard_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API Ecore_Wl_Input *ecore_wl_window_keyboard_get(Ecore_Wl_Window *win);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -629,10 +617,10 @@ EAPI Ecore_Wl_Input *ecore_wl_window_keyboard_get(Ecore_Wl_Window *win);
  *
  * @since 1.8
  */
-EAPI struct wl_surface *ecore_wl_window_surface_create(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API struct wl_surface *ecore_wl_window_surface_create(Ecore_Wl_Window *win);
 
-EAPI void ecore_wl_window_alpha_set(Ecore_Wl_Window *win, Eina_Bool alpha);
-EAPI Eina_Bool ecore_wl_window_alpha_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API void ecore_wl_window_alpha_set(Ecore_Wl_Window *win, Eina_Bool alpha);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_window_alpha_get(Ecore_Wl_Window *win);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -643,7 +631,7 @@ EAPI Eina_Bool ecore_wl_window_alpha_get(Ecore_Wl_Window *win);
  *
  * @since 1.8
  */
-EAPI Ecore_Wl_Window *ecore_wl_window_surface_find(struct wl_surface *surface);
+ECORE_WAYLAND_API Ecore_Wl_Window *ecore_wl_window_surface_find(struct wl_surface *surface);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -661,7 +649,7 @@ EAPI Ecore_Wl_Window *ecore_wl_window_surface_find(struct wl_surface *surface);
  *
  * @since 1.8
  */
-EAPI void ecore_wl_window_input_region_set(Ecore_Wl_Window *win, int x, int y, int w, int h);
+ECORE_WAYLAND_API void ecore_wl_window_input_region_set(Ecore_Wl_Window *win, int x, int y, int w, int h);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -675,7 +663,7 @@ EAPI void ecore_wl_window_input_region_set(Ecore_Wl_Window *win, int x, int y, i
  *
  * @since 1.8
  */
-EAPI void ecore_wl_window_opaque_region_set(Ecore_Wl_Window *win, int x, int y, int w, int h);
+ECORE_WAYLAND_API void ecore_wl_window_opaque_region_set(Ecore_Wl_Window *win, int x, int y, int w, int h);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -686,7 +674,7 @@ EAPI void ecore_wl_window_opaque_region_set(Ecore_Wl_Window *win, int x, int y, 
  *
  * @since 1.8
  */
-EAPI void ecore_wl_window_rotation_set(Ecore_Wl_Window *win, int rotation);
+ECORE_WAYLAND_API void ecore_wl_window_rotation_set(Ecore_Wl_Window *win, int rotation);
 
 /**
  * @ingroup Ecore_Wl_Window_Group
@@ -697,7 +685,7 @@ EAPI void ecore_wl_window_rotation_set(Ecore_Wl_Window *win, int rotation);
  *
  * @since 1.8
  */
-EAPI int ecore_wl_window_rotation_get(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API int ecore_wl_window_rotation_get(Ecore_Wl_Window *win);
 
 /**
  * @defgroup Ecore_Wl_Dnd_Group Functions dealing with Wayland Drag-n-Drop
@@ -710,31 +698,31 @@ EAPI int ecore_wl_window_rotation_get(Ecore_Wl_Window *win);
  * @deprecated use ecore_wl_dnd_selection_set
  * @since 1.7
 */
-EINA_DEPRECATED EAPI Eina_Bool ecore_wl_dnd_set_selection(Ecore_Wl_Dnd *dnd, const char **types_offered);
+EINA_DEPRECATED ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_set_selection(Ecore_Wl_Dnd *dnd, const char **types_offered);
 
 /**
  * @deprecated use ecore_wl_dnd_selection_get
  * @since 1.7
 */
-EINA_DEPRECATED EAPI Eina_Bool ecore_wl_dnd_get_selection(Ecore_Wl_Dnd *dnd, const char *type);
+EINA_DEPRECATED ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_get_selection(Ecore_Wl_Dnd *dnd, const char *type);
 
 /**
  * @deprecated Do Not Use
  * @since 1.7
  */
-EINA_DEPRECATED EAPI Ecore_Wl_Dnd *ecore_wl_dnd_get(void);
+EINA_DEPRECATED ECORE_WAYLAND_API Ecore_Wl_Dnd *ecore_wl_dnd_get(void);
 
 /**
  * @deprecated use ecore_wl_dnd_drag_start
  * @since 1.7
  */
-EINA_DEPRECATED EAPI Eina_Bool ecore_wl_dnd_start_drag(Ecore_Wl_Dnd *dnd);
+EINA_DEPRECATED ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_start_drag(Ecore_Wl_Dnd *dnd);
 
 /**
  * @deprecated use ecore_wl_dnd_selection_owner_has
  * @since 1.7
  */
-EINA_DEPRECATED EAPI Eina_Bool ecore_wl_dnd_selection_has_owner(Ecore_Wl_Dnd *dnd);
+EINA_DEPRECATED ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_selection_has_owner(Ecore_Wl_Dnd *dnd);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
@@ -742,7 +730,7 @@ EINA_DEPRECATED EAPI Eina_Bool ecore_wl_dnd_selection_has_owner(Ecore_Wl_Dnd *dn
  *
  * @since 1.8
  */
-EAPI Eina_Bool ecore_wl_dnd_selection_set(Ecore_Wl_Input *input, const char **types_offered);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_selection_set(Ecore_Wl_Input *input, const char **types_offered);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
@@ -750,7 +738,7 @@ EAPI Eina_Bool ecore_wl_dnd_selection_set(Ecore_Wl_Input *input, const char **ty
  *
  * @since 1.8
  */
-EAPI Eina_Bool ecore_wl_dnd_selection_get(Ecore_Wl_Input *input, const char *type);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_selection_get(Ecore_Wl_Input *input, const char *type);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
@@ -758,7 +746,7 @@ EAPI Eina_Bool ecore_wl_dnd_selection_get(Ecore_Wl_Input *input, const char *typ
  *
  * @since 1.8
  */
-EAPI Eina_Bool ecore_wl_dnd_selection_owner_has(Ecore_Wl_Input *input);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_selection_owner_has(Ecore_Wl_Input *input);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
@@ -766,19 +754,19 @@ EAPI Eina_Bool ecore_wl_dnd_selection_owner_has(Ecore_Wl_Input *input);
  *
  * @since 1.8
  */
-EAPI Eina_Bool ecore_wl_dnd_selection_clear(Ecore_Wl_Input *input);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_selection_clear(Ecore_Wl_Input *input);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI void ecore_wl_dnd_drag_start(Ecore_Wl_Input *input, Ecore_Wl_Window *win, Ecore_Wl_Window *dragwin, int x, int y, int w, int h);
+ECORE_WAYLAND_API void ecore_wl_dnd_drag_start(Ecore_Wl_Input *input, Ecore_Wl_Window *win, Ecore_Wl_Window *dragwin, int x, int y, int w, int h);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI void ecore_wl_dnd_drag_end(Ecore_Wl_Input *input);
+ECORE_WAYLAND_API void ecore_wl_dnd_drag_end(Ecore_Wl_Input *input);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
@@ -786,13 +774,13 @@ EAPI void ecore_wl_dnd_drag_end(Ecore_Wl_Input *input);
  *
  * @since 1.8
  */
-EAPI Eina_Bool ecore_wl_dnd_drag_get(Ecore_Wl_Input *input, const char *type);
+ECORE_WAYLAND_API Eina_Bool ecore_wl_dnd_drag_get(Ecore_Wl_Input *input, const char *type);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI void ecore_wl_dnd_drag_types_set(Ecore_Wl_Input *input, const char **types_offered);
+ECORE_WAYLAND_API void ecore_wl_dnd_drag_types_set(Ecore_Wl_Input *input, const char **types_offered);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
@@ -800,13 +788,13 @@ EAPI void ecore_wl_dnd_drag_types_set(Ecore_Wl_Input *input, const char **types_
  *
  * @since 1.8
  */
-EAPI struct wl_array *ecore_wl_dnd_drag_types_get(Ecore_Wl_Input *input);
+ECORE_WAYLAND_API struct wl_array *ecore_wl_dnd_drag_types_get(Ecore_Wl_Input *input);
 
 /**
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-/* EAPI Ecore_Wl_Dnd_Source *ecore_wl_dnd_drag_source_create(Ecore_Wl_Dnd *dnd); */
+/* ECORE_WAYLAND_API Ecore_Wl_Dnd_Source *ecore_wl_dnd_drag_source_create(Ecore_Wl_Dnd *dnd); */
 
 /**
  * Enables/disables server mode.
@@ -815,7 +803,7 @@ EAPI struct wl_array *ecore_wl_dnd_drag_types_get(Ecore_Wl_Input *input);
  * the display and dispatching events.  With it disabled, the process is
  * handled as a client.
  */
-EAPI void ecore_wl_server_mode_set(Eina_Bool on);
+ECORE_WAYLAND_API void ecore_wl_server_mode_set(Eina_Bool on);
 
 /**
  * @defgroup Ecore_Wl_Subsurf Functions to manipulate subsurfaces.
@@ -847,7 +835,7 @@ EAPI void ecore_wl_server_mode_set(Eina_Bool on);
  *
  * @since 1.8
  */
-EAPI Ecore_Wl_Subsurf *ecore_wl_subsurf_create(Ecore_Wl_Window *win);
+ECORE_WAYLAND_API Ecore_Wl_Subsurf *ecore_wl_subsurf_create(Ecore_Wl_Window *win);
 
 /**
  * @ingroup Ecore_Wl_Subsurf
@@ -857,7 +845,7 @@ EAPI Ecore_Wl_Subsurf *ecore_wl_subsurf_create(Ecore_Wl_Window *win);
  *
  * @since 1.8
  */
-EAPI void ecore_wl_subsurf_del(Ecore_Wl_Subsurf *ess);
+ECORE_WAYLAND_API void ecore_wl_subsurf_del(Ecore_Wl_Subsurf *ess);
 
 /**
  * @ingroup Ecore_Wl_Subsurf
@@ -868,7 +856,7 @@ EAPI void ecore_wl_subsurf_del(Ecore_Wl_Subsurf *ess);
  *
  * @since 1.8
  */
-EAPI struct wl_surface *ecore_wl_subsurf_surface_get(Ecore_Wl_Subsurf *ess);
+ECORE_WAYLAND_API struct wl_surface *ecore_wl_subsurf_surface_get(Ecore_Wl_Subsurf *ess);
 
 /**
  * @ingroup Ecore_Wl_Subsurf
@@ -882,7 +870,7 @@ EAPI struct wl_surface *ecore_wl_subsurf_surface_get(Ecore_Wl_Subsurf *ess);
  *
  * @since 1.8
  */
-EAPI void ecore_wl_subsurf_position_set(Ecore_Wl_Subsurf *ess, int x, int y);
+ECORE_WAYLAND_API void ecore_wl_subsurf_position_set(Ecore_Wl_Subsurf *ess, int x, int y);
 
 /**
  * @ingroup Ecore_Wl_Subsurf
@@ -895,7 +883,7 @@ EAPI void ecore_wl_subsurf_position_set(Ecore_Wl_Subsurf *ess, int x, int y);
  *
  * @since 1.8
  */
-EAPI void ecore_wl_subsurf_position_get(Ecore_Wl_Subsurf *ess, int *x, int *y);
+ECORE_WAYLAND_API void ecore_wl_subsurf_position_get(Ecore_Wl_Subsurf *ess, int *x, int *y);
 
 /**
  * @ingroup Ecore_Wl_Subsurf
@@ -911,7 +899,7 @@ EAPI void ecore_wl_subsurf_position_get(Ecore_Wl_Subsurf *ess, int *x, int *y);
  *
  * @since 1.8
  */
-EAPI void ecore_wl_subsurf_place_above(Ecore_Wl_Subsurf *ess, struct wl_surface *surface);
+ECORE_WAYLAND_API void ecore_wl_subsurf_place_above(Ecore_Wl_Subsurf *ess, struct wl_surface *surface);
 
 /**
  * @ingroup Ecore_Wl_Subsurf
@@ -924,7 +912,7 @@ EAPI void ecore_wl_subsurf_place_above(Ecore_Wl_Subsurf *ess, struct wl_surface 
  *
  * @since 1.8
  */
-EAPI void ecore_wl_subsurf_place_below(Ecore_Wl_Subsurf *ess, struct wl_surface *surface);
+ECORE_WAYLAND_API void ecore_wl_subsurf_place_below(Ecore_Wl_Subsurf *ess, struct wl_surface *surface);
 
 /**
  * @ingroup Ecore_Wl_Subsurf
@@ -952,7 +940,7 @@ EAPI void ecore_wl_subsurf_place_below(Ecore_Wl_Subsurf *ess, struct wl_surface 
  *
  * @since 1.8
  */
-EAPI void ecore_wl_subsurf_sync_set(Ecore_Wl_Subsurf *ess, Eina_Bool val);
+ECORE_WAYLAND_API void ecore_wl_subsurf_sync_set(Ecore_Wl_Subsurf *ess, Eina_Bool val);
 
 /**
  * @ingroup Ecore_Wl_Subsurf
@@ -972,13 +960,10 @@ EAPI void ecore_wl_subsurf_sync_set(Ecore_Wl_Subsurf *ess, Eina_Bool val);
  *
  * @since 1.8
  */
-EAPI void ecore_wl_subsurf_opaque_region_set(Ecore_Wl_Subsurf *ess, int x, int y, int w, int h);
+ECORE_WAYLAND_API void ecore_wl_subsurf_opaque_region_set(Ecore_Wl_Subsurf *ess, int x, int y, int w, int h);
 
 #ifdef __cplusplus
 }
 #endif
-
-#undef EAPI
-#define EAPI
 
 #endif

--- a/src/lib/ecore_wayland/ecore_wayland_api.h
+++ b/src/lib/ecore_wayland/ecore_wayland_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_ECORE_WAYLAND_API_H
+#define _EFL_ECORE_WAYLAND_API_H
+
+#ifdef ECORE_WAYLAND_API
+#error ECORE_WAYLAND_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef ECORE_WAYLAND_STATIC
+#  ifdef ECORE_WAYLAND_BUILD
+#   define ECORE_WAYLAND_API __declspec(dllexport)
+#  else
+#   define ECORE_WAYLAND_API __declspec(dllimport)
+#  endif
+# else
+#  define ECORE_WAYLAND_API
+# endif
+# define ECORE_WAYLAND_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define ECORE_WAYLAND_API __attribute__ ((visibility("default")))
+#   define ECORE_WAYLAND_API_WEAK __attribute__ ((weak))
+#  else
+#   define ECORE_WAYLAND_API
+#   define ECORE_WAYLAND_API_WEAK
+#  endif
+# else
+#  define ECORE_WAYLAND_API
+#  define ECORE_WAYLAND_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/ecore_wayland/ecore_wl.c
+++ b/src/lib/ecore_wayland/ecore_wl.c
@@ -81,22 +81,22 @@ static const struct xdg_shell_listener xdg_shell_listener =
 int _ecore_wl_log_dom = -1;
 Ecore_Wl_Display *_ecore_wl_disp = NULL;
 
-EAPI int ECORE_WL_EVENT_MOUSE_IN = 0;
-EAPI int ECORE_WL_EVENT_MOUSE_OUT = 0;
-EAPI int ECORE_WL_EVENT_FOCUS_IN = 0;
-EAPI int ECORE_WL_EVENT_FOCUS_OUT = 0;
-EAPI int ECORE_WL_EVENT_WINDOW_CONFIGURE = 0;
-EAPI int ECORE_WL_EVENT_DND_ENTER = 0;
-EAPI int ECORE_WL_EVENT_DND_POSITION = 0;
-EAPI int ECORE_WL_EVENT_DND_LEAVE = 0;
-EAPI int ECORE_WL_EVENT_DND_DROP = 0;
-EAPI int ECORE_WL_EVENT_DND_OFFER = 0;
-EAPI int ECORE_WL_EVENT_DND_END = 0;
-EAPI int ECORE_WL_EVENT_DATA_SOURCE_TARGET = 0;
-EAPI int ECORE_WL_EVENT_DATA_SOURCE_SEND = 0;
-EAPI int ECORE_WL_EVENT_SELECTION_DATA_READY = 0;
-EAPI int ECORE_WL_EVENT_DATA_SOURCE_CANCELLED = 0;
-EAPI int ECORE_WL_EVENT_INTERFACES_BOUND = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_MOUSE_IN = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_MOUSE_OUT = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_FOCUS_IN = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_FOCUS_OUT = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_WINDOW_CONFIGURE = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DND_ENTER = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DND_POSITION = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DND_LEAVE = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DND_DROP = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DND_OFFER = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DND_END = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DATA_SOURCE_TARGET = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DATA_SOURCE_SEND = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_SELECTION_DATA_READY = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_DATA_SOURCE_CANCELLED = 0;
+ECORE_WAYLAND_API int ECORE_WL_EVENT_INTERFACES_BOUND = 0;
 
 static void
 _ecore_wl_init_callback(void *data, struct wl_callback *callback, uint32_t serial EINA_UNUSED)
@@ -124,7 +124,7 @@ _ecore_wl_init_wait(void)
      }
 }
 
-EAPI int
+ECORE_WAYLAND_API int
 ecore_wl_init(const char *name)
 {
    struct wl_callback *callback;
@@ -237,7 +237,7 @@ exit_eina:
    return --_ecore_wl_init_count;
 }
 
-EAPI int
+ECORE_WAYLAND_API int
 ecore_wl_shutdown(void)
 {
    LOGFN;
@@ -245,14 +245,14 @@ ecore_wl_shutdown(void)
    return _ecore_wl_shutdown(EINA_TRUE);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_flush(void)
 {
    if ((!_ecore_wl_disp) || (!_ecore_wl_disp->wl.display)) return;
    wl_display_flush(_ecore_wl_disp->wl.display);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_sync(void)
 {
    int ret;
@@ -271,7 +271,7 @@ ecore_wl_sync(void)
      }
 }
 
-EAPI struct wl_shm *
+ECORE_WAYLAND_API struct wl_shm *
 ecore_wl_shm_get(void)
 {
    if (!_ecore_wl_disp) return NULL;
@@ -281,7 +281,7 @@ ecore_wl_shm_get(void)
    return _ecore_wl_disp->wl.shm;
 }
 
-EAPI struct wl_display *
+ECORE_WAYLAND_API struct wl_display *
 ecore_wl_display_get(void)
 {
    if ((!_ecore_wl_disp) || (!_ecore_wl_disp->wl.display))
@@ -289,7 +289,7 @@ ecore_wl_display_get(void)
    return _ecore_wl_disp->wl.display;
 }
 
-EAPI Eina_Inlist *
+ECORE_WAYLAND_API Eina_Inlist *
 ecore_wl_globals_get(void)
 {
    if ((!_ecore_wl_disp) || (!_ecore_wl_disp->wl.display))
@@ -300,7 +300,7 @@ ecore_wl_globals_get(void)
    return _ecore_wl_disp->globals;
 }
 
-EAPI struct wl_registry *
+ECORE_WAYLAND_API struct wl_registry *
 ecore_wl_registry_get(void)
 {
    if ((!_ecore_wl_disp) || (!_ecore_wl_disp->wl.display))
@@ -330,7 +330,7 @@ _ecore_wl_subcompositor_get(void)
    return _ecore_wl_disp->wl.subcompositor;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_screen_size_get(int *w, int *h)
 {
    Ecore_Wl_Output *out;
@@ -377,7 +377,7 @@ ecore_wl_screen_size_get(int *w, int *h)
 }
 
 /* @since 1.2 */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_pointer_xy_get(int *x, int *y)
 {
    LOGFN;
@@ -385,7 +385,7 @@ ecore_wl_pointer_xy_get(int *x, int *y)
    _ecore_wl_input_pointer_xy_get(x, y);
 }
 
-EAPI int
+ECORE_WAYLAND_API int
 ecore_wl_dpi_get(void)
 {
    int w, mw;
@@ -407,7 +407,7 @@ ecore_wl_dpi_get(void)
    return (((w * 254) / mw) + 5) / 10;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_display_iterate(void)
 {
    int ret;
@@ -425,7 +425,7 @@ ecore_wl_display_iterate(void)
 }
 
 /* @since 1.8 */
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_animator_source_set(Ecore_Animator_Source source)
 {
    LOGFN;
@@ -457,7 +457,7 @@ ecore_wl_animator_source_set(Ecore_Animator_Source source)
    return EINA_TRUE;
 }
 
-EAPI struct wl_cursor *
+ECORE_WAYLAND_API struct wl_cursor *
 ecore_wl_cursor_get(const char *cursor_name)
 {
    if ((!_ecore_wl_disp) || (!_ecore_wl_disp->cursor_theme))
@@ -467,7 +467,7 @@ ecore_wl_cursor_get(const char *cursor_name)
                                      cursor_name);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_server_mode_set(Eina_Bool on)
 {
    _ecore_wl_server_mode = on;

--- a/src/lib/ecore_wayland/ecore_wl_dnd.c
+++ b/src/lib/ecore_wayland/ecore_wl_dnd.c
@@ -82,7 +82,7 @@ _ecore_wl_dnd_offer_listener =
  * @deprecated use ecore_wl_dnd_selection_set
  * @since 1.7
 */
-EINA_DEPRECATED EAPI Eina_Bool
+EINA_DEPRECATED ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_set_selection(Ecore_Wl_Dnd *dnd, const char **types_offered)
 {
    LOGFN;
@@ -94,7 +94,7 @@ ecore_wl_dnd_set_selection(Ecore_Wl_Dnd *dnd, const char **types_offered)
  * @deprecated use ecore_wl_dnd_selection_get
  * @since 1.7
 */
-EINA_DEPRECATED EAPI Eina_Bool
+EINA_DEPRECATED ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_get_selection(Ecore_Wl_Dnd *dnd, const char *type)
 {
    LOGFN;
@@ -106,7 +106,7 @@ ecore_wl_dnd_get_selection(Ecore_Wl_Dnd *dnd, const char *type)
  * @deprecated Do Not Use
  * @since 1.7
  */
-EINA_DEPRECATED EAPI Ecore_Wl_Dnd *
+EINA_DEPRECATED ECORE_WAYLAND_API Ecore_Wl_Dnd *
 ecore_wl_dnd_get(void)
 {
    return NULL;
@@ -116,7 +116,7 @@ ecore_wl_dnd_get(void)
  * @deprecated use ecore_wl_dnd_drag_start
  * @since 1.7
  */
-EINA_DEPRECATED EAPI Eina_Bool
+EINA_DEPRECATED ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_start_drag(Ecore_Wl_Dnd *dnd EINA_UNUSED)
 {
    return EINA_FALSE;
@@ -126,7 +126,7 @@ ecore_wl_dnd_start_drag(Ecore_Wl_Dnd *dnd EINA_UNUSED)
  * @deprecated use ecore_wl_dnd_selection_owner_has
  * @since 1.7
  */
-EINA_DEPRECATED EAPI Eina_Bool
+EINA_DEPRECATED ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_selection_has_owner(Ecore_Wl_Dnd *dnd)
 {
    return ecore_wl_dnd_selection_owner_has(dnd->input);
@@ -136,7 +136,7 @@ ecore_wl_dnd_selection_has_owner(Ecore_Wl_Dnd *dnd)
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_selection_set(Ecore_Wl_Input *input, const char **types_offered)
 {
    struct wl_data_device_manager *man;
@@ -192,7 +192,7 @@ ecore_wl_dnd_selection_set(Ecore_Wl_Input *input, const char **types_offered)
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_selection_get(Ecore_Wl_Input *input, const char *type)
 {
    char **t;
@@ -218,7 +218,7 @@ ecore_wl_dnd_selection_get(Ecore_Wl_Input *input, const char *type)
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_selection_owner_has(Ecore_Wl_Input *input)
 {
    LOGFN;
@@ -231,7 +231,7 @@ ecore_wl_dnd_selection_owner_has(Ecore_Wl_Input *input)
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_selection_clear(Ecore_Wl_Input *input)
 {
    LOGFN;
@@ -250,7 +250,7 @@ ecore_wl_dnd_selection_clear(Ecore_Wl_Input *input)
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_dnd_drag_start(Ecore_Wl_Input *input, Ecore_Wl_Window *win, Ecore_Wl_Window *dragwin, int x EINA_UNUSED, int y EINA_UNUSED, int w EINA_UNUSED, int h EINA_UNUSED)
 {
    struct wl_surface *drag_surface;
@@ -307,7 +307,7 @@ ecore_wl_dnd_drag_start(Ecore_Wl_Input *input, Ecore_Wl_Window *win, Ecore_Wl_Wi
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_dnd_drag_end(Ecore_Wl_Input *input)
 {
    Ecore_Wl_Event_Dnd_End *ev;
@@ -349,7 +349,7 @@ ecore_wl_dnd_drag_end(Ecore_Wl_Input *input)
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_dnd_drag_get(Ecore_Wl_Input *input, const char *type)
 {
    char **t;
@@ -373,7 +373,7 @@ ecore_wl_dnd_drag_get(Ecore_Wl_Input *input, const char *type)
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_dnd_drag_types_set(Ecore_Wl_Input *input, const char **types_offered)
 {
    struct wl_data_device_manager *man;
@@ -423,7 +423,7 @@ ecore_wl_dnd_drag_types_set(Ecore_Wl_Input *input, const char **types_offered)
  * @ingroup Ecore_Wl_Dnd_Group
  * @since 1.8
  */
-EAPI struct wl_array *
+ECORE_WAYLAND_API struct wl_array *
 ecore_wl_dnd_drag_types_get(Ecore_Wl_Input *input)
 {
    LOGFN;

--- a/src/lib/ecore_wayland/ecore_wl_input.c
+++ b/src/lib/ecore_wayland/ecore_wl_input.c
@@ -147,7 +147,7 @@ static const struct wl_callback_listener _ecore_wl_pointer_surface_listener =
 /* local variables */
 static int _pointer_x, _pointer_y;
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_input_grab(Ecore_Wl_Input *input, Ecore_Wl_Window *win, unsigned int button)
 {
    LOGFN;
@@ -157,7 +157,7 @@ ecore_wl_input_grab(Ecore_Wl_Input *input, Ecore_Wl_Window *win, unsigned int bu
    input->grab_button = button;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_input_ungrab(Ecore_Wl_Input *input)
 {
    LOGFN;
@@ -201,7 +201,7 @@ _pointer_update_stop(Ecore_Wl_Input *input)
    input->cursor_timer = NULL;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_input_pointer_set(Ecore_Wl_Input *input, struct wl_surface *surface, int hot_x, int hot_y)
 {
    LOGFN;
@@ -214,7 +214,7 @@ ecore_wl_input_pointer_set(Ecore_Wl_Input *input, struct wl_surface *surface, in
                            surface, hot_x, hot_y);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_input_cursor_size_set(Ecore_Wl_Input *input, const int size)
 {
    LOGFN;
@@ -231,7 +231,7 @@ ecore_wl_input_cursor_size_set(Ecore_Wl_Input *input, const int size)
      wl_cursor_theme_load(NULL, input->cursor_size, input->display->wl.shm);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_input_cursor_theme_name_set(Ecore_Wl_Input *input, const char *cursor_theme_name)
 {
    LOGFN;
@@ -249,7 +249,7 @@ ecore_wl_input_cursor_theme_name_set(Ecore_Wl_Input *input, const char *cursor_t
                           input->display->wl.shm);
 }
 
-EAPI struct xkb_keymap *
+ECORE_WAYLAND_API struct xkb_keymap *
 ecore_wl_input_keymap_get(Ecore_Wl_Input *input)
 {
    LOGFN;
@@ -303,7 +303,7 @@ _ecore_wl_input_cursor_update(void *data)
    return ECORE_CALLBACK_RENEW;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_input_cursor_from_name_set(Ecore_Wl_Input *input, const char *cursor_name)
 {
    struct wl_cursor *cursor;
@@ -343,7 +343,7 @@ ecore_wl_input_cursor_from_name_set(Ecore_Wl_Input *input, const char *cursor_na
    _ecore_wl_input_cursor_update(input);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_input_cursor_default_restore(Ecore_Wl_Input *input)
 {
    LOGFN;
@@ -357,7 +357,7 @@ ecore_wl_input_cursor_default_restore(Ecore_Wl_Input *input)
 /**
  * @since 1.8
  */
-EAPI Ecore_Wl_Input *
+ECORE_WAYLAND_API Ecore_Wl_Input *
 ecore_wl_input_get(void)
 {
    return _ecore_wl_disp->input;
@@ -366,7 +366,7 @@ ecore_wl_input_get(void)
 /**
  * @since 1.8
  */
-EAPI struct wl_seat *
+ECORE_WAYLAND_API struct wl_seat *
 ecore_wl_input_seat_get(Ecore_Wl_Input *input)
 {
    LOGFN;

--- a/src/lib/ecore_wayland/ecore_wl_output.c
+++ b/src/lib/ecore_wayland/ecore_wl_output.c
@@ -63,7 +63,7 @@ static const struct wl_output_listener _ecore_wl_output_listener =
 
 /* Get list of available outputs
  * @since 1.2 */
-EAPI Eina_Inlist *
+ECORE_WAYLAND_API Eina_Inlist *
 ecore_wl_outputs_get(void)
 {
    return _ecore_wl_disp->outputs;

--- a/src/lib/ecore_wayland/ecore_wl_subsurf.c
+++ b/src/lib/ecore_wayland/ecore_wl_subsurf.c
@@ -27,7 +27,7 @@ struct _Ecore_Wl_Subsurf
    Eina_Bool sync : 1;
 };
 
-EAPI Ecore_Wl_Subsurf *
+ECORE_WAYLAND_API Ecore_Wl_Subsurf *
 ecore_wl_subsurf_create(Ecore_Wl_Window *win)
 {
    struct wl_subsurface *subsurface;
@@ -86,7 +86,7 @@ _ecore_wl_subsurf_destroy(Ecore_Wl_Subsurf *ess)
    free(ess);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_subsurf_del(Ecore_Wl_Subsurf *ess)
 {
    LOGFN;
@@ -109,7 +109,7 @@ _ecore_wl_subsurfs_del_all(Ecore_Wl_Window *win)
      }
 }
 
-EAPI struct wl_surface *
+ECORE_WAYLAND_API struct wl_surface *
 ecore_wl_subsurf_surface_get(Ecore_Wl_Subsurf *ess)
 {
    LOGFN;
@@ -119,7 +119,7 @@ ecore_wl_subsurf_surface_get(Ecore_Wl_Subsurf *ess)
    return ess->surface;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_subsurf_position_set(Ecore_Wl_Subsurf *ess, int x, int y)
 {
    LOGFN;
@@ -136,7 +136,7 @@ ecore_wl_subsurf_position_set(Ecore_Wl_Subsurf *ess, int x, int y)
    wl_subsurface_set_position(ess->subsurface, x, y);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_subsurf_position_get(Ecore_Wl_Subsurf *ess, int *x, int *y)
 {
    LOGFN;
@@ -147,7 +147,7 @@ ecore_wl_subsurf_position_get(Ecore_Wl_Subsurf *ess, int *x, int *y)
    if (y) *y = ess->y;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_subsurf_place_above(Ecore_Wl_Subsurf *ess, struct wl_surface *surface)
 {
    LOGFN;
@@ -159,7 +159,7 @@ ecore_wl_subsurf_place_above(Ecore_Wl_Subsurf *ess, struct wl_surface *surface)
    wl_subsurface_place_above(ess->subsurface, surface);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_subsurf_place_below(Ecore_Wl_Subsurf *ess, struct wl_surface *surface)
 {
    LOGFN;
@@ -171,7 +171,7 @@ ecore_wl_subsurf_place_below(Ecore_Wl_Subsurf *ess, struct wl_surface *surface)
    wl_subsurface_place_below(ess->subsurface, surface);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_subsurf_sync_set(Ecore_Wl_Subsurf *ess, Eina_Bool val)
 {
    LOGFN;
@@ -190,7 +190,7 @@ ecore_wl_subsurf_sync_set(Ecore_Wl_Subsurf *ess, Eina_Bool val)
      wl_subsurface_set_desync(ess->subsurface);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_subsurf_opaque_region_set(Ecore_Wl_Subsurf *ess, int x, int y, int w, int h)
 {
    struct wl_region *region = NULL;

--- a/src/lib/ecore_wayland/ecore_wl_window.c
+++ b/src/lib/ecore_wayland/ecore_wl_window.c
@@ -190,7 +190,7 @@ _ecore_wl_window_shell_surface_init(Ecore_Wl_Window *win)
      }
 }
 
-EAPI Ecore_Wl_Window *
+ECORE_WAYLAND_API Ecore_Wl_Window *
 ecore_wl_window_new(Ecore_Wl_Window *parent, int x, int y, int w, int h, int buffer_type)
 {
    Ecore_Wl_Window *win;
@@ -231,7 +231,7 @@ ecore_wl_window_new(Ecore_Wl_Window *parent, int x, int y, int w, int h, int buf
    return win;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_free(Ecore_Wl_Window *win)
 {
    Ecore_Wl_Input *input;
@@ -280,7 +280,7 @@ ecore_wl_window_free(Ecore_Wl_Window *win)
    free(win);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_move(Ecore_Wl_Window *win, int x, int y)
 {
    Ecore_Wl_Input *input;
@@ -309,7 +309,7 @@ ecore_wl_window_move(Ecore_Wl_Window *win, int x, int y)
                            input->display->serial);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_resize(Ecore_Wl_Window *win, int w EINA_UNUSED, int h EINA_UNUSED, int location)
 {
    Ecore_Wl_Input *input;
@@ -338,7 +338,7 @@ ecore_wl_window_resize(Ecore_Wl_Window *win, int w EINA_UNUSED, int h EINA_UNUSE
                              input->display->serial, location);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_damage(Ecore_Wl_Window *win, int x, int y, int w, int h)
 {
    LOGFN;
@@ -348,7 +348,7 @@ ecore_wl_window_damage(Ecore_Wl_Window *win, int x, int y, int w, int h)
    if (win->surface) wl_surface_damage(win->surface, x, y, w, h);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_commit(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -359,7 +359,7 @@ ecore_wl_window_commit(Ecore_Wl_Window *win)
      wl_surface_commit(win->surface);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_buffer_attach(Ecore_Wl_Window *win, struct wl_buffer *buffer, int x, int y)
 {
    LOGFN;
@@ -388,7 +388,7 @@ ecore_wl_window_buffer_attach(Ecore_Wl_Window *win, struct wl_buffer *buffer, in
      }
 }
 
-EAPI struct wl_surface *
+ECORE_WAYLAND_API struct wl_surface *
 ecore_wl_window_surface_create(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -415,7 +415,7 @@ ecore_wl_window_surface_create(Ecore_Wl_Window *win)
    return win->surface;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_show(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -427,7 +427,7 @@ ecore_wl_window_show(Ecore_Wl_Window *win)
    _ecore_wl_window_shell_surface_init(win);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_hide(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -447,7 +447,7 @@ ecore_wl_window_hide(Ecore_Wl_Window *win)
    win->surface = NULL;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_raise(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -459,7 +459,7 @@ ecore_wl_window_raise(Ecore_Wl_Window *win)
      wl_shell_surface_set_toplevel(win->shell_surface);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_maximized_set(Ecore_Wl_Window *win, Eina_Bool maximized)
 {
    Eina_Bool prev;
@@ -491,7 +491,7 @@ ecore_wl_window_maximized_set(Ecore_Wl_Window *win, Eina_Bool maximized)
    win->maximized = maximized;
 }
 
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_window_maximized_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -501,7 +501,7 @@ ecore_wl_window_maximized_get(Ecore_Wl_Window *win)
    return win->maximized;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_fullscreen_set(Ecore_Wl_Window *win, Eina_Bool fullscreen)
 {
    Eina_Bool prev;
@@ -538,7 +538,7 @@ ecore_wl_window_fullscreen_set(Ecore_Wl_Window *win, Eina_Bool fullscreen)
    win->fullscreen = fullscreen;
 }
 
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_window_fullscreen_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -548,7 +548,7 @@ ecore_wl_window_fullscreen_get(Ecore_Wl_Window *win)
    return win->fullscreen;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_transparent_set(Ecore_Wl_Window *win, Eina_Bool transparent)
 {
    LOGFN;
@@ -563,7 +563,7 @@ ecore_wl_window_transparent_set(Ecore_Wl_Window *win, Eina_Bool transparent)
      ecore_wl_window_opaque_region_set(win, win->opaque.x, win->opaque.y, 0, 0);
 }
 
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_window_alpha_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -573,7 +573,7 @@ ecore_wl_window_alpha_get(Ecore_Wl_Window *win)
    return win->alpha;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_alpha_set(Ecore_Wl_Window *win, Eina_Bool alpha)
 {
    LOGFN;
@@ -588,7 +588,7 @@ ecore_wl_window_alpha_set(Ecore_Wl_Window *win, Eina_Bool alpha)
      ecore_wl_window_opaque_region_set(win, win->opaque.x, win->opaque.y, 0, 0);
 }
 
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_window_transparent_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -598,7 +598,7 @@ ecore_wl_window_transparent_get(Ecore_Wl_Window *win)
    return win->transparent;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_update_size(Ecore_Wl_Window *win, int w, int h)
 {
    LOGFN;
@@ -619,7 +619,7 @@ ecore_wl_window_update_size(Ecore_Wl_Window *win, int w, int h)
                                      win->allocation.w, win->allocation.h);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_update_location(Ecore_Wl_Window *win, int x, int y)
 {
    LOGFN;
@@ -635,7 +635,7 @@ ecore_wl_window_update_location(Ecore_Wl_Window *win, int x, int y)
                                      win->allocation.w, win->allocation.h);
 }
 
-EAPI struct wl_surface *
+ECORE_WAYLAND_API struct wl_surface *
 ecore_wl_window_surface_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -646,7 +646,7 @@ ecore_wl_window_surface_get(Ecore_Wl_Window *win)
 }
 
 /* @since 1.2 */
-EAPI struct wl_shell_surface *
+ECORE_WAYLAND_API struct wl_shell_surface *
 ecore_wl_window_shell_surface_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -657,7 +657,7 @@ ecore_wl_window_shell_surface_get(Ecore_Wl_Window *win)
 }
 
 /* @since 1.11 */
-EAPI struct xdg_surface *
+ECORE_WAYLAND_API struct xdg_surface *
 ecore_wl_window_xdg_surface_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -667,7 +667,7 @@ ecore_wl_window_xdg_surface_get(Ecore_Wl_Window *win)
    return win->xdg_surface;
 }
 
-EAPI Ecore_Wl_Window *
+ECORE_WAYLAND_API Ecore_Wl_Window *
 ecore_wl_window_find(unsigned int id)
 {
    Ecore_Wl_Window *win = NULL;
@@ -677,7 +677,7 @@ ecore_wl_window_find(unsigned int id)
    return win;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_type_set(Ecore_Wl_Window *win, Ecore_Wl_Window_Type type)
 {
    LOGFN;
@@ -687,7 +687,7 @@ ecore_wl_window_type_set(Ecore_Wl_Window *win, Ecore_Wl_Window_Type type)
    win->type = type;
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_pointer_set(Ecore_Wl_Window *win, struct wl_surface *surface, int hot_x, int hot_y)
 {
    Ecore_Wl_Input *input;
@@ -705,7 +705,7 @@ ecore_wl_window_pointer_set(Ecore_Wl_Window *win, struct wl_surface *surface, in
      ecore_wl_input_pointer_set(input, surface, hot_x, hot_y);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_cursor_from_name_set(Ecore_Wl_Window *win, const char *cursor_name)
 {
    Ecore_Wl_Input *input;
@@ -725,7 +725,7 @@ ecore_wl_window_cursor_from_name_set(Ecore_Wl_Window *win, const char *cursor_na
      ecore_wl_input_cursor_from_name_set(input, cursor_name);
 }
 
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_cursor_default_restore(Ecore_Wl_Window *win)
 {
    Ecore_Wl_Input *input;
@@ -741,7 +741,7 @@ ecore_wl_window_cursor_default_restore(Ecore_Wl_Window *win)
 }
 
 /* @since 1.2 */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_parent_set(Ecore_Wl_Window *win, Ecore_Wl_Window *parent)
 {
    LOGFN;
@@ -752,7 +752,7 @@ ecore_wl_window_parent_set(Ecore_Wl_Window *win, Ecore_Wl_Window *parent)
 }
 
 /* @since 1.12 */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_iconified_set(Ecore_Wl_Window *win, Eina_Bool iconified)
 {
    Eina_Bool prev;
@@ -795,7 +795,7 @@ ecore_wl_window_iconified_set(Ecore_Wl_Window *win, Eina_Bool iconified)
    win->minimized = iconified;
 }
 
-EAPI Eina_Bool
+ECORE_WAYLAND_API Eina_Bool
 ecore_wl_window_iconified_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -805,7 +805,7 @@ ecore_wl_window_iconified_get(Ecore_Wl_Window *win)
    return win->minimized;
 }
 
-EAPI Ecore_Wl_Window *
+ECORE_WAYLAND_API Ecore_Wl_Window *
 ecore_wl_window_surface_find(struct wl_surface *surface)
 {
    Eina_Iterator *itr;
@@ -830,7 +830,7 @@ ecore_wl_window_surface_find(struct wl_surface *surface)
 }
 
 /* @since 1.8 */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_input_region_set(Ecore_Wl_Window *win, int x, int y, int w, int h)
 {
    LOGFN;
@@ -871,7 +871,7 @@ ecore_wl_window_input_region_set(Ecore_Wl_Window *win, int x, int y, int w, int 
 }
 
 /* @since 1.8 */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_opaque_region_set(Ecore_Wl_Window *win, int x, int y, int w, int h)
 {
    struct wl_region *region;
@@ -911,7 +911,7 @@ ecore_wl_window_opaque_region_set(Ecore_Wl_Window *win, int x, int y, int w, int
 }
 
 /* @since 1.8 */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_rotation_set(Ecore_Wl_Window *win, int rotation)
 {
    LOGFN;
@@ -922,7 +922,7 @@ ecore_wl_window_rotation_set(Ecore_Wl_Window *win, int rotation)
 }
 
 /* @since 1.8 */
-EAPI int
+ECORE_WAYLAND_API int
 ecore_wl_window_rotation_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -933,7 +933,7 @@ ecore_wl_window_rotation_get(Ecore_Wl_Window *win)
 }
 
 /* @since 1.8 */
-EAPI int
+ECORE_WAYLAND_API int
 ecore_wl_window_id_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -944,7 +944,7 @@ ecore_wl_window_id_get(Ecore_Wl_Window *win)
 }
 
 /* @since 1.8 */
-EAPI int
+ECORE_WAYLAND_API int
 ecore_wl_window_surface_id_get(Ecore_Wl_Window *win)
 {
    LOGFN;
@@ -955,7 +955,7 @@ ecore_wl_window_surface_id_get(Ecore_Wl_Window *win)
 }
 
 /* @since 1.8 */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_title_set(Ecore_Wl_Window *win, const char *title)
 {
    LOGFN;
@@ -971,7 +971,7 @@ ecore_wl_window_title_set(Ecore_Wl_Window *win, const char *title)
 }
 
 /* @since 1.8 */
-EAPI void
+ECORE_WAYLAND_API void
 ecore_wl_window_class_name_set(Ecore_Wl_Window *win, const char *class_name)
 {
    LOGFN;
@@ -988,7 +988,7 @@ ecore_wl_window_class_name_set(Ecore_Wl_Window *win, const char *class_name)
 
 /* @since 1.8 */
 /* Maybe we need an ecore_wl_window_pointer_get() too */
-EAPI Ecore_Wl_Input *
+ECORE_WAYLAND_API Ecore_Wl_Input *
 ecore_wl_window_keyboard_get(Ecore_Wl_Window *win)
 {
    LOGFN;

--- a/src/lib/ecore_wayland/meson.build
+++ b/src/lib/ecore_wayland/meson.build
@@ -28,7 +28,7 @@ ecore_wayland_lib = library('ecore_wayland',
     dependencies: [m] + ecore_wayland_deps + ecore_wayland_pub_deps,
     include_directories : config_dir + [include_directories(join_paths('..','..'))],
     install: true,
-    c_args : package_c_args,
+    c_args : [package_c_args, '-DECORE_WAYLAND_BUILD'],
 )
 
 ecore_wayland = declare_dependency(

--- a/src/lib/ecore_wayland/meson.build
+++ b/src/lib/ecore_wayland/meson.build
@@ -20,6 +20,7 @@ ecore_wayland_src = [
 ]
 ecore_wayland_header_src = [
   'Ecore_Wayland.h'
+  'ecore_wayland_api.h'
 ]
 
 


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.