### PR TITLE
[Emile] [Redone] Building with tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -339,7 +339,10 @@ elif (get_option('crypto') == 'gnutls')
   config_h.set('HAVE_GNUTLS', '1')
 elif (get_option('crypto') == 'openssl')
   if (get_option('openssl_dir') != '')
-    crypto = cc.find_library('crypto', dirs : [get_option('openssl_dir')])
+    crypto = declare_dependency(
+      link_args: ['-L' + get_option('openssl_dir'), '-llibssl_static', '-llibcrypto_static'],
+      compile_args: ['-I' + get_option('openssl_dir') + '/include'],
+    )
   else
     crypto = dependency('openssl')
   endif

--- a/meson.build
+++ b/meson.build
@@ -514,7 +514,6 @@ if sys_windows
     'elementary',
     'elua',
     'embryo',
-    'emile',
     'emotion',
     'ephysics',
     'ethumb',

--- a/native-file-windows.txt
+++ b/native-file-windows.txt
@@ -11,4 +11,4 @@ endian = 'little'
 [properties]
 c_args = ['-D_WIN32_WINNT=0x0601', '-march=x86-64']
 cpp_args = ['-D_WIN32_WINNT=0x0601', '-march=x86-64']
-nuget-download = false
+nuget-download = true 

--- a/src/lib/emile/emile_cipher_openssl.c
+++ b/src/lib/emile/emile_cipher_openssl.c
@@ -16,6 +16,10 @@
 
 #include "emile_private.h"
 
+#ifdef _MSC_VER
+# include <evil_private.h> /* S_ISDIR */
+#endif
+
 #define MAX_KEY_LEN   EVP_MAX_KEY_LENGTH
 #define MAX_IV_LEN    EVP_MAX_IV_LENGTH
 

--- a/src/lib/evil/evil_stat.h
+++ b/src/lib/evil/evil_stat.h
@@ -17,6 +17,8 @@
 # define S_IROTH  0                           /* Read others */
 # define S_IWOTH  0                           /* Write others */
 # define S_IXOTH  0                           /* Execute others */
+
+#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
 #endif
 
 #endif

--- a/win32-deps/meson.build
+++ b/win32-deps/meson.build
@@ -1,14 +1,16 @@
-
 if sys_windows
 
   # Libjpeg-Turbo
-  libjpeg_inc = include_directories('Libjpeg-Turbo.1.5.15/build/native/include')
-  libjpeg_lib = static_library('libjpeg', 
-    include_directories: 'Libjpeg-Turbo.1.5.15/lib/native/v140/windesktop/msvcstl/x64/Release/md'
+  jpeg_inc_dir = include_directories('Libjpeg-Turbo.1.5.15/build/native/include')
+  jpeg_lib_dir = 'Libjpeg-Turbo.1.5.15/lib/native/v140/windesktop/msvcstl/x64/Debug/md'
+  jpeg_lib = cc.find_library('libjpeg-turbo',
+    dirs: meson.build_root() + '/../win32-deps/' + jpeg_lib_dir,
+    required: true,
   )
-  libjpeg = declare_dependency(
-    link_with: freetype_lib,
-    include_directories: freetype_inc
+
+  jpeg = declare_dependency(
+    dependencies: jpeg_lib,
+    include_directories: jpeg_inc_dir,
   )
 
 endif


### PR DESCRIPTION
Turns out that emile doesn't need ecore, so I redone the work of PR #120 here, sending it directly to windows-native.

Test:
```
23/23 emile-suite               OK             0.10s
```