### PR TITLE
[modules] EMODAPI wans't available for everything in evas_ecore_wayland

### DIFF
--- a/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_api.h
+++ b/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_api.h
@@ -1,0 +1,27 @@
+#ifndef _EFL_ECORE_EVAS_WAYLAND_API_H
+#define _EFL_ECORE_EVAS_WAYLAND_API_H
+
+#ifdef EMODAPI_API
+#error EMODAPI_API should not be already defined
+#endif
+
+
+#ifdef _WIN32
+# ifndef EFL_MODULE_STATIC
+#  define EMODAPI __declspec(dllexport)
+# else
+#  define EMODAPI
+# endif
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define EMODAPI __attribute__ ((visibility("default")))
+#  endif
+# endif
+#endif /* ! _WIN32 */
+
+#ifndef EMODAPI
+# define EMODAPI
+#endif
+
+#endif

--- a/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_common.c
+++ b/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_common.c
@@ -5,6 +5,7 @@
 #include "ecore_evas_wayland_private.h"
 #include <Evas_Engine_Wayland.h>
 #include "ecore_wl2_internal.h"
+#include <ecore_evas_wayland_api.h>
 
 EMODAPI extern Eina_List *_evas_canvas_image_data_unset(Evas *eo_e);
 EMODAPI extern void _evas_canvas_image_data_regenerate(Eina_List *list);

--- a/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_egl.c
+++ b/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_egl.c
@@ -5,23 +5,7 @@
 # include <string.h>
 # include <unistd.h>
 
-#ifdef _WIN32
-# ifndef EFL_MODULE_STATIC
-#  define EMODAPI __declspec(dllexport)
-# else
-#  define EMODAPI
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EMODAPI __attribute__ ((visibility("default")))
-#  endif
-# endif
-#endif /* ! _WIN32 */
-
-#ifndef EMODAPI
-# define EMODAPI
-#endif
+# include <ecore_evas_wayland_api.h>
 
 /* external functions */
 EMODAPI Ecore_Evas *

--- a/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_shm.c
+++ b/src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_shm.c
@@ -5,23 +5,7 @@
 # include <string.h>
 # include <unistd.h>
 
-#ifdef _WIN32
-# ifndef EFL_MODULE_STATIC
-#  define EMODAPI __declspec(dllexport)
-# else
-#  define EMODAPI
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EMODAPI __attribute__ ((visibility("default")))
-#  endif
-# endif
-#endif /* ! _WIN32 */
-
-#ifndef EMODAPI
-# define EMODAPI
-#endif
+# include <ecore_evas_wayland_api.h>
 
 /* external functions */
 EMODAPI Ecore_Evas *


### PR DESCRIPTION
Before that Travis-CI [yields](https://travis-ci.com/github/expertisesolutions/efl/jobs/358111661#L3640):
```
../src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_common.c:9:8: error: expected ';' before 'extern'
    9 | EMODAPI extern Eina_List *_evas_canvas_image_data_unset(Evas *eo_e);
      |        ^~~~~~~
      |        ;
../src/modules/ecore_evas/engines/wayland/ecore_evas_wayland_common.c:10:8: error: expected ';' before 'extern'
   10 | EMODAPI extern void _evas_canvas_image_data_regenerate(Eina_List *list);
      |        ^~~~~~~
      |        ;
```