### PR TITLE
Fixing ecore_x linkage to elementary examples

### DIFF
--- a/src/examples/elementary/meson.build
+++ b/src/examples/elementary/meson.build
@@ -124,7 +124,7 @@ examples = [
 ]
 
 foreach example : examples
-  executable(example, example + '.c', dependencies: [elementary, ecore, eio, m])
+  executable(example, example + '.c', dependencies: [elementary, ecore, ecore_x, eio, m])
 endforeach
 if get_option('bindings').contains('cxx')
   cxx_examples = [

--- a/src/examples/elementary/win_example.c
+++ b/src/examples/elementary/win_example.c
@@ -1,11 +1,11 @@
 /*
  * gcc -o win_example win_example.c `pkg-config --cflags --libs elementary ecore-x`
  */
+#include <Elementary.h>
+
 #ifdef HAVE_ELEMENTARY_X
 # include <Ecore_X.h>
 #endif
-
-#include <Elementary.h>
 
 static Evas_Object *win2;
 


### PR DESCRIPTION
Yes, its odd but Elementary should be included first or Ecore_X won't link on linux.


