### PR TITLE
[efl_canvas_wl] Use EFL_CANVAS_WL_API instead of EAPI

### DIFF
--- a/src/lib/efl_canvas_wl/Efl_Canvas_Wl.h
+++ b/src/lib/efl_canvas_wl/Efl_Canvas_Wl.h
@@ -3,24 +3,7 @@
 #include <Evas.h>
 #include <Efl_Core.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-#ifdef EAPI_WEAK
-# undef EAPI_WEAK
-#endif
-
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#   define EAPI_WEAK
-#  else
-#   define EAPI
-#   define EAPI_WEAK
-#  endif
-# endif
-
-#define EWAPI EAPI EAPI_WEAK
+#include <efl_canvas_wl_api.h>
 
 #ifdef WAYLAND_UTIL_H
 typedef struct wl_surface Efl_Canvas_Wl_Wl_Surface;
@@ -53,9 +36,5 @@ typedef struct Efl_Canvas_Wl_Xkb_State Efl_Canvas_Wl_Xkb_State;
  * @return The Evas_Object of the surface, NULL on failure
  * @since 1.24
  */
-EAPI Evas_Object *efl_canvas_wl_extracted_surface_object_find(void *surface_resource);
-#undef EAPI
-#define EAPI
-#undef EAPI_WEAK
-#define EAPI_WEAK
+EFL_CANVAS_WL_API Evas_Object *efl_canvas_wl_extracted_surface_object_find(void *surface_resource);
 #endif

--- a/src/lib/efl_canvas_wl/efl_canvas_wl_api.h
+++ b/src/lib/efl_canvas_wl/efl_canvas_wl_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_EFL_CANVAS_WL_API_H
+#define _EFL_EFL_CANVAS_WL_API_H
+
+#ifdef EFL_CANVAS_WL_API
+#error EFL_CANVAS_WL_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_CANVAS_WL_STATIC
+#  ifdef EFL_CANVAS_WL_BUILD
+#   define EFL_CANVAS_WL_API __declspec(dllexport)
+#  else
+#   define EFL_CANVAS_WL_API __declspec(dllimport)
+#  endif
+# else
+#  define EFL_CANVAS_WL_API
+# endif
+# define EFL_CANVAS_WL_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define EFL_CANVAS_WL_API __attribute__ ((visibility("default")))
+#   define EFL_CANVAS_WL_API_WEAK __attribute__ ((weak))
+#  else
+#   define EFL_CANVAS_WL_API
+#   define EFL_CANVAS_WL_API_WEAK
+#  endif
+# else
+#  define EFL_CANVAS_WL_API
+#  define EFL_CANVAS_WL_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/efl_canvas_wl/meson.build
+++ b/src/lib/efl_canvas_wl/meson.build
@@ -23,6 +23,7 @@ foreach eo_file : pub_eo_files
                            '-o', 'h:' + join_paths(meson.current_build_dir(), eo_file + '.h'),
                            '-o', 'c:' + join_paths(meson.current_build_dir(), eo_file + '.c'),
                            '-o', 'd:' + join_paths(meson.current_build_dir(), eo_file + '.d'),
+                           '-e', 'EFL_CANVAS_WL_API',
                            '-gchd', '@INPUT@'])
 endforeach
 
@@ -31,7 +32,7 @@ efl_canvas_wl_src = files([
  'efl_canvas_wl.c',
 ])
 
-efl_canvas_wl_header_src = ['Efl_Canvas_Wl.h']
+efl_canvas_wl_header_src = ['Efl_Canvas_Wl.h', 'efl_canvas_wl_api.h']
 eolian_include_directories += ['-I', meson.current_source_dir()]
 
 efl_canvas_wl_lib = library('efl_canvas_wl',


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;
8. Add `LIB_api.h` to public headers;
9. If files are generated here, add `-e` flag to `eolian_gen` with
   `LIB_API` as argument (It didn't happen until now);

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.