### PR TITLE
eolian_gen: Don't fall back to EAPI if symbol isn't specified with -e

### DIFF
--- a/src/bin/eolian/headers.c
+++ b/src/bin/eolian/headers.c
@@ -120,7 +120,10 @@ _gen_func(const Eolian_State *state, const Eolian_Function *fid,
         eina_strbuf_append_char(buf, '\n');
         eina_strbuf_free(dbuf);
      }
-   eina_strbuf_append_printf(buf, "%s %s_WEAK ", _eolian_api_symbol, _eolian_api_symbol);
+   if (_eolian_api_symbol)
+     {
+        eina_strbuf_append_printf(buf, "%s %s_WEAK ", _eolian_api_symbol, _eolian_api_symbol);
+     }
    if (rtp)
      {
         if (!rtps)
@@ -226,9 +229,11 @@ eo_gen_header_gen(const Eolian_State *state, const Eolian_Class *cl,
    Eina_Stringshare *gname = eolian_class_c_get_function_name_get(cl);
    eina_strbuf_append_printf(buf, "#define %s %s()\n\n", mname, gname);
    eina_stringshare_del(mname);
-
-   eina_strbuf_append_printf(buf, "%s %s_WEAK const Efl_Class *%s(void);\n",
-                             _eolian_api_symbol, _eolian_api_symbol, gname);
+   if (_eolian_api_symbol)
+     {
+        eina_strbuf_append_printf(buf, "%s %s_WEAK ", _eolian_api_symbol, _eolian_api_symbol);
+     }
+   eina_strbuf_append_printf(buf, "const Efl_Class *%s(void);\n", gname);
    eina_stringshare_del(gname);
 
    /* method section */
@@ -286,10 +291,11 @@ events:
         if (!eolian_event_is_beta(ev) && evs == EOLIAN_SCOPE_PUBLIC)
           eina_strbuf_append_char(buf, '\n');
 
-        eina_strbuf_append_printf(buf, "%s %s_WEAK extern const "
-                                  "Efl_Event_Description _%s;\n\n",
-                                  _eolian_api_symbol, _eolian_api_symbol, evn);
-
+        if (_eolian_api_symbol)
+          {
+             eina_strbuf_append_printf(buf, "%s %s_WEAK ", _eolian_api_symbol, _eolian_api_symbol);
+          }
+        eina_strbuf_append_printf(buf, "extern const Efl_Event_Description _%s;\n\n", evn);
         Eina_Strbuf *evdbuf = eo_gen_docs_event_gen(state, ev,
            eolian_class_c_name_get(cl));
         eina_strbuf_append(buf, eina_strbuf_string_get(evdbuf));

--- a/src/bin/eolian/main.c
+++ b/src/bin/eolian/main.c
@@ -501,7 +501,7 @@ main(int argc, char **argv)
      NULL, NULL, NULL, NULL, NULL, NULL
    };
    char *basen = NULL;
-   _eolian_api_symbol = strdup("EAPI");
+   _eolian_api_symbol = NULL;
    Eina_List *includes = NULL;
 
    eina_init();

--- a/src/bin/eolian/sources.c
+++ b/src/bin/eolian/sources.c
@@ -476,8 +476,10 @@ static void
 _emit_class_function(Eina_Strbuf *buf, const Eolian_Function *fid, const char *rtpn, Eina_Strbuf *params_full,
                      const char *ocnamel, const char *func_suffix, Eina_Strbuf *params, const char *function_name)
 {
-   eina_strbuf_append_printf(buf, "%s %s_WEAK", _eolian_api_symbol, _eolian_api_symbol);
-   eina_strbuf_append(buf, " ");
+   if (_eolian_api_symbol)
+     {
+        eina_strbuf_append_printf(buf, "%s %s_WEAK ", _eolian_api_symbol, _eolian_api_symbol);
+     }
    eina_strbuf_append(buf, rtpn);
    eina_strbuf_append(buf, " ");
    eina_strbuf_append(buf, function_name);
@@ -885,8 +887,11 @@ _gen_func(const Eolian_Class *cl, const Eolian_Function *fid,
              eina_strbuf_append_printf(buf, "}\n\n");
           }
 
-        eina_strbuf_append_printf(buf, "%s %s_WEAK", _eolian_api_symbol, _eolian_api_symbol);
-        eina_strbuf_append(buf, " EFL_");
+        if (_eolian_api_symbol)
+          {
+             eina_strbuf_append_printf(buf, "%s %s_WEAK ", _eolian_api_symbol, _eolian_api_symbol);
+          }
+        eina_strbuf_append(buf, "EFL_");
         if (!strcmp(rtpn, "void"))
           eina_strbuf_append(buf, "VOID_");
         eina_strbuf_append(buf, "FUNC_BODY");
@@ -1117,8 +1122,11 @@ eo_gen_source_gen(const Eolian_Class *cl, Eina_Strbuf *buf)
       EINA_ITERATOR_FOREACH(itr, ev)
         {
            Eina_Stringshare *evn = eolian_event_c_macro_get(ev);
-           eina_strbuf_append_printf(buf, "%s %s_WEAK", _eolian_api_symbol, _eolian_api_symbol);
-           eina_strbuf_append(buf, " const Efl_Event_Description _");
+           if (_eolian_api_symbol)
+             {
+                eina_strbuf_append_printf(buf, "%s %s_WEAK ", _eolian_api_symbol, _eolian_api_symbol);
+             }
+           eina_strbuf_append(buf, "const Efl_Event_Description _");
            eina_strbuf_append(buf, evn);
            eina_strbuf_append(buf, " =\n   EFL_EVENT_DESCRIPTION");
            if (eolian_event_is_hot(ev))

--- a/src/bin/eolian/types.c
+++ b/src/bin/eolian/types.c
@@ -228,8 +228,11 @@ _err_generate(const Eolian_State *state, const Eolian_Error *err)
    if (!buf) buf = eina_strbuf_new();
    else eina_strbuf_append_char(buf, '\n');
 
-   eina_strbuf_prepend_printf(buf, "%s %s_WEAK Eina_Error %s_get(void);\n\n",
-                              _eolian_api_symbol, _eolian_api_symbol, fn);
+   eina_strbuf_prepend_printf(buf, "%s_get(void);\n\n", fn);
+   if (_eolian_api_symbol)
+     {
+        eina_strbuf_prepend_printf(buf, "%s %s_WEAK Eina_Error ", _eolian_api_symbol, _eolian_api_symbol);
+     }
 
    char *ufn = strdup(fn);
    eina_str_toupper(&ufn);
@@ -327,8 +330,11 @@ _source_gen_error(Eina_Strbuf *buf, const Eolian_Error *err)
      *p = '_';
    eina_str_tolower(&fn);
 
-   eina_strbuf_append_printf(buf, "%s %s_WEAK Eina_Error %s_get(void)\n{\n",
-                             _eolian_api_symbol, _eolian_api_symbol, fn);
+   if (_eolian_api_symbol)
+     {
+        eina_strbuf_append_printf(buf, "%s %s_WEAK Eina_Error ", _eolian_api_symbol, _eolian_api_symbol);
+     }
+   eina_strbuf_append_printf(buf, "%s_get(void)\n{\n", fn);
    free(fn);
 
    const char *msg = eolian_error_message_get(err);


### PR DESCRIPTION
This makes most tests in the `eolian_generation` test case pass.