### PR TITLE
Add LIB_API.h to files to be installed

### DIFF
--- a/src/lib/ecore/meson.build
+++ b/src/lib/ecore/meson.build
@@ -90,6 +90,7 @@ eolian_include_directories += ['-I', meson.current_source_dir()]
 
 ecore_header_src = [
   'Ecore.h',
+  'ecore_api.h',
   'Ecore_Common.h',
   'Ecore_Legacy.h',
   'Ecore_Eo.h',

--- a/src/lib/ecore_audio/meson.build
+++ b/src/lib/ecore_audio/meson.build
@@ -32,6 +32,7 @@ pub_eo_types_files = []
 
 ecore_audio_header_src = [
   'Ecore_Audio.h',
+  'ecore_audio_api.h',
   'ecore_audio_obj.h',
   'ecore_audio_obj_in.h',
   'ecore_audio_obj_out.h',

--- a/src/lib/ecore_avahi/meson.build
+++ b/src/lib/ecore_avahi/meson.build
@@ -2,7 +2,7 @@ ecore_avahi_deps = []
 ecore_avahi_pub_deps = [eina, ecore]
 
 ecore_avahi_src = ['ecore_avahi.c']
-ecore_avahi_header_src = ['Ecore_Avahi.h']
+ecore_avahi_header_src = ['Ecore_Avahi.h', 'ecore_avahi_api.h']
 
 ecore_avahi_deps += dependency('avahi-client')
 config_h.set('HAVE_AVAHI', '1')

--- a/src/lib/ecore_buffer/meson.build
+++ b/src/lib/ecore_buffer/meson.build
@@ -4,6 +4,7 @@ ecore_buffer_ext_deps = [dependency('wayland-client'), dependency('wayland-serve
 
 ecore_buffer_header_src = [
   'Ecore_Buffer.h',
+  'ecore_buffer_api.h',
   'Ecore_Buffer_Queue.h'
 ]
 

--- a/src/lib/ecore_cocoa/meson.build
+++ b/src/lib/ecore_cocoa/meson.build
@@ -10,6 +10,7 @@ pub_eo_file_target = []
 
 ecore_cocoa_header_src = [
   'Ecore_Cocoa.h'
+  'ecore_cocoa_api.h',
 ]
 
 ecore_cocoa_src = files([

--- a/src/lib/ecore_cocoa/meson.build
+++ b/src/lib/ecore_cocoa/meson.build
@@ -9,7 +9,7 @@ ecore_cocoa_ext_deps = [cocoa_external_dep]
 pub_eo_file_target = []
 
 ecore_cocoa_header_src = [
-  'Ecore_Cocoa.h'
+  'Ecore_Cocoa.h',
   'ecore_cocoa_api.h',
 ]
 

--- a/src/lib/ecore_con/meson.build
+++ b/src/lib/ecore_con/meson.build
@@ -100,6 +100,7 @@ eolian_include_directories += ['-I', meson.current_source_dir()]
 
 ecore_con_header_src = [
   'Ecore_Con.h',
+  'ecore_con_api.h',
   'Efl_Net.h',
   'Ecore_Con_Eet.h',
   'Ecore_Con_Eet_Legacy.h',

--- a/src/lib/ecore_drm/meson.build
+++ b/src/lib/ecore_drm/meson.build
@@ -17,6 +17,7 @@ ecore_drm_src = [
 ]
 ecore_drm_header_src = [
   'Ecore_Drm.h'
+  'ecore_drm_api.h'
 ]
 
 

--- a/src/lib/ecore_drm/meson.build
+++ b/src/lib/ecore_drm/meson.build
@@ -16,8 +16,8 @@ ecore_drm_src = [
   'ecore_drm_private.h'
 ]
 ecore_drm_header_src = [
-  'Ecore_Drm.h'
-  'ecore_drm_api.h'
+  'Ecore_Drm.h',
+  'ecore_drm_api.h',
 ]
 
 

--- a/src/lib/ecore_drm2/meson.build
+++ b/src/lib/ecore_drm2/meson.build
@@ -3,8 +3,8 @@ ecore_drm2_pub_deps = [ecore]
 ecore_drm2_ext_deps = [dl, libdrm]
 
 ecore_drm2_header_src = [
-  'Ecore_Drm2.h'
-  'ecore_drm2_api.h'
+  'Ecore_Drm2.h',
+  'ecore_drm2_api.h',
 ]
 
 ecore_drm2_src = files([

--- a/src/lib/ecore_drm2/meson.build
+++ b/src/lib/ecore_drm2/meson.build
@@ -4,6 +4,7 @@ ecore_drm2_ext_deps = [dl, libdrm]
 
 ecore_drm2_header_src = [
   'Ecore_Drm2.h'
+  'ecore_drm2_api.h'
 ]
 
 ecore_drm2_src = files([

--- a/src/lib/ecore_file/meson.build
+++ b/src/lib/ecore_file/meson.build
@@ -18,7 +18,7 @@ else
   ecore_file_src += files([ 'ecore_file_monitor_poll.c'])
 endif
 
-ecore_file_header_src = ['Ecore_File.h']
+ecore_file_header_src = ['Ecore_File.h', 'ecore_file_api.h']
 
 
 ecore_file_lib = library('ecore_file',

--- a/src/lib/ecore_imf/meson.build
+++ b/src/lib/ecore_imf/meson.build
@@ -4,6 +4,7 @@ ecore_imf_ext_deps = [buildsystem_simple]
 
 ecore_imf_header_src = [
    'Ecore_IMF.h'
+   'ecore_imf_api.h'
 ]
 
 ecore_imf_src = files([

--- a/src/lib/ecore_imf/meson.build
+++ b/src/lib/ecore_imf/meson.build
@@ -3,8 +3,8 @@ ecore_imf_pub_deps = [eina]
 ecore_imf_ext_deps = [buildsystem_simple]
 
 ecore_imf_header_src = [
-   'Ecore_IMF.h'
-   'ecore_imf_api.h'
+   'Ecore_IMF.h',
+   'ecore_imf_api.h',
 ]
 
 ecore_imf_src = files([

--- a/src/lib/ecore_input/meson.build
+++ b/src/lib/ecore_input/meson.build
@@ -3,8 +3,8 @@ ecore_input_pub_deps = [eina, eo]
 ecore_input_ext_deps = []
 
 ecore_input_header_src = [
-  'Ecore_Input.h'
-  'ecore_input_api.h'
+  'Ecore_Input.h,'
+  'ecore_input_api.h',
 ]
 
 ecore_input_src = files([

--- a/src/lib/ecore_input/meson.build
+++ b/src/lib/ecore_input/meson.build
@@ -3,7 +3,7 @@ ecore_input_pub_deps = [eina, eo]
 ecore_input_ext_deps = []
 
 ecore_input_header_src = [
-  'Ecore_Input.h,'
+  'Ecore_Input.h',
   'ecore_input_api.h',
 ]
 

--- a/src/lib/ecore_input/meson.build
+++ b/src/lib/ecore_input/meson.build
@@ -4,6 +4,7 @@ ecore_input_ext_deps = []
 
 ecore_input_header_src = [
   'Ecore_Input.h'
+  'ecore_input_api.h'
 ]
 
 ecore_input_src = files([

--- a/src/lib/ecore_input_evas/meson.build
+++ b/src/lib/ecore_input_evas/meson.build
@@ -4,8 +4,8 @@ ecore_input_evas_ext_deps = []
 pub_eo_file_target = []
 
 ecore_input_evas_header_src = [
-   'Ecore_Input_Evas.h'
-   'ecore_input_evas_api.h'
+   'Ecore_Input_Evas.h',
+   'ecore_input_evas_api.h',
 ]
 
 ecore_input_evas_src = files([

--- a/src/lib/ecore_input_evas/meson.build
+++ b/src/lib/ecore_input_evas/meson.build
@@ -5,6 +5,7 @@ pub_eo_file_target = []
 
 ecore_input_evas_header_src = [
    'Ecore_Input_Evas.h'
+   'ecore_input_evas_api.h'
 ]
 
 ecore_input_evas_src = files([

--- a/src/lib/ecore_ipc/meson.build
+++ b/src/lib/ecore_ipc/meson.build
@@ -2,8 +2,8 @@ ecore_ipc_deps = [ecore, ecore_con]
 ecore_ipc_pub_deps = [eina]
 ecore_ipc_ext_deps = []
 ecore_ipc_header_src = [
-  'Ecore_Ipc.h'
-  'ecore_ipc_api.h'
+  'Ecore_Ipc.h',
+  'ecore_ipc_api.h',
 ]
 
 ecore_ipc_src = files([

--- a/src/lib/ecore_ipc/meson.build
+++ b/src/lib/ecore_ipc/meson.build
@@ -3,6 +3,7 @@ ecore_ipc_pub_deps = [eina]
 ecore_ipc_ext_deps = []
 ecore_ipc_header_src = [
   'Ecore_Ipc.h'
+  'ecore_ipc_api.h'
 ]
 
 ecore_ipc_src = files([

--- a/src/lib/ecore_win32/meson.build
+++ b/src/lib/ecore_win32/meson.build
@@ -23,8 +23,8 @@ if sys_windows == true
   ])
 
   ecore_win32_header_src = [
-    'Ecore_Win32.h'
-    'ecore_win32_api.h'
+    'Ecore_Win32.h',
+    'ecore_win32_api.h',
   ]
 
   ecore_win32_lib = library('ecore_win32',

--- a/src/lib/ecore_win32/meson.build
+++ b/src/lib/ecore_win32/meson.build
@@ -24,6 +24,7 @@ if sys_windows == true
 
   ecore_win32_header_src = [
     'Ecore_Win32.h'
+    'ecore_win32_api.h'
   ]
 
   ecore_win32_lib = library('ecore_win32',

--- a/src/lib/ecore_x/meson.build
+++ b/src/lib/ecore_x/meson.build
@@ -4,6 +4,7 @@ ecore_x_ext_deps = [dl, m]
 
 ecore_x_header_src = [
   'Ecore_X.h',
+  'ecore_x_api.h',
   'Ecore_X_Atoms.h',
   'Ecore_X_Cursor.h'
 ]

--- a/src/lib/edje/meson.build
+++ b/src/lib/edje/meson.build
@@ -96,6 +96,7 @@ eolian_include_directories += ['-I', meson.current_source_dir()]
 
 edje_header_src = [
   'Edje.h',
+  'edje_api.h',
   'Efl_Layout.h',
   'Edje_Common.h',
   'Edje_Eo.h',

--- a/src/lib/eet/meson.build
+++ b/src/lib/eet/meson.build
@@ -4,6 +4,7 @@ eet_ext_deps = [crypto, jpeg, m, rg_etc_simple]
 
 eet_header_src = [
   'Eet.h'
+  'eet_api.h'
 ]
 
 eet_src = files([

--- a/src/lib/eet/meson.build
+++ b/src/lib/eet/meson.build
@@ -3,8 +3,8 @@ eet_pub_deps = [eina, emile, efl]
 eet_ext_deps = [crypto, jpeg, m, rg_etc_simple]
 
 eet_header_src = [
-  'Eet.h'
-  'eet_api.h'
+  'Eet.h',
+  'eet_api.h',
 ]
 
 eet_src = files([

--- a/src/lib/eeze/meson.build
+++ b/src/lib/eeze/meson.build
@@ -5,6 +5,7 @@ pub_eo_file_target = []
 
 eeze_header_src = [
   'Eeze.h',
+  'eeze_api.h',
   'Eeze_Net.h',
   'Eeze_Sensor.h',
   'Eeze_Disk.h',

--- a/src/lib/efl/meson.build
+++ b/src/lib/efl/meson.build
@@ -4,6 +4,7 @@ efl_ext_deps = []
 
 efl_header_src = [
   'Efl.h',
+  'efl_api.h',
   'Efl_MVVM_Common.h'
 ]
 

--- a/src/lib/efreet/meson.build
+++ b/src/lib/efreet/meson.build
@@ -1,5 +1,6 @@
 efreet_header_src = [
   'Efreet.h',
+  'efreet_api.h',
   'efreet_base.h',
   'efreet_desktop.h',
   'efreet_icon.h',

--- a/src/lib/eio/meson.build
+++ b/src/lib/eio/meson.build
@@ -28,6 +28,7 @@ eolian_include_directories += ['-I', meson.current_source_dir()]
 
 eio_header_src = [
   'Eio.h',
+  'eio_api.h',
   'Eio_Legacy.h',
   'Eio_Eo.h',
   'eio_inline_helper.x'

--- a/src/lib/eldbus/meson.build
+++ b/src/lib/eldbus/meson.build
@@ -50,6 +50,7 @@ eolian_include_directories += ['-I', meson.current_source_dir()]
 
 eldbus_header_src = [
   'Eldbus.h',
+  'eldbus_api.h',
   'eldbus_connection.h',
   'eldbus_freedesktop.h',
   'eldbus_message.h',

--- a/src/lib/elementary/meson.build
+++ b/src/lib/elementary/meson.build
@@ -717,6 +717,7 @@ elementary_pub_headers = [
 
 elementary_header_src = [
   'Elementary.h',
+  'elementary_api.h',
   'Elementary_Cursor.h'
 ] + elementary_pub_headers + elementary_headers_unstable
 

--- a/src/lib/elput/meson.build
+++ b/src/lib/elput/meson.build
@@ -4,6 +4,7 @@ elput_ext_deps = []
 
 elput_header_src = [
   'Elput.h'
+  'elput_api.h'
 ]
 
 elput_src = files([

--- a/src/lib/elput/meson.build
+++ b/src/lib/elput/meson.build
@@ -3,8 +3,8 @@ elput_pub_deps = [eina, eldbus]
 elput_ext_deps = []
 
 elput_header_src = [
-  'Elput.h'
-  'elput_api.h'
+  'Elput.h',
+  'elput_api.h',
 ]
 
 elput_src = files([

--- a/src/lib/elua/meson.build
+++ b/src/lib/elua/meson.build
@@ -9,7 +9,7 @@ if get_option('lua-interpreter') == 'lua'
 endif
 
 elua_src = ['elua.c', 'io.c', 'cache.c']
-elua_header_src = ['Elua.h']
+elua_header_src = ['Elua.h', 'elua_api.h']
 
 elua_lib_deps = []
 if not sys_windows

--- a/src/lib/embryo/meson.build
+++ b/src/lib/embryo/meson.build
@@ -3,8 +3,8 @@ embryo_pub_deps = [eina, eo, efl]
 embryo_ext_deps = [buildsystem_simple, m]
 
 embryo_header_src = [
-  'Embryo.h'
-  'embryo_api.h'
+  'Embryo.h',
+  'embryo_api.h',
 ]
 
 embryo_src = files([

--- a/src/lib/embryo/meson.build
+++ b/src/lib/embryo/meson.build
@@ -4,6 +4,7 @@ embryo_ext_deps = [buildsystem_simple, m]
 
 embryo_header_src = [
   'Embryo.h'
+  'embryo_api.h'
 ]
 
 embryo_src = files([

--- a/src/lib/emile/meson.build
+++ b/src/lib/emile/meson.build
@@ -4,6 +4,7 @@ emile_ext_deps = [jpeg, crypto, zlib, lz4, rg_etc, m]
 
 emile_headers = [
   'Emile.h',
+  'emile_api.h',
   'emile_cipher.h',
   'emile_compress.h',
   'emile_image.h',

--- a/src/lib/emotion/meson.build
+++ b/src/lib/emotion/meson.build
@@ -24,6 +24,7 @@ eolian_include_directories += ['-I', meson.current_source_dir()]
 
 emotion_header_src = [
   'Emotion.h',
+  'emotion_api.h',
   'Emotion_Legacy.h',
   'Emotion_Eo.h',
   'efl_canvas_video_eo.legacy.h',

--- a/src/lib/eo/meson.build
+++ b/src/lib/eo/meson.build
@@ -42,7 +42,7 @@ foreach eo_file : pub_eo_types_files
                            '-gchd', '@INPUT@'])
 endforeach
 
-eo_header = ['Eo.h']
+eo_header = ['Eo.h', 'eo_api.h']
 
 foreach eo_file : pub_eo_files
   pub_eo_file_target += custom_target('eolian_gen_' + eo_file,

--- a/src/lib/eolian/meson.build
+++ b/src/lib/eolian/meson.build
@@ -53,7 +53,8 @@ eolian_include_dir = join_paths(dir_data, 'eolian', 'include')
 
 eolian_header_src = [
 'Eolian.h',
-'Eolian_Aux.h'
+'Eolian_Aux.h',
+'eolian_api.h',
 ]
 
 install_headers(eolian_header_src,

--- a/src/lib/ethumb/meson.build
+++ b/src/lib/ethumb/meson.build
@@ -1,6 +1,6 @@
 ethumb_header_src = [
-  'Ethumb.h'
-  'ethumb_api.h'
+  'Ethumb.h',
+  'ethumb_api.h',
 ]
 
 ethumb_src = files([

--- a/src/lib/ethumb/meson.build
+++ b/src/lib/ethumb/meson.build
@@ -1,5 +1,6 @@
 ethumb_header_src = [
   'Ethumb.h'
+  'ethumb_api.h'
 ]
 
 ethumb_src = files([

--- a/src/lib/evas/meson.build
+++ b/src/lib/evas/meson.build
@@ -137,6 +137,7 @@ evas_src += pub_eo_file_target
 
 evas_header_src = [
   'Evas.h',
+  'evas_api.h',
   'Evas_Common.h',
   'Evas_Eo.h',
   'Evas_GL.h',

--- a/src/lib/evil/meson.build
+++ b/src/lib/evil/meson.build
@@ -25,6 +25,7 @@ if target_machine.system() == 'windows'
 
   evil_header_src = [
     'evil_private.h',
+    'evil_api.h',
   ]
 
   psapi = cc.find_library('psapi')


### PR DESCRIPTION
Travis-CI [yields](https://travis-ci.com/github/expertisesolutions/efl/builds/174232232#L5012):
```
/usr/local/include/eo-1/Eo.h:7:10: fatal error: eo_api.h: No such file or directory
    7 | #include <eo_api.h>
      |          ^~~~~~~~~~
```
Because `eo_api.h` wasn't defined as a header to be installed.

This PR sets every `LIB_api.h` as a header to be installed.

`Ector` is not installed, so its API header doesn't need it either.
