### PR TITLE
[Linux] Bug: Add lock `.x` files to eina public headers

### DIFF
--- a/src/lib/eina/meson.build
+++ b/src/lib/eina/meson.build
@@ -206,11 +206,17 @@ if sys_windows
     'eina_win32_dllmain.c',
     'eina_thread_win32.c',
   )
+  public_sub_headers += files(
+    'eina_inline_lock_win32.x'
+  )
 else
   eina_src += files(
     'eina_file.c',
     'eina_sched.c',
     'eina_thread_posix.c',
+  )
+  public_sub_headers += files(
+    'eina_inline_lock_posix.x'
   )
 endif
 


### PR DESCRIPTION
\#209 removed lock `.x` files from public headers causing
[Travis](https://travis-ci.com/github/expertisesolutions/efl/builds/174619415) to yield:
```
/usr/local/include/eina-1/eina/eina_lock.h:103:11: fatal error: eina_inline_lock_posix.x: No such file or directory
103 | # include "eina_inline_lock_posix.x"
    |           ^~~~~~~~~~~~~~~~~~~~~~~~~~
```