### PR TITLE
fix: The -I should be passed to the linker.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -339,9 +339,11 @@ elif (get_option('crypto') == 'gnutls')
   config_h.set('HAVE_GNUTLS', '1')
 elif (get_option('crypto') == 'openssl')
   if (get_option('openssl_dir') != '')
-    crypto = declare_dependency(
-      link_args: ['-L' + get_option('openssl_dir'), '-L' + get_option('openssl_dir') + '/lib', '-llibssl_static', '-llibcrypto_static'],
-      compile_args: ['-I' + get_option('openssl_dir') + '/include'],
+    crypto = declare_dependency(link_args: [
+      '-I' + get_option('openssl_dir') / 'include',
+      '-L' + get_option('openssl_dir'),
+      '-L' + get_option('openssl_dir') / 'lib',
+      '-llibssl_static', '-llibcrypto_static'],
     )
   else
     crypto = dependency('openssl')


### PR DESCRIPTION
The meson has a buildin argument for `declare_dependency()` called `include_directories` but to use it the path should NOT be an absolute path. To be able to use absolute path here we need to use 'I' include flag. The equivalent for `include_directories` here is `link_args` and not `compile_args`.