### PR TITLE
[ecore] Use eina_pipe

### DIFF
--- a/src/lib/eina/eina_thread_queue.c
+++ b/src/lib/eina/eina_thread_queue.c
@@ -480,7 +480,7 @@ eina_thread_queue_send_done(Eina_Thread_Queue *thq, void *allocref)
    if (thq->fd >= 0)
      {
         char dummy = 0;
-        if (write(thq->fd, &dummy, 1) != 1)
+        if (pipe_write(thq->fd, &dummy, 1) != 1)
           ERR("Eina Threadqueue write to fd %i failed", thq->fd);
      }
 }

--- a/src/tests/ecore/ecore_test_ecore.c
+++ b/src/tests/ecore/ecore_test_ecore.c
@@ -120,13 +120,13 @@ EFL_START_TEST(ecore_test_ecore_main_loop_fd_handler)
      (comm[0], ECORE_FD_READ, _fd_handler_cb, &did, NULL, NULL);
    fail_if(fd_handler == NULL);
 
-   ret = write(comm[1], &did, 1);
+   ret = pipe_write(comm[1], &did, 1);
    fail_if(ret != 1);
 
    ecore_main_loop_begin();
 
-   close(comm[0]);
-   close(comm[1]);
+   pipe_close(comm[0]);
+   pipe_close(comm[1]);
 
    fail_if(did == EINA_FALSE);
 
@@ -149,8 +149,8 @@ EFL_START_TEST(ecore_test_ecore_main_loop_fd_handler_valid_flags)
    if (fd_handler)
 	   ecore_main_fd_handler_del(fd_handler);
 
-   close(comm[0]);
-   close(comm[1]);
+   pipe_close(comm[0]);
+   pipe_close(comm[1]);
 }
 EFL_END_TEST
 
@@ -170,13 +170,13 @@ EFL_START_TEST(ecore_test_ecore_main_loop_fd_handler_activate_modify)
 
    ecore_main_fd_handler_active_set(fd_handler, ECORE_FD_READ);
 
-   ret = write(comm[1], "e", 1);
+   ret = pipe_write(comm[1], "e", 1);
    fail_if(ret != 1);
 
    ecore_main_loop_begin();
 
-   close(comm[0]);
-   close(comm[1]);
+   pipe_close(comm[0]);
+   pipe_close(comm[1]);
 
    fail_if(did != EINA_TRUE);
 

--- a/src/tests/ecore/ecore_test_ecore_thread_eina_thread_queue.c
+++ b/src/tests/ecore/ecore_test_ecore_thread_eina_thread_queue.c
@@ -661,7 +661,7 @@ EFL_START_TEST(ecore_test_ecore_thread_eina_thread_queue_t7)
      {
         char buf;
 
-        if (read(p[0], &buf, 1) != 1)
+        if (pipe_read(p[0], &buf, 1) != 1)
           if (DEBUG) printf("Error reading from pipe\n");
         msg = eina_thread_queue_wait(thq1, &ref);
         if (msg)
@@ -675,8 +675,8 @@ EFL_START_TEST(ecore_test_ecore_thread_eina_thread_queue_t7)
    if (DEBUG) printf("msg fd ok\n");
    ecore_thread_wait(eth1, 0.1);
    eina_thread_queue_free(thq1);
-   close(p[0]);
-   close(p[1]);
+   pipe_close(p[0]);
+   pipe_close(p[1]);
 }
 EFL_END_TEST
 

--- a/src/tests/ecore/efl_app_test_loop_fd.c
+++ b/src/tests/ecore/efl_app_test_loop_fd.c
@@ -39,13 +39,13 @@ EFL_START_TEST(ecore_test_efl_loop_fd)
                efl_event_callback_add(efl_added, EFL_LOOP_FD_EVENT_READ, _eo_read_cb, &did));
    fail_if(fd == NULL);
 
-   ret = write(comm[1], &did, 1);
+   ret = pipe_write(comm[1], &did, 1);
    fail_if(ret != 1);
 
    efl_loop_begin(efl_main_loop_get());
 
-   close(comm[0]);
-   close(comm[1]);
+   pipe_close(comm[0]);
+   pipe_close(comm[1]);
 
    fail_if(did == EINA_FALSE);
 
@@ -77,13 +77,13 @@ EFL_START_TEST(ecore_test_efl_loop_fd_lifecycle)
                efl_event_callback_add(efl_added, EFL_EVENT_DEL, _efl_del_cb, &dead));
    fail_if(fd == NULL);
 
-   ret = write(comm[1], &did, 1);
+   ret = pipe_write(comm[1], &did, 1);
    fail_if(ret != 1);
 
    efl_loop_begin(efl_main_loop_get());
 
-   close(comm[0]);
-   close(comm[1]);
+   pipe_close(comm[0]);
+   pipe_close(comm[1]);
 
    fail_if(did == EINA_FALSE);
    fail_if(dead == EINA_TRUE);


### PR DESCRIPTION
Use `pipe_write`, `pipe_read` and `pipe_close` instead of `write`, `read`, `close`.