### PR TITLE
[modules] Bug: Remove remaining EWAPI

### DIFF
--- a/src/modules/elementary/web/none/elm_web_none_eo.h
+++ b/src/modules/elementary/web/none/elm_web_none_eo.h
@@ -19,6 +19,6 @@ typedef Eo Elm_Web_None;
  */
 #define ELM_WEB_NONE_CLASS elm_web_none_class_get()
 
-EWAPI const Efl_Class *elm_web_none_class_get(void);
+EMODAPI EMODAPI_WEAK const Efl_Class *elm_web_none_class_get(void);
 
 #endif


### PR DESCRIPTION
There was stil a EWAPI which [yields](https://travis-ci.com/github/expertisesolutions/efl/builds/174202249#L2290):
```
In file included from ../src/modules/elementary/web/none/elm_web_none.c:17:
../src/modules/elementary/web/none/elm_web_none_eo.h:22:6: error: expected ';' before 'const'
   22 | EWAPI const Efl_Class *elm_web_none_class_get(void);
      |      ^~~~~~
      |      ;
```