### PR TITLE
Fixing undefined useconds_t

### DIFF
--- a/src/lib/evas/common/evas_image_scalecache.c
+++ b/src/lib/evas/common/evas_image_scalecache.c
@@ -2,7 +2,7 @@
 # include "config.h"
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 # include <evil_private.h>
 #endif
 

--- a/src/lib/evas/common/evas_image_scalecache.c
+++ b/src/lib/evas/common/evas_image_scalecache.c
@@ -2,12 +2,8 @@
 # include "config.h"
 #endif
 
-#ifdef _WIN32
-# ifndef WIN32_LEAN_AND_MEAN
-#  define WIN32_LEAN_AND_MEAN
-# endif
-# include <windows.h>
-# undef WIN32_LEAN_AND_MEAN
+#ifdef _MSC_VER
+# include <evil_private.h>
 #endif
 
 #include <assert.h>
@@ -541,11 +537,7 @@ evas_common_rgba_image_scalecache_prepare(Image_Entry *ie, RGBA_Image *dst EINA_
         
         while (slpt < 500000)
           {
-#ifdef _WIN32
-             Sleep(slp / 1000);
-#else
              usleep(slp);
-#endif
              slpt += slp;
              slp++;
              ret = SLKT(im->cache.lock);

--- a/src/lib/evil/evil_unistd.c
+++ b/src/lib/evil/evil_unistd.c
@@ -95,7 +95,7 @@ evil_time_get(void)
 
 #ifdef _MSC_VER
 EVIL_API void
-usleep(uint64_t usec) 
+usleep(useconds_t usec) 
 { 
    HANDLE timer; 
    LARGE_INTEGER ft; 

--- a/src/lib/evil/evil_unistd.h
+++ b/src/lib/evil/evil_unistd.h
@@ -62,8 +62,9 @@ EVIL_API int ftruncate(int fd, off_t size);
 EVIL_API double evil_time_get(void);
 
 #ifdef _MSC_VER
-# include <stdint.h>
-EVIL_API void usleep(uint64_t usec);
+typedef unsigned long useconds_t;
+
+EVIL_API void usleep(useconds_t usec);
 #endif
 
 /*

--- a/src/lib/evil/evil_unistd.h
+++ b/src/lib/evil/evil_unistd.h
@@ -62,7 +62,7 @@ EVIL_API int ftruncate(int fd, off_t size);
 EVIL_API double evil_time_get(void);
 
 #ifdef _MSC_VER
-typedef unsigned long useconds_t;
+typedef unsigned int useconds_t;
 
 EVIL_API void usleep(useconds_t usec);
 #endif


### PR DESCRIPTION
 * now `usleep()` is implemented in evil (PR #192), then we don't need to keep the `Sleep()` specifically for windows, and then we don't need to include `windows.h` here.

 * stdint.h include removed because it was only needed because of uint64_t.

 * from [IEEE](https://pubs.opengroup.org/onlinepubs/007904975/basedefs/sys/types.h.html): _The type useconds_t shall be an unsigned integer type capable of storing values at least in the range [0, 1000000]. The type suseconds_t shall be a signed integer type capable of storing values at least in the range [-1, 1000000]._, -> then it is here defined as `unsigned int`.