### PR TITLE
Clean up eolian_generation test to work around #218

### DIFF
--- a/src/tests/eolian/eolian_generation.c
+++ b/src/tests/eolian/eolian_generation.c
@@ -11,20 +11,17 @@
 #include "eolian_suite.h"
 
 static Eina_Bool
-_files_compare (const char *ref_filename, const char *tmp_filename, const char *ext)
+_files_compare (const char *ref_filename, const char *tmp_filename)
 {
    Eina_Bool result = EINA_FALSE;
 
    FILE *tmp_file = NULL, *ref_file = NULL;
    char *tmp_content = NULL, *ref_content = NULL;
 
-   char ifnbuf[PATH_MAX];
-   snprintf(ifnbuf, sizeof(ifnbuf), "%s.%s", tmp_filename, ext);
-
-   tmp_file = fopen(ifnbuf, "rb");
+   tmp_file = fopen(tmp_filename, "rb");
    if (!tmp_file)
      {
-        printf("Unable to open %s\n", ifnbuf);
+        printf("Unable to open %s\n", tmp_filename);
         goto end;
      }
    ref_file = fopen(ref_filename, "rb");
@@ -68,162 +65,171 @@ end:
    return result;
 }
 
-static void
-_remove_ref(const char *base, const char *ext)
-{
-   char ifnbuf[PATH_MAX];
-   if (snprintf(ifnbuf, sizeof(ifnbuf), "%s.%s", base, ext) > PATH_MAX)
-     {
-        printf("remove ref too long for buffer\n");
-        abort();
-     }
-   remove(ifnbuf);
-}
-
 static int
-_eolian_gen_execute(const char *eo_filename, const char *options, const char *output_filename)
+_eolian_gen_execute(const char *eo_filename, const char *type, const char *output_filename)
 {
    char command[PATH_MAX];
    if (snprintf(command, PATH_MAX,
-                EOLIAN_GEN" %s -S -I \""TESTS_SRC_DIR"/data\" -o %s %s",
-                options, output_filename, eo_filename) > PATH_MAX)
+                EOLIAN_GEN" -S -I \""TESTS_SRC_DIR"/data\" -o %s:%s %s",
+                type, output_filename, eo_filename) > PATH_MAX)
      {
         printf("eolian gen command too long for buffer\n");
         abort();
      }
+   fprintf(stderr, "%s\n", command);
    return system(command);
 }
 
 EFL_START_TEST(eolian_dev_impl_code)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
    char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_object_impl",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "c");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/object_impl.eo", "-gi", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/object_impl_ref.c", output_filepath, "c"));
+
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_object_impl.c", tmp_dir);
+
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/object_impl.eo", "i", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/object_impl_ref.c", output_filepath));
    /* Check that nothing is added */
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/object_impl.eo", "-gi", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/object_impl_ref.c", output_filepath, "c"));
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/object_impl_add.eo", "-gi", output_filepath));
-   fprintf(stderr, "[%s]\n", output_filepath);
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/object_impl_add_ref.c", output_filepath, "c"));
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/object_impl.eo", "i", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/object_impl_ref.c", output_filepath));
+
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/object_impl_add.eo", "i", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/object_impl_add_ref.c", output_filepath));
 }
 EFL_END_TEST
 
 EFL_START_TEST(eolian_types_generation)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
    char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_typedef",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "eo.h");
-   _remove_ref(output_filepath, "eo.stub.h");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/typedef.eo", "-gh", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/typedef_ref.h", output_filepath, "eo.h"));
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/struct.eo", "-gh", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/struct_ref.h", output_filepath, "eo.h"));
 
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/typedef.eo", "-gs", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/typedef_ref_stub.h", output_filepath, "eo.stub.h"));
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/struct.eo", "-gs", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/struct_ref_stub.h", output_filepath, "eo.stub.h"));
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_typedef.eo.h", tmp_dir);
+
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/typedef.eo", "h", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/typedef_ref.h", output_filepath));
+
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/struct.eo", "h", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/struct_ref.h", output_filepath));
+
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_typedef.eo.stub.h", tmp_dir);
+
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/typedef.eo", "s", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/typedef_ref_stub.h", output_filepath));
+
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/struct.eo", "s", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/struct_ref_stub.h", output_filepath));
 }
 EFL_END_TEST
 
 EFL_START_TEST(eolian_default_values_generation)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
    char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_class_simple",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "eo.c");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/class_simple.eo", "-gc", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/class_simple_ref.c", output_filepath, "eo.c"));
+
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_class_simple.eo.c", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/class_simple.eo", "c", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/class_simple_ref.c", output_filepath));
 }
 EFL_END_TEST
 
 EFL_START_TEST(eolian_override_generation)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
    char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_override",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "eo.c");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/override.eo", "-gc", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/override_ref.c", output_filepath, "eo.c"));
+
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_override.eo.c", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/override.eo", "c", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/override_ref.c", output_filepath));
 }
 EFL_END_TEST
 
 EFL_START_TEST(eolian_functions_descriptions)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
    char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_class_simple",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "eo.h");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/class_simple.eo", "-gh", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/class_simple_ref_eo.h", output_filepath, "eo.h"));
+
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_class_simple.eo.h", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/class_simple.eo", "h", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/class_simple_ref_eo.h", output_filepath));
 }
 EFL_END_TEST
 
 EFL_START_TEST(eolian_import)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
    char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_import_types",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "eot.h");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/import_types.eot", "-gh", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/import_types_ref.h", output_filepath, "eot.h"));
+
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_import_types.eot.h", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/import_types.eot", "h", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/import_types_ref.h", output_filepath));
 }
 EFL_END_TEST
 
 EFL_START_TEST(eolian_docs)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
    char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_docs",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "eo.h");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/eo_docs.eo", "-gh", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/docs_ref.h", output_filepath, "eo.h"));
+
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_docs.eo.h", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/eo_docs.eo", "h", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/docs_ref.h", output_filepath));
 }
 EFL_END_TEST
 
 EFL_START_TEST(eolian_function_pointers)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
+   char output_filepath[PATH_MAX + 128] = "";
 
    // .eot
-   char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_function_pointers",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "eot.h");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_types.eot", "-gh", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_types_ref.h", output_filepath, "eot.h"));
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_function_pointers.eot.h", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_types.eot", "h", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_types_ref.h", output_filepath));
 
    // .eo.h
-   _remove_ref(output_filepath, "eo.h");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_as_argument.eo", "-gh", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_as_argument_ref.h", output_filepath, "eo.h"));
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_function_pointers.eo.h", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_as_argument.eo", "h", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_as_argument_ref.h", output_filepath));
 
    // .eo.c
-   _remove_ref(output_filepath, "eo.c");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_as_argument.eo", "-gc", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_as_argument_ref.c", output_filepath, "eo.c"));
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_function_pointers.eo.c", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_as_argument.eo", "c", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_as_argument_ref.c", output_filepath));
 
    // .eo.imp.c
-   _remove_ref(output_filepath, "c");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_as_argument.eo", "-gi", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_as_argument_impl_ref.c", output_filepath, "c"));
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_function_pointers.c", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_as_argument.eo", "i", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_as_argument_impl_ref.c", output_filepath));
    /* Check that nothing is added */
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_as_argument.eo", "-gi", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_as_argument_impl_ref.c", output_filepath, "c"));
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/function_as_argument.eo", "i", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/function_as_argument_impl_ref.c", output_filepath));
 }
 EFL_END_TEST
 
 EFL_START_TEST(owning)
 {
+   const char *tmp_dir = eina_environment_tmp_get();
    char output_filepath[PATH_MAX + 128] = "";
-   snprintf(output_filepath, PATH_MAX, "%s/eolian_owning",
-            eina_environment_tmp_get());
-   _remove_ref(output_filepath, "eo.c");
-   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/owning.eo", "-gc", output_filepath));
-   fail_if(!_files_compare(TESTS_SRC_DIR"/data/owning_ref.c", output_filepath, "eo.c"));
+
+   snprintf(output_filepath, PATH_MAX, "%s/eolian_owning.eo.c", tmp_dir);
+   remove(output_filepath);
+   fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/owning.eo", "c", output_filepath));
+   fail_if(!_files_compare(TESTS_SRC_DIR"/data/owning_ref.c", output_filepath));
 
 }
 EFL_END_TEST
@@ -231,12 +237,12 @@ EFL_END_TEST
 void eolian_generation_test(TCase *tc)
 {
    tcase_add_test(tc, eolian_types_generation);
-   tcase_add_test(tc, eolian_default_values_generation);
-   tcase_add_test(tc, eolian_override_generation);
-   tcase_add_test(tc, eolian_dev_impl_code);
-   tcase_add_test(tc, eolian_functions_descriptions);
-   tcase_add_test(tc, eolian_import);
-   tcase_add_test(tc, eolian_docs);
-   tcase_add_test(tc, eolian_function_pointers);
-   tcase_add_test(tc, owning);
+   // tcase_add_test(tc, eolian_default_values_generation);
+   // tcase_add_test(tc, eolian_override_generation);
+   // tcase_add_test(tc, eolian_dev_impl_code);
+   // tcase_add_test(tc, eolian_functions_descriptions);
+   // tcase_add_test(tc, eolian_import);
+   // tcase_add_test(tc, eolian_docs);
+   // tcase_add_test(tc, eolian_function_pointers);
+   // tcase_add_test(tc, owning);
 }

--- a/src/tests/eolian/eolian_generation.c
+++ b/src/tests/eolian/eolian_generation.c
@@ -237,12 +237,12 @@ EFL_END_TEST
 void eolian_generation_test(TCase *tc)
 {
    tcase_add_test(tc, eolian_types_generation);
-   // tcase_add_test(tc, eolian_default_values_generation);
-   // tcase_add_test(tc, eolian_override_generation);
-   // tcase_add_test(tc, eolian_dev_impl_code);
-   // tcase_add_test(tc, eolian_functions_descriptions);
-   // tcase_add_test(tc, eolian_import);
-   // tcase_add_test(tc, eolian_docs);
-   // tcase_add_test(tc, eolian_function_pointers);
-   // tcase_add_test(tc, owning);
+   tcase_add_test(tc, eolian_default_values_generation);
+   tcase_add_test(tc, eolian_override_generation);
+   tcase_add_test(tc, eolian_dev_impl_code);
+   tcase_add_test(tc, eolian_functions_descriptions);
+   tcase_add_test(tc, eolian_import);
+   tcase_add_test(tc, eolian_docs);
+   tcase_add_test(tc, eolian_function_pointers);
+   tcase_add_test(tc, owning);
 }

--- a/src/tests/eolian/eolian_generation.c
+++ b/src/tests/eolian/eolian_generation.c
@@ -76,7 +76,6 @@ _eolian_gen_execute(const char *eo_filename, const char *type, const char *outpu
         printf("eolian gen command too long for buffer\n");
         abort();
      }
-   fprintf(stderr, "%s\n", command);
    return system(command);
 }
 

--- a/src/tests/eolian/eolian_generation.c
+++ b/src/tests/eolian/eolian_generation.c
@@ -93,7 +93,6 @@ EFL_START_TEST(eolian_dev_impl_code)
    fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/object_impl.eo", "i", output_filepath));
    fail_if(!_files_compare(TESTS_SRC_DIR"/data/object_impl_ref.c", output_filepath));
 
-   remove(output_filepath);
    fail_if(0 != _eolian_gen_execute(TESTS_SRC_DIR"/data/object_impl_add.eo", "i", output_filepath));
    fail_if(!_files_compare(TESTS_SRC_DIR"/data/object_impl_add_ref.c", output_filepath));
 }


### PR DESCRIPTION
Works around #218 so that eolian_generation tests can be ran on Windows.

Changes helper functions to pass around the filename already with the extension and use `-o type:filename` instead of `-o basename`.