### PR TITLE
[efl mono] Define and use EFL_MONO_API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,17 @@ env:
 
 jobs:
   include:
+    - os: osx
+    - os: linux
+      env: DISTRO=Fedora32-mingw CI_BUILD_TYPE=mingw
+    - os: linux
+      env: DISTRO=Fedora32 CI_BUILD_TYPE=options-enabled
     - os: linux
       env: DISTRO=Fedora32 CI_BUILD_TYPE=options-disabled
+    - os: linux
+      env: DISTRO=Fedora32 CI_BUILD_TYPE=wayland
+    - os: linux
+      env: DISTRO=Fedora32 CI_BUILD_TYPE=default
     - os: linux
       if: type = cron
       env: DISTRO=Fedora32 CI_BUILD_TYPE=release-ready

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,17 +46,8 @@ env:
 
 jobs:
   include:
-    - os: osx
-    - os: linux
-      env: DISTRO=Fedora32-mingw CI_BUILD_TYPE=mingw
-    - os: linux
-      env: DISTRO=Fedora32 CI_BUILD_TYPE=options-enabled
     - os: linux
       env: DISTRO=Fedora32 CI_BUILD_TYPE=options-disabled
-    - os: linux
-      env: DISTRO=Fedora32 CI_BUILD_TYPE=wayland
-    - os: linux
-      env: DISTRO=Fedora32 CI_BUILD_TYPE=default
     - os: linux
       if: type = cron
       env: DISTRO=Fedora32 CI_BUILD_TYPE=release-ready

--- a/src/bindings/mono/efl_mono/meson.build
+++ b/src/bindings/mono/efl_mono/meson.build
@@ -91,6 +91,7 @@ efl_mono_lib = library('eflcustomexportsmono',
     install : true,
     include_directories : config_dir + [include_directories(join_paths('.'))],
     dependencies : [eo, eina, ecore],
+    c_args = ['-DEFL_MONO_BUILD'],
     version : meson.project_version()
 )
 

--- a/src/bindings/mono/efl_mono/meson.build
+++ b/src/bindings/mono/efl_mono/meson.build
@@ -76,6 +76,7 @@ foreach eo_file : mono_eo_files
                            '-o', 'h:' + join_paths(meson.current_build_dir(), eo_file + '.h'),
                            '-o', 'c:' + join_paths(meson.current_build_dir(), eo_file + '.c'),
                            '-o', 'd:' + join_paths(meson.current_build_dir(), eo_file + '.d'),
+                           '-e', 'EFL_MONO_API',
                            '-gchd', '@INPUT@'])
   # mono_eo_c_files += join_paths(meson.current_build_dir(), eo_file + '.c')
 endforeach

--- a/src/lib/efl_mono/efl_custom_exports_mono.c
+++ b/src/lib/efl_mono/efl_custom_exports_mono.c
@@ -20,36 +20,19 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
+#include "efl_mono_api.h"
 
-#ifdef _WIN32
-#  define EAPI __declspec(dllexport)
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif /* ! _WIN32 */
-
-
-EAPI const char *efl_mono_wrapper_supervisor_key_get()
+EFL_MONO_API const char *efl_mono_wrapper_supervisor_key_get()
 {
    return "__c#_wrapper_supervisor";
 }
 
-EAPI void *efl_mono_wrapper_supervisor_get(Eo *eo)
+EFL_MONO_API void *efl_mono_wrapper_supervisor_get(Eo *eo)
 {
    return efl_key_data_get(eo, efl_mono_wrapper_supervisor_key_get());
 }
 
-EAPI void efl_mono_wrapper_supervisor_set(Eo *eo, void *ws)
+EFL_MONO_API void efl_mono_wrapper_supervisor_set(Eo *eo, void *ws)
 {
    efl_key_data_set(eo, efl_mono_wrapper_supervisor_key_get(), ws);
 }
@@ -58,17 +41,17 @@ typedef void (*Efl_Mono_Free_Wrapper_Supervisor_Cb)(Eo *obj);
 
 static Efl_Mono_Free_Wrapper_Supervisor_Cb _efl_mono_free_wrapper_supervisor_call = NULL;
 
-EAPI void efl_mono_wrapper_supervisor_callbacks_set(Efl_Mono_Free_Wrapper_Supervisor_Cb free_wrapper_supervisor_cb)
+EFL_MONO_API void efl_mono_wrapper_supervisor_callbacks_set(Efl_Mono_Free_Wrapper_Supervisor_Cb free_wrapper_supervisor_cb)
 {
    _efl_mono_free_wrapper_supervisor_call = free_wrapper_supervisor_cb;
 }
 
-EAPI void efl_mono_native_dispose(Eo *obj)
+EFL_MONO_API void efl_mono_native_dispose(Eo *obj)
 {
    _efl_mono_free_wrapper_supervisor_call(obj);
 }
 
-EAPI void efl_mono_thread_safe_native_dispose(Eo *obj)
+EFL_MONO_API void efl_mono_thread_safe_native_dispose(Eo *obj)
 {
    ecore_main_loop_thread_safe_call_async((Ecore_Cb)efl_mono_native_dispose, obj);
 }
@@ -78,12 +61,12 @@ static void _efl_mono_unref_cb(void *obj)
    efl_unref(obj);
 }
 
-EAPI void efl_mono_thread_safe_efl_unref(Eo* obj)
+EFL_MONO_API void efl_mono_thread_safe_efl_unref(Eo* obj)
 {
    ecore_main_loop_thread_safe_call_async(_efl_mono_unref_cb, obj);
 }
 
-EAPI void efl_mono_thread_safe_free_cb_exec(Eina_Free_Cb free_cb, void* cb_data)
+EFL_MONO_API void efl_mono_thread_safe_free_cb_exec(Eina_Free_Cb free_cb, void* cb_data)
 {
    ecore_main_loop_thread_safe_call_async(free_cb, cb_data);
 }
@@ -93,7 +76,7 @@ static void _efl_mono_list_free_cb(void *l)
    eina_list_free(l);
 }
 
-EAPI void efl_mono_thread_safe_eina_list_free(Eina_List* list)
+EFL_MONO_API void efl_mono_thread_safe_eina_list_free(Eina_List* list)
 {
    ecore_main_loop_thread_safe_call_async(_efl_mono_list_free_cb, list);
 }
@@ -111,7 +94,7 @@ static void _efl_mono_promise_reject_cb(void *data)
    free(d);
 }
 
-EAPI void efl_mono_thread_safe_promise_reject(Eina_Promise *p, Eina_Error err)
+EFL_MONO_API void efl_mono_thread_safe_promise_reject(Eina_Promise *p, Eina_Error err)
 {
    Efl_Mono_Promise_Reject_Data *d = malloc(sizeof(Efl_Mono_Promise_Reject_Data));
    d->promise = p;
@@ -119,34 +102,34 @@ EAPI void efl_mono_thread_safe_promise_reject(Eina_Promise *p, Eina_Error err)
    ecore_main_loop_thread_safe_call_async(_efl_mono_promise_reject_cb, d);
 }
 
-EAPI void *efl_mono_native_alloc(unsigned int size)
+EFL_MONO_API void *efl_mono_native_alloc(unsigned int size)
 {
    return malloc(size);
 }
 
-EAPI void efl_mono_native_memset(void *ptr, unsigned int fill, unsigned int count)
+EFL_MONO_API void efl_mono_native_memset(void *ptr, unsigned int fill, unsigned int count)
 {
    memset(ptr, fill, count);
 }
 
-EAPI void efl_mono_native_free(void *ptr)
+EFL_MONO_API void efl_mono_native_free(void *ptr)
 {
    free(ptr);
 }
 
-EAPI void efl_mono_native_free_ref(void **ptr)
+EFL_MONO_API void efl_mono_native_free_ref(void **ptr)
 {
    if (!ptr) return;
    free(*ptr);
 }
 
-EAPI void efl_mono_native_stringshare_del_ref(void **str)
+EFL_MONO_API void efl_mono_native_stringshare_del_ref(void **str)
 {
    if (!str) return;
    eina_stringshare_del(*str);
 }
 
-EAPI void *efl_mono_native_alloc_copy(const void *val, unsigned int size)
+EFL_MONO_API void *efl_mono_native_alloc_copy(const void *val, unsigned int size)
 {
     if (!val) return NULL;
     void *r = malloc(size);
@@ -154,40 +137,40 @@ EAPI void *efl_mono_native_alloc_copy(const void *val, unsigned int size)
     return r;
 }
 
-EAPI const char *efl_mono_native_strdup(const char *str)
+EFL_MONO_API const char *efl_mono_native_strdup(const char *str)
 {
     if (!str) return NULL;
     return strdup(str);
 }
 
-EAPI int efl_mono_native_ptr_compare(const void *ptr1, const void *ptr2)
+EFL_MONO_API int efl_mono_native_ptr_compare(const void *ptr1, const void *ptr2)
 {
     uintptr_t addr1 = (uintptr_t)ptr1;
     uintptr_t addr2 = (uintptr_t)ptr2;
     return (addr1 > addr2) - (addr1 < addr2);
 }
 
-EAPI Eina_Compare_Cb efl_mono_native_ptr_compare_addr_get()
+EFL_MONO_API Eina_Compare_Cb efl_mono_native_ptr_compare_addr_get()
 {
     return efl_mono_native_ptr_compare;
 }
 
-EAPI Eina_Compare_Cb efl_mono_native_str_compare_addr_get()
+EFL_MONO_API Eina_Compare_Cb efl_mono_native_str_compare_addr_get()
 {
     return (Eina_Compare_Cb)strcmp;
 }
 
-EAPI Eina_Free_Cb efl_mono_native_free_addr_get()
+EFL_MONO_API Eina_Free_Cb efl_mono_native_free_addr_get()
 {
     return (Eina_Free_Cb)free;
 }
 
-EAPI Eina_Free_Cb efl_mono_native_stringshare_del_addr_get()
+EFL_MONO_API Eina_Free_Cb efl_mono_native_stringshare_del_addr_get()
 {
     return (Eina_Free_Cb)eina_stringshare_del;
 }
 
-EAPI Eina_Free_Cb efl_mono_native_efl_unref_addr_get()
+EFL_MONO_API Eina_Free_Cb efl_mono_native_efl_unref_addr_get()
 {
     return (Eina_Free_Cb)efl_mono_thread_safe_efl_unref;
 }
@@ -197,18 +180,18 @@ static Eo *_efl_mono_avoid_top_level_constructor_cb(void *data EINA_UNUSED, Eo *
    return efl_constructor(efl_super(obj, efl_class_get(obj)));
 }
 
-EAPI Efl_Substitute_Ctor_Cb efl_mono_avoid_top_level_constructor_callback_addr_get()
+EFL_MONO_API Efl_Substitute_Ctor_Cb efl_mono_avoid_top_level_constructor_callback_addr_get()
 {
    return &_efl_mono_avoid_top_level_constructor_cb;
 }
 
 // Environment wrappers //
-EAPI const char *efl_mono_native_getenv(const char *name)
+EFL_MONO_API const char *efl_mono_native_getenv(const char *name)
 {
    return getenv(name);
 }
 
-EAPI Eina_Error efl_mono_native_setenv(const char *name, const char *value, int overwrite)
+EFL_MONO_API Eina_Error efl_mono_native_setenv(const char *name, const char *value, int overwrite)
 {
    return setenv(name, value, overwrite);
 }
@@ -259,42 +242,42 @@ static Eina_Iterator *eina_iterator_wrapper_new_mono(Eina_Iterator *internal, Ei
 
 // Array //
 
-EAPI void eina_array_clean_custom_export_mono(Eina_Array *array) EINA_ARG_NONNULL(1)
+EFL_MONO_API void eina_array_clean_custom_export_mono(Eina_Array *array) EINA_ARG_NONNULL(1)
 {
    eina_array_clean(array);
 }
 
-EAPI Eina_Bool eina_array_push_custom_export_mono(Eina_Array *array, const void *data) EINA_ARG_NONNULL(1, 2)
+EFL_MONO_API Eina_Bool eina_array_push_custom_export_mono(Eina_Array *array, const void *data) EINA_ARG_NONNULL(1, 2)
 {
    return eina_array_push(array, data);
 }
 
-EAPI void *eina_array_pop_custom_export_mono(Eina_Array *array) EINA_ARG_NONNULL(1)
+EFL_MONO_API void *eina_array_pop_custom_export_mono(Eina_Array *array) EINA_ARG_NONNULL(1)
 {
    return eina_array_pop(array);
 }
 
-EAPI void *eina_array_data_get_custom_export_mono(const Eina_Array *array, unsigned int idx) EINA_ARG_NONNULL(1)
+EFL_MONO_API void *eina_array_data_get_custom_export_mono(const Eina_Array *array, unsigned int idx) EINA_ARG_NONNULL(1)
 {
    return eina_array_data_get(array, idx);
 }
 
-EAPI void eina_array_data_set_custom_export_mono(const Eina_Array *array, unsigned int idx, const void *data) EINA_ARG_NONNULL(1)
+EFL_MONO_API void eina_array_data_set_custom_export_mono(const Eina_Array *array, unsigned int idx, const void *data) EINA_ARG_NONNULL(1)
 {
    eina_array_data_set(array, idx, data);
 }
 
-EAPI unsigned int eina_array_count_custom_export_mono(const Eina_Array *array) EINA_ARG_NONNULL(1)
+EFL_MONO_API unsigned int eina_array_count_custom_export_mono(const Eina_Array *array) EINA_ARG_NONNULL(1)
 {
    return eina_array_count(array);
 }
 
-EAPI Eina_Bool eina_array_foreach_custom_export_mono(Eina_Array *array, Eina_Each_Cb cb, void *fdata)
+EFL_MONO_API Eina_Bool eina_array_foreach_custom_export_mono(Eina_Array *array, Eina_Each_Cb cb, void *fdata)
 {
    return eina_array_foreach(array, cb, fdata);
 }
 
-EAPI void eina_array_insert_at_custom_export_mono(Eina_Array* array, unsigned int index, void* const data)
+EFL_MONO_API void eina_array_insert_at_custom_export_mono(Eina_Array* array, unsigned int index, void* const data)
 {
    eina_array_push(array, data);
    for (unsigned int i = eina_array_count(array) - 1; i > index; --i)
@@ -307,37 +290,37 @@ EAPI void eina_array_insert_at_custom_export_mono(Eina_Array* array, unsigned in
 
 // List //
 
-EAPI Eina_List *eina_list_last_custom_export_mono(const Eina_List *list)
+EFL_MONO_API Eina_List *eina_list_last_custom_export_mono(const Eina_List *list)
 {
    return eina_list_last(list);
 }
 
-EAPI Eina_List *eina_list_next_custom_export_mono(const Eina_List *list)
+EFL_MONO_API Eina_List *eina_list_next_custom_export_mono(const Eina_List *list)
 {
    return eina_list_next(list);
 }
 
-EAPI Eina_List *eina_list_prev_custom_export_mono(const Eina_List *list)
+EFL_MONO_API Eina_List *eina_list_prev_custom_export_mono(const Eina_List *list)
 {
    return eina_list_prev(list);
 }
 
-EAPI void *eina_list_data_get_custom_export_mono(const Eina_List *list)
+EFL_MONO_API void *eina_list_data_get_custom_export_mono(const Eina_List *list)
 {
    return eina_list_data_get(list);
 }
 
-EAPI void *eina_list_data_set_custom_export_mono(Eina_List *list, const void *data)
+EFL_MONO_API void *eina_list_data_set_custom_export_mono(Eina_List *list, const void *data)
 {
    return eina_list_data_set(list, data);
 }
 
-EAPI unsigned int eina_list_count_custom_export_mono(const Eina_List *list)
+EFL_MONO_API unsigned int eina_list_count_custom_export_mono(const Eina_List *list)
 {
    return eina_list_count(list);
 }
 
-EAPI void *eina_list_last_data_get_custom_export_mono(const Eina_List *list)
+EFL_MONO_API void *eina_list_last_data_get_custom_export_mono(const Eina_List *list)
 {
    return eina_list_last_data_get(list);
 }
@@ -363,29 +346,29 @@ static Eina_Bool eina_inlist_iterator_wrapper_next_mono(Eina_Iterator_Wrapper_Mo
    return EINA_TRUE;
 }
 
-EAPI Eina_Iterator *eina_inlist_iterator_wrapper_new_custom_export_mono(const Eina_Inlist *in_list)
+EFL_MONO_API Eina_Iterator *eina_inlist_iterator_wrapper_new_custom_export_mono(const Eina_Inlist *in_list)
 {
    return eina_iterator_wrapper_new_mono(eina_inlist_iterator_new(in_list), FUNC_ITERATOR_NEXT(eina_inlist_iterator_wrapper_next_mono));
 }
 
-EAPI Eina_Inlist *eina_inlist_first_custom_export_mono(const Eina_Inlist *list)
+EFL_MONO_API Eina_Inlist *eina_inlist_first_custom_export_mono(const Eina_Inlist *list)
 {
    return eina_inlist_first(list);
 }
 
-EAPI Eina_Inlist *eina_inlist_last_custom_export_mono(const Eina_Inlist *list)
+EFL_MONO_API Eina_Inlist *eina_inlist_last_custom_export_mono(const Eina_Inlist *list)
 {
    return eina_inlist_last(list);
 }
 
-EAPI Eina_Inlist *eina_inlist_next_custom_export_mono(const Eina_Inlist *list)
+EFL_MONO_API Eina_Inlist *eina_inlist_next_custom_export_mono(const Eina_Inlist *list)
 {
    if (list)
      return list->next;
    return NULL;
 }
 
-EAPI Eina_Inlist *eina_inlist_prev_custom_export_mono(const Eina_Inlist *list)
+EFL_MONO_API Eina_Inlist *eina_inlist_prev_custom_export_mono(const Eina_Inlist *list)
 {
    if (list)
      return list->prev;
@@ -407,77 +390,77 @@ static Eina_Bool eina_hash_iterator_ptr_key_wrapper_next_mono(Eina_Iterator_Wrap
    return EINA_TRUE;
 }
 
-EAPI Eina_Iterator *eina_hash_iterator_ptr_key_wrapper_new_custom_export_mono(const Eina_Hash *hash)
+EFL_MONO_API Eina_Iterator *eina_hash_iterator_ptr_key_wrapper_new_custom_export_mono(const Eina_Hash *hash)
 {
    return eina_iterator_wrapper_new_mono(eina_hash_iterator_key_new(hash), FUNC_ITERATOR_NEXT(eina_hash_iterator_ptr_key_wrapper_next_mono));
 }
 
 // Eina Value //
-EAPI const Eina_Value_Type *type_byte() {
+EFL_MONO_API const Eina_Value_Type *type_byte() {
    return EINA_VALUE_TYPE_UCHAR;
 }
-EAPI const Eina_Value_Type *type_sbyte() {
+EFL_MONO_API const Eina_Value_Type *type_sbyte() {
    return EINA_VALUE_TYPE_CHAR;
 }
-EAPI const Eina_Value_Type *type_short() {
+EFL_MONO_API const Eina_Value_Type *type_short() {
    return EINA_VALUE_TYPE_SHORT;
 }
-EAPI const Eina_Value_Type *type_ushort() {
+EFL_MONO_API const Eina_Value_Type *type_ushort() {
    return EINA_VALUE_TYPE_USHORT;
 }
-EAPI const Eina_Value_Type *type_int32() {
+EFL_MONO_API const Eina_Value_Type *type_int32() {
    return EINA_VALUE_TYPE_INT;
 }
-EAPI const Eina_Value_Type *type_uint32() {
+EFL_MONO_API const Eina_Value_Type *type_uint32() {
    return EINA_VALUE_TYPE_UINT;
 }
-EAPI const Eina_Value_Type *type_long() {
+EFL_MONO_API const Eina_Value_Type *type_long() {
    return EINA_VALUE_TYPE_LONG;
 }
-EAPI const Eina_Value_Type *type_ulong() {
+EFL_MONO_API const Eina_Value_Type *type_ulong() {
    return EINA_VALUE_TYPE_ULONG;
 }
-EAPI const Eina_Value_Type *type_int64() {
+EFL_MONO_API const Eina_Value_Type *type_int64() {
    return EINA_VALUE_TYPE_INT64;
 }
-EAPI const Eina_Value_Type *type_uint64() {
+EFL_MONO_API const Eina_Value_Type *type_uint64() {
    return EINA_VALUE_TYPE_UINT64;
 }
-EAPI const Eina_Value_Type *type_string() {
+EFL_MONO_API const Eina_Value_Type *type_string() {
    return EINA_VALUE_TYPE_STRING;
 }
-EAPI const Eina_Value_Type *type_float() {
+EFL_MONO_API const Eina_Value_Type *type_float() {
    return EINA_VALUE_TYPE_FLOAT;
 }
-EAPI const Eina_Value_Type *type_double() {
+EFL_MONO_API const Eina_Value_Type *type_double() {
    return EINA_VALUE_TYPE_DOUBLE;
 }
-EAPI const Eina_Value_Type *type_array() {
+EFL_MONO_API const Eina_Value_Type *type_array() {
    return EINA_VALUE_TYPE_ARRAY;
 }
-EAPI const Eina_Value_Type *type_list() {
+EFL_MONO_API const Eina_Value_Type *type_list() {
    return EINA_VALUE_TYPE_LIST;
 }
-EAPI const Eina_Value_Type *type_hash() {
+EFL_MONO_API const Eina_Value_Type *type_hash() {
    return EINA_VALUE_TYPE_HASH;
 }
-EAPI const Eina_Value_Type *type_error() {
+EFL_MONO_API const Eina_Value_Type *type_error() {
    return EINA_VALUE_TYPE_ERROR;
 }
-EAPI const Eina_Value_Type *type_object() {
+EFL_MONO_API const Eina_Value_Type *type_object() {
    return EINA_VALUE_TYPE_OBJECT;
 }
 
-EAPI const Eina_Value_Type *type_optional() {
+EFL_MONO_API const Eina_Value_Type *type_optional() {
    return EINA_VALUE_TYPE_OPTIONAL;
 }
 
-EAPI size_t eina_value_sizeof()
+EFL_MONO_API size_t eina_value_sizeof()
 {
    return sizeof(Eina_Value);
 }
 
-#define EINA_SET_WRAPPER(N, T) EAPI Eina_Bool eina_value_set_wrapper_##N(Eina_Value *value, T new_value) \
+#define EINA_SET_WRAPPER(N, T) EFL_MONO_API Eina_Bool eina_value_set_wrapper_##N(Eina_Value *value, T new_value) \
 { \
     return eina_value_set(value, new_value); \
 }
@@ -495,7 +478,7 @@ EINA_SET_WRAPPER(double, double)
 EINA_SET_WRAPPER(string, const char *)
 EINA_SET_WRAPPER(ptr, void *)
 
-#define EINA_CONTAINER_SET_WRAPPER(N, T) EAPI Eina_Bool eina_value_container_set_wrapper_##N(Eina_Value *value, int i, T new_value) \
+#define EINA_CONTAINER_SET_WRAPPER(N, T) EFL_MONO_API Eina_Bool eina_value_container_set_wrapper_##N(Eina_Value *value, int i, T new_value) \
 { \
     const Eina_Value_Type *tp = eina_value_type_get(value); \
     if (tp == EINA_VALUE_TYPE_ARRAY) \
@@ -519,7 +502,7 @@ EINA_CONTAINER_SET_WRAPPER(double, double)
 EINA_CONTAINER_SET_WRAPPER(string, const char *)
 EINA_CONTAINER_SET_WRAPPER(ptr, void *)
 
-#define EINA_CONTAINER_APPEND_WRAPPER(N, T) EAPI Eina_Bool eina_value_container_append_wrapper_##N(Eina_Value *value, T new_value) \
+#define EINA_CONTAINER_APPEND_WRAPPER(N, T) EFL_MONO_API Eina_Bool eina_value_container_append_wrapper_##N(Eina_Value *value, T new_value) \
 { \
     const Eina_Value_Type *tp = eina_value_type_get(value); \
     if (tp == EINA_VALUE_TYPE_ARRAY) \
@@ -543,7 +526,7 @@ EINA_CONTAINER_APPEND_WRAPPER(double, double)
 EINA_CONTAINER_APPEND_WRAPPER(string, const char *)
 EINA_CONTAINER_APPEND_WRAPPER(ptr, void *)
 
-#define EINA_CONTAINER_INSERT_WRAPPER(N, T) EAPI Eina_Bool eina_value_container_insert_wrapper_##N(Eina_Value *value, unsigned int position, T new_value) \
+#define EINA_CONTAINER_INSERT_WRAPPER(N, T) EFL_MONO_API Eina_Bool eina_value_container_insert_wrapper_##N(Eina_Value *value, unsigned int position, T new_value) \
 { \
     const Eina_Value_Type *tp = eina_value_type_get(value); \
     if (tp == EINA_VALUE_TYPE_ARRAY) \
@@ -568,7 +551,7 @@ EINA_CONTAINER_INSERT_WRAPPER(string, const char *)
 EINA_CONTAINER_INSERT_WRAPPER(ptr, void *)
 
 
-EAPI void eina_value_container_get_wrapper(const Eina_Value *value, int i, void *output)
+EFL_MONO_API void eina_value_container_get_wrapper(const Eina_Value *value, int i, void *output)
 {
     const Eina_Value_Type *tp = eina_value_type_get(value);
     if (tp == EINA_VALUE_TYPE_ARRAY)
@@ -577,18 +560,18 @@ EAPI void eina_value_container_get_wrapper(const Eina_Value *value, int i, void 
         eina_value_list_get(value, i, output);
 }
 
-EAPI Eina_Bool eina_value_setup_wrapper(Eina_Value *value,
+EFL_MONO_API Eina_Bool eina_value_setup_wrapper(Eina_Value *value,
                                    const Eina_Value_Type *type)
 {
    return eina_value_setup(value, type);
 }
 
-EAPI void eina_value_flush_wrapper(Eina_Value *value)
+EFL_MONO_API void eina_value_flush_wrapper(Eina_Value *value)
 {
    eina_value_flush(value);
 }
 
-EAPI const Eina_Value_Type *eina_value_type_get_wrapper(const Eina_Value *value)
+EFL_MONO_API const Eina_Value_Type *eina_value_type_get_wrapper(const Eina_Value *value)
 {
    EINA_SAFETY_ON_NULL_RETURN_VAL(value, NULL);
 
@@ -598,92 +581,92 @@ EAPI const Eina_Value_Type *eina_value_type_get_wrapper(const Eina_Value *value)
    return eina_value_type_get(value);
 }
 
-EAPI Eina_Bool eina_value_get_wrapper(const Eina_Value *value, void *output)
+EFL_MONO_API Eina_Bool eina_value_get_wrapper(const Eina_Value *value, void *output)
 {
    return eina_value_get(value, output);
 }
 
-EAPI int eina_value_compare_wrapper(const Eina_Value *this, const Eina_Value *other)
+EFL_MONO_API int eina_value_compare_wrapper(const Eina_Value *this, const Eina_Value *other)
 {
    return eina_value_compare(this, other);
 }
 
-EAPI Eina_Bool eina_value_array_setup_wrapper(Eina_Value *array, const Eina_Value_Type *subtype, unsigned int step)
+EFL_MONO_API Eina_Bool eina_value_array_setup_wrapper(Eina_Value *array, const Eina_Value_Type *subtype, unsigned int step)
 {
    return eina_value_array_setup(array, subtype, step);
 }
 
-EAPI Eina_Bool eina_value_list_setup_wrapper(Eina_Value *list, const Eina_Value_Type *subtype)
+EFL_MONO_API Eina_Bool eina_value_list_setup_wrapper(Eina_Value *list, const Eina_Value_Type *subtype)
 {
    return eina_value_list_setup(list, subtype);
 }
 
-EAPI Eina_Bool eina_value_array_append_wrapper(Eina_Value *array, va_list argp)
+EFL_MONO_API Eina_Bool eina_value_array_append_wrapper(Eina_Value *array, va_list argp)
 {
    return eina_value_array_append(array, argp);
 }
 
-EAPI Eina_Bool eina_value_list_append_wrapper(Eina_Value *list, va_list argp)
+EFL_MONO_API Eina_Bool eina_value_list_append_wrapper(Eina_Value *list, va_list argp)
 {
    return eina_value_list_append(list, argp);
 }
 
-EAPI Eina_Bool eina_value_array_get_wrapper(const Eina_Value *array, int i, void *output)
+EFL_MONO_API Eina_Bool eina_value_array_get_wrapper(const Eina_Value *array, int i, void *output)
 {
    return eina_value_array_get(array, i, output);
 }
 
-EAPI Eina_Bool eina_value_list_get_wrapper(const Eina_Value *list, int i, void *output)
+EFL_MONO_API Eina_Bool eina_value_list_get_wrapper(const Eina_Value *list, int i, void *output)
 {
    return eina_value_list_get(list, i, output);
 }
 
-EAPI Eina_Bool eina_value_array_set_wrapper(Eina_Value *array, int i, void *value)
+EFL_MONO_API Eina_Bool eina_value_array_set_wrapper(Eina_Value *array, int i, void *value)
 {
    return eina_value_array_set(array, i, value);
 }
 
-EAPI Eina_Bool eina_value_list_set_wrapper(Eina_Value *list, int i, void *value)
+EFL_MONO_API Eina_Bool eina_value_list_set_wrapper(Eina_Value *list, int i, void *value)
 {
    return eina_value_list_set(list, i, value);
 }
 
 // Not actually a wrapper, but keeping the naming convention for functions on this file.
-EAPI const Eina_Value_Type* eina_value_array_subtype_get_wrapper(const Eina_Value *array)
+EFL_MONO_API const Eina_Value_Type* eina_value_array_subtype_get_wrapper(const Eina_Value *array)
 {
    Eina_Value_Array array_value;
    eina_value_get(array, &array_value);
    return array_value.subtype;
 }
 
-EAPI const Eina_Value_Type* eina_value_list_subtype_get_wrapper(const Eina_Value *list)
+EFL_MONO_API const Eina_Value_Type* eina_value_list_subtype_get_wrapper(const Eina_Value *list)
 {
    Eina_Value_List list_value;
    eina_value_get(list, &list_value);
    return list_value.subtype;
 }
 
-EAPI unsigned int eina_value_array_count_wrapper(const Eina_Value *array)
+EFL_MONO_API unsigned int eina_value_array_count_wrapper(const Eina_Value *array)
 {
    return eina_value_array_count(array);
 }
 
-EAPI unsigned int eina_value_list_count_wrapper(const Eina_Value *list)
+EFL_MONO_API unsigned int eina_value_list_count_wrapper(const Eina_Value *list)
 {
    return eina_value_list_count(list);
 }
 
-EAPI Eina_Bool eina_value_optional_empty_is_wrapper(const Eina_Value *value, Eina_Bool *empty)
+EFL_MONO_API Eina_Bool eina_value_optional_empty_is_wrapper(const Eina_Value *value, Eina_Bool *empty)
 {
    return eina_value_optional_empty_is(value, empty);
 }
 
-EAPI const Eina_Value_Type *eina_value_optional_type_get_wrapper(Eina_Value *value)
+EFL_MONO_API const Eina_Value_Type *eina_value_optional_type_get_wrapper(Eina_Value *value)
 {
    return eina_value_optional_type_get(value);
 }
 
-EAPI Eina_Bool eina_value_pset_wrapper(Eina_Value *value, void *ptr)
+EFL_MONO_API Eina_Bool eina_value_pset_wrapper(Eina_Value *value, void *ptr)
 {
    return eina_value_pset(value, ptr);
 }

--- a/src/lib/efl_mono/efl_mono_accessors.c
+++ b/src/lib/efl_mono/efl_mono_accessors.c
@@ -18,23 +18,7 @@
 
 #include "Eina.h"
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-#  define EAPI __declspec(dllexport)
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif /* ! _WIN32 */
+#include "efl_mono_api.h"
 
 // This just a wrapper around carray acessors for pinned managed data
 // It uses the free callback to unpin the managed data so it can be
@@ -70,7 +54,7 @@ static void eina_mono_owned_carray_free_cb(Eina_Mono_Owned_Accessor* accessor)
    free(accessor);
 }
 
-EAPI Eina_Accessor *eina_mono_owned_carray_length_accessor_new(void** array, unsigned int step, unsigned int length, Eina_Free_Cb free_cb, void *handle)
+EFL_MONO_API Eina_Accessor *eina_mono_owned_carray_length_accessor_new(void** array, unsigned int step, unsigned int length, Eina_Free_Cb free_cb, void *handle)
 {
    Eina_Mono_Owned_Accessor *accessor = calloc(1, sizeof(Eina_Mono_Owned_Accessor));
    if (!accessor) return NULL;

--- a/src/lib/efl_mono/efl_mono_api.h
+++ b/src/lib/efl_mono/efl_mono_api.h
@@ -1,0 +1,34 @@
+#ifndef _EFL_EFL_MONO_API_H
+#define _EFL_EFL_MONO_API_H
+
+#ifdef EFL_MONO_API
+#error EFL_MONO_API should not be already defined
+#endif
+
+#ifdef _WIN32
+# ifndef EFL_MONO_STATIC
+#  ifdef EFL_MONO_BUILD
+#   define EFL_MONO_API __declspec(dllexport)
+#  else
+#   define EFL_MONO_API __declspec(dllimport)
+#  endif
+# else
+#  define EFL_MONO_API
+# endif
+# define EFL_MONO_API_WEAK
+#else
+# ifdef __GNUC__
+#  if __GNUC__ >= 4
+#   define EFL_MONO_API __attribute__ ((visibility("default")))
+#   define EFL_MONO_API_WEAK __attribute__ ((weak))
+#  else
+#   define EFL_MONO_API
+#   define EFL_MONO_API_WEAK
+#  endif
+# else
+#  define EFL_MONO_API
+#  define EFL_MONO_API_WEAK
+# endif
+#endif
+
+#endif

--- a/src/lib/efl_mono/efl_mono_model_internal.c
+++ b/src/lib/efl_mono/efl_mono_model_internal.c
@@ -6,24 +6,7 @@
 #include "Ecore.h"
 #include <Eo.h>
 
-#ifdef EAPI
-# undef EAPI
-#endif
-
-#ifdef _WIN32
-#  define EAPI __declspec(dllexport)
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif /* ! _WIN32 */
-
+#include "efl_mono_api.h"
 
 #include "efl_mono_model_internal.eo.h"
 #include "efl_mono_model_internal_child.eo.h"

--- a/src/tests/efl_mono/dummy_test_object.c
+++ b/src/tests/efl_mono/dummy_test_object.c
@@ -3986,11 +3986,11 @@ int _dummy_test_object_call_callback(EINA_UNUSED Eo *obj, Dummy_Test_Object_Data
 // Global var used due to the current issue of calling methods from the GC thread
 static Eina_Bool _free_called = EINA_FALSE;
 
-EAPI Eina_Bool free_called_get() {
+ Eina_Bool free_called_get() {
    return _free_called;
 }
 
-EAPI void free_called_set(Eina_Bool b) {
+ void free_called_set(Eina_Bool b) {
    _free_called = b;
 }
 

--- a/src/tests/efl_mono/libefl_mono_native_test.h
+++ b/src/tests/efl_mono/libefl_mono_native_test.h
@@ -25,42 +25,8 @@
 #include <Ecore.h>
 #include <Eo.h>
 
-#ifdef EOAPI
-#undef EOAPI
-#endif
-
-#ifdef EWAPI
-#undef EWAPI
-#endif
-
-#ifdef EAPI
-#undef EAPI
-#endif
-
-#define EOAPI EAPI EAPI_WEAK
-#define EWAPI EAPI EAPI_WEAK
-
-#ifdef _WIN32
-# ifdef EFL_BUILD
-#  ifdef DLL_EXPORT
-#   define EAPI __declspec(dllexport)
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI __declspec(dllimport)
-# endif
-#else
-# ifdef __GNUC__
-#  if __GNUC__ >= 4
-#   define EAPI __attribute__ ((visibility("default")))
-#  else
-#   define EAPI
-#  endif
-# else
-#  define EAPI
-# endif
-#endif
+#define EFL_MONO_TEST_API
+#define EFL_MONO_TEST_API_WEAK
 
 #include "dummy_test_iface.eo.h"
 #include "dummy_inherit_iface.eo.h"

--- a/src/tests/efl_mono/meson.build
+++ b/src/tests/efl_mono/meson.build
@@ -24,6 +24,7 @@ foreach eo_file : eo_files + private_eo_files
     command : eolian_gen + [ '-I', meson.current_source_dir(), eolian_include_directories,
                            '-o', 'h:' + join_paths(meson.current_build_dir(), eo_file + '.h'),
                            '-o', 'c:' + join_paths(meson.current_build_dir(), eo_file + '.c'),
+                           '-e', 'EFL_MONO_TEST_API',
                            '-gch', '@INPUT@'])
 endforeach
 


### PR DESCRIPTION
One more on the series to use `LIB_API` instead of `EAPI`.
In general, I followed these steps:
1. Create `lib_api.h`;
2. Remove every `#undef EAPI`;
3. Every place that was defining `EAPI` or `EWAPI` now includes
   `lib_api.h`;
4. Substitute `EAPI` for `LIB_API`;
5. Substitute `EWAPI` for `LIB_API LIB_API_WEAK`;
6. Substitute `EOAPI` for `LIB_API LIB_API_WEAK`;
7. Add `-DLIB_BUILD` at its lib definition on meson.build;
8. Add `LIB_api.h` to public headers;
9. If files are generated here, add `-e` flag to `eolian_gen` with
   `LIB_API` as argument (It didn't happen until now);

So, in the end, there should be no `EOAPI`/`EWAPI`/`EAPI` and only one
definition of `LIB_API`.

This one also worked on efl_mono tests, so `EAPI`/`EWAPI`/`EOAPI` were removed,
where those were defined, now I define `EFL_MONO_TEST_API` and its `WEAK`
contra part. Also, `meson.build` should change accordingly to pass `-e
EFL_MONO_TEST_API`.