### PR TITLE
[module] Bug: Move `extern` keyword to the right of API definitions

### DIFF
--- a/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_common.c
+++ b/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_common.c
@@ -6,8 +6,8 @@
 #include <Evas_Engine_Wayland.h>
 #include "ecore_wl2_internal.h"
 
-extern EMODAPI Eina_List *_evas_canvas_image_data_unset(Evas *eo_e);
-extern EMODAPI void _evas_canvas_image_data_regenerate(Eina_List *list);
+EMODAPI extern Eina_List *_evas_canvas_image_data_unset(Evas *eo_e);
+EMODAPI extern void _evas_canvas_image_data_regenerate(Eina_List *list);
 
 #define _smart_frame_type "ecore_evas_wl_frame"
 


### PR DESCRIPTION
As specified at `__declspec(dllexport)`
[doc](https://docs.microsoft.com/pt-br/cpp/build/exporting-from-a-dll-using-declspec-dllexport?view=vs-2017),
`__declspec(dllexport)` should be to the left of any other
calling-convention keyword.