### PR TITLE
[WIP] [Bug] An example was using EAPI instead of EAPI_MAIN as all the others

### DIFF
--- a/src/examples/elementary/toolbar_cxx_example_01.cc
+++ b/src/examples/elementary/toolbar_cxx_example_01.cc
@@ -25,7 +25,7 @@
 #endif
 #include <Efl_Ui.hh>
 
-EAPI int
+EAPI_MAIN int
 elm_main(int argc EINA_UNUSED, char* argv[] EINA_UNUSED)
 {
    elm_policy_set(ELM_POLICY_QUIT, ELM_POLICY_QUIT_LAST_WINDOW_HIDDEN);
@@ -148,7 +148,7 @@ elm_main(int argc EINA_UNUSED, char* argv[] EINA_UNUSED)
    efl::eolian::event_add(efl::ui::Selectable::selected_event, item_5, _item_5_selected_cb);
 
 #endif
-   
+
    elm_run();
    return 0;
 }


### PR DESCRIPTION
This is the only `EAPI` on `src/example` beside it, there is `EAPI_MAIN` (which is defined by core) so I'm following the pattern that this `EAPI` should be `EAPI_MAIN`.
