### PR TITLE
Building eet

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -508,7 +508,6 @@ if sys_windows
     'ecore_x',
     'ector',
     'edje',
-    'eet',
     'eeze',
     'efl_canvas_wl',
     'efreet',


### PR DESCRIPTION
As commented in #138, building eet is straight-forward, but its tests is failing:
```
24/24 eet-suite                 FAIL           12.93s (exit status 1)
```