### PR TITLE
Building Ector

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -506,7 +506,6 @@ if sys_windows
     'ecore_win32',
     'ecore_wl2',
     'ecore_x',
-    'ector',
     'edje',
     'eeze',
     'efl_canvas_wl',


### PR DESCRIPTION
This PR is redoing #139, but merging to native-windows.

Ector is building and passing tests:
```
25/25 ector-suite               OK             0.11s
```

Note that this PR depends on (#273).