### PR TITLE
[ecore] Guard unistd for native windows builds

### DIFF
--- a/src/tests/ecore/ecore_test_ecore.c
+++ b/src/tests/ecore/ecore_test_ecore.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER_
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* pipe */

--- a/src/tests/ecore/ecore_test_ecore_input.c
+++ b/src/tests/ecore/ecore_test_ecore_input.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore_Input.h>
 

--- a/src/tests/ecore/ecore_test_ecore_thread_eina_thread_queue.c
+++ b/src/tests/ecore/ecore_test_ecore_thread_eina_thread_queue.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* pipe */

--- a/src/tests/ecore/ecore_test_idle.c
+++ b/src/tests/ecore/ecore_test_idle.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eina.h>
 #include <Ecore.h>

--- a/src/tests/ecore/ecore_test_poller.c
+++ b/src/tests/ecore/ecore_test_poller.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eina.h>
 #include <Ecore.h>

--- a/src/tests/ecore/efl_app_suite.c
+++ b/src/tests/ecore/efl_app_suite.c
@@ -3,7 +3,15 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
+
 #define EFL_NOLEGACY_API_SUPPORT
 #include <Efl_Core.h>
 #include "efl_app_suite.h"

--- a/src/tests/ecore/efl_app_test_cml.c
+++ b/src/tests/ecore/efl_app_test_cml.c
@@ -5,7 +5,11 @@
 #define EFL_CORE_COMMAND_LINE_PROTECTED
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #define EFL_NOLEGACY_API_SUPPORT
 #include <Efl_Core.h>
 #include "efl_app_suite.h"

--- a/src/tests/ecore/efl_app_test_env.c
+++ b/src/tests/ecore/efl_app_test_env.c
@@ -3,7 +3,11 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #define EFL_NOLEGACY_API_SUPPORT
 #include <Efl_Core.h>
 #include "efl_app_suite.h"

--- a/src/tests/ecore/efl_app_test_loop.c
+++ b/src/tests/ecore/efl_app_test_loop.c
@@ -3,7 +3,11 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #include "eo_internal.h"
 #define EFL_NOLEGACY_API_SUPPORT
 #include <Efl_Core.h>

--- a/src/tests/ecore/efl_app_test_loop_fd.c
+++ b/src/tests/ecore/efl_app_test_loop_fd.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* pipe */

--- a/src/tests/ecore/efl_app_test_loop_timer.c
+++ b/src/tests/ecore/efl_app_test_loop_timer.c
@@ -3,7 +3,11 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #define EFL_NOLEGACY_API_SUPPORT
 #include <Efl_Core.h>
 #include "efl_app_suite.h"

--- a/src/tests/ecore/efl_app_test_promise.c
+++ b/src/tests/ecore/efl_app_test_promise.c
@@ -3,7 +3,11 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #define EFL_NOLEGACY_API_SUPPORT
 #include <Efl_Core.h>
 #include "efl_app_suite.h"

--- a/src/tests/ecore_con/ecore_con_test_ecore_con_url.c
+++ b/src/tests/ecore_con/ecore_con_test_ecore_con_url.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eina.h>
 #include <Ecore.h>


### PR DESCRIPTION
This is based on
[5d28ab4](https://github.com/expertisesolutions/efl/commit/5d28ab4) but
instead of removing `unistd.h`, this adds guards making it only included
on non-native windows builds.