### PR TITLE
[efl] Change efl build definition

### DIFF
--- a/src/lib/efl/efl_api.h
+++ b/src/lib/efl/efl_api.h
@@ -7,7 +7,7 @@
 
 #ifdef _WIN32
 # ifndef EFL_STATIC
-#  ifdef EFL_BUILD
+#  ifdef EFL_LIB_BUILD
 #   define EFL_API __declspec(dllexport)
 #  else
 #   define EFL_API __declspec(dllimport)

--- a/src/lib/efl/meson.build
+++ b/src/lib/efl/meson.build
@@ -21,7 +21,7 @@ endif
 
 efl_lib = library('efl',
     efl_src, pub_eo_file_target,
-    c_args : [package_c_args, '-DEFL_BUILD'],
+    c_args : [package_c_args, '-DEFL_LIB_BUILD'],
     dependencies: [efl_deps, efl_pub_deps, efl_ext_deps],
     install: true,
     version : meson.project_version()


### PR DESCRIPTION
As `EFL_BUILD` is already a thing, this changes `EFL_BUILD` to
`EFL_LIB_BUILD` removing any chance of wrongly setting it.

Based on [946db](https://github.com/expertisesolutions/efl/commit/946db530a7dc799b841f24311b68a23ebc439497)