### PR TITLE
evas: Add guards to some includes

### DIFF
--- a/src/lib/ecore_evas/ecore_evas.c
+++ b/src/lib/ecore_evas/ecore_evas.c
@@ -12,7 +12,10 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* mmap */

--- a/src/lib/ecore_evas/ecore_evas_module.c
+++ b/src/lib/ecore_evas/ecore_evas_module.c
@@ -7,7 +7,14 @@
 
 #include "Ecore_Evas.h"
 #include "ecore_evas_private.h"
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
 
 #include "../../static_libs/buildsystem/buildsystem.h"
 

--- a/src/lib/evas/canvas/efl_canvas_vg_gradient.c
+++ b/src/lib/evas/canvas/efl_canvas_vg_gradient.c
@@ -3,7 +3,13 @@
 
 #include "evas_vg_private.h"
 
-#include <strings.h>
+#ifndef _MSC_VER
+# include <strings.h>
+#endif
+
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
 
 #define MY_CLASS EFL_CANVAS_VG_GRADIENT_CLASS
 

--- a/src/lib/evas/canvas/efl_canvas_vg_gradient_linear.c
+++ b/src/lib/evas/canvas/efl_canvas_vg_gradient_linear.c
@@ -3,7 +3,13 @@
 
 #include "evas_vg_private.h"
 
-#include <strings.h>
+#ifndef _MSC_VER
+# include <strings.h>
+#endif
+
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
 
 #define MY_CLASS EFL_CANVAS_VG_GRADIENT_LINEAR_CLASS
 

--- a/src/lib/evas/canvas/evas_async_events.c
+++ b/src/lib/evas/canvas/evas_async_events.c
@@ -2,7 +2,10 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #include <errno.h>
 
 #ifdef _WIN32

--- a/src/lib/evas/canvas/evas_font_dir.c
+++ b/src/lib/evas/canvas/evas_font_dir.c
@@ -66,8 +66,12 @@ static FcConfig *fc_config = NULL;
 /* FIXME move these helper function to eina_file or eina_path */
 /* get the casefold feature! */
 #include <Eina.h>
-#include <unistd.h>
-#include <sys/param.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+# include <sys/param.h>
+#endif
+
 int
 _file_path_is_full_path(const char *path)
 {

--- a/src/lib/evas/canvas/evas_image_private.h
+++ b/src/lib/evas/canvas/evas_image_private.h
@@ -11,8 +11,15 @@
 #include "evas_common_private.h"
 
 #include <sys/types.h>
-#include <unistd.h>
 #include <math.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
+#ifdef _WIN32_
+# include <evil_private.h>
+#endif
 
 #include "evas_private.h"
 #include "../common/evas_convert_color.h"

--- a/src/lib/evas/common/evas_image_load.c
+++ b/src/lib/evas/common/evas_image_load.c
@@ -4,7 +4,14 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
+#ifdef _WIN32_
+# include <evil_private.h>
+#endif
 
 #include "evas_common_private.h"
 #include "evas_private.h"
@@ -23,43 +30,43 @@ struct ext_loader_s
 static const struct ext_loader_s loaders[] =
 { /* map extensions to loaders to use for good first-guess tries */
    MATCHING(".png", "png"),
-   
+
    MATCHING(".jpg", "jpeg"),
    MATCHING(".jpeg", "jpeg"),
    MATCHING(".jfif", "jpeg"),
-   
+
    MATCHING(".j2k", "jp2k"),
    MATCHING(".jp2", "jp2k"),
    MATCHING(".jpx", "jp2k"),
    MATCHING(".jpf", "jp2k"),
-   
+
    MATCHING(".eet", "eet"),
    MATCHING(".edj", "eet"),
    MATCHING(".eap", "eet"),
-   
+
    MATCHING(".xpm", "xpm"),
-   
+
    MATCHING(".tiff", "tiff"),
    MATCHING(".tif", "tiff"),
-   
+
    MATCHING(".gif", "gif"),
-   
+
    MATCHING(".pbm", "pmaps"),
    MATCHING(".pgm", "pmaps"),
    MATCHING(".ppm", "pmaps"),
    MATCHING(".pnm", "pmaps"),
-   
+
    MATCHING(".bmp", "bmp"),
-   
+
    MATCHING(".tga", "tga"),
-   
+
    MATCHING(".wbmp", "wbmp"),
-   
+
    MATCHING(".webp", "webp"),
-   
+
    MATCHING(".ico", "ico"),
    MATCHING(".cur", "ico"),
-   
+
    MATCHING(".psd", "psd"),
 
    MATCHING(".tgv", "tgv"),

--- a/src/lib/evas/common/evas_image_load.c
+++ b/src/lib/evas/common/evas_image_load.c
@@ -30,43 +30,43 @@ struct ext_loader_s
 static const struct ext_loader_s loaders[] =
 { /* map extensions to loaders to use for good first-guess tries */
    MATCHING(".png", "png"),
-
+   
    MATCHING(".jpg", "jpeg"),
    MATCHING(".jpeg", "jpeg"),
    MATCHING(".jfif", "jpeg"),
-
+   
    MATCHING(".j2k", "jp2k"),
    MATCHING(".jp2", "jp2k"),
    MATCHING(".jpx", "jp2k"),
    MATCHING(".jpf", "jp2k"),
-
+   
    MATCHING(".eet", "eet"),
    MATCHING(".edj", "eet"),
    MATCHING(".eap", "eet"),
-
+   
    MATCHING(".xpm", "xpm"),
-
+   
    MATCHING(".tiff", "tiff"),
    MATCHING(".tif", "tiff"),
-
+   
    MATCHING(".gif", "gif"),
-
+   
    MATCHING(".pbm", "pmaps"),
    MATCHING(".pgm", "pmaps"),
    MATCHING(".ppm", "pmaps"),
    MATCHING(".pnm", "pmaps"),
-
+   
    MATCHING(".bmp", "bmp"),
-
+   
    MATCHING(".tga", "tga"),
-
+   
    MATCHING(".wbmp", "wbmp"),
-
+   
    MATCHING(".webp", "webp"),
-
+   
    MATCHING(".ico", "ico"),
    MATCHING(".cur", "ico"),
-
+   
    MATCHING(".psd", "psd"),
 
    MATCHING(".tgv", "tgv"),

--- a/src/lib/evas/common/evas_pipe.c
+++ b/src/lib/evas/common/evas_pipe.c
@@ -1,5 +1,12 @@
 #include "evas_common_private.h"
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
 
 #ifdef BUILD_PIPE_RENDER
 
@@ -621,7 +628,7 @@ static Eina_Bool
 evas_common_pipe_map_draw_prepare(void *data EINA_UNUSED, RGBA_Image *dst, RGBA_Pipe_Op *op)
 {
    RGBA_Draw_Context context;
-   Eina_Bool r; 
+   Eina_Bool r;
 
    memcpy(&(context), &(op->context), sizeof(RGBA_Draw_Context));
    r = evas_common_map_rgba_prepare(op->op.map.src, dst,
@@ -641,10 +648,10 @@ evas_common_pipe_map_draw(RGBA_Image *src, RGBA_Image *dst,
    /* pts_copy = malloc(sizeof (RGBA_Map_Point) * 4); */
    /* if (!pts_copy) return; */
    dst->cache_entry.pipe = evas_common_pipe_add(dst->cache_entry.pipe, &op);
-   if (!dst->cache_entry.pipe) 
+   if (!dst->cache_entry.pipe)
      {
        /* free(pts_copy); */
-       return; 
+       return;
      }
 
    /* for (i = 0; i < 4; ++i) */

--- a/src/lib/evas/common/evas_pipe.h
+++ b/src/lib/evas/common/evas_pipe.h
@@ -1,7 +1,15 @@
 #ifndef _EVAS_PIPE_H
 #define _EVAS_PIPE_H
 
-#include <sys/time.h>
+
+#ifndef _MSC_VER
+# include <sys/time.h>
+#endif
+
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
+
 #include "language/evas_bidi_utils.h"
 
 /* image rendering pipelines... new optional system - non-immediate and

--- a/src/lib/evas/file/evas_path.c
+++ b/src/lib/evas/file/evas_path.c
@@ -13,8 +13,11 @@
 #include <sys/stat.h>
 /* get the casefold feature! */
 #include <Eina.h>
-#include <unistd.h>
-#include <sys/param.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+# include <sys/param.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* evil_path_is_absolute */

--- a/src/lib/evas/include/evas_common_private.h
+++ b/src/lib/evas/include/evas_common_private.h
@@ -29,7 +29,7 @@
 # include <sys/stat.h>
 #endif
 
-#ifndef _WIN32
+#ifdef _WIN32
 # include <evil_private.h>
 #endif
 

--- a/src/lib/evas/include/evas_common_private.h
+++ b/src/lib/evas/include/evas_common_private.h
@@ -22,15 +22,21 @@
 #include <time.h>
 #include <ctype.h>
 #include <stdint.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+# include <sys/types.h>
+# include <sys/stat.h>
+#endif
+
+#ifndef _WIN32
+# include <evil_private.h>
+#endif
+
 
 #ifdef HAVE_PIXMAN
 #include <pixman.h>
 #endif
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 #include <Eina.h>
 #include <Eo.h>

--- a/src/modules/evas/engines/software_generic/evas_native_dmabuf.c
+++ b/src/modules/evas/engines/software_generic/evas_native_dmabuf.c
@@ -2,7 +2,9 @@
 #include "evas_private.h"
 #include "evas_native_common.h"
 
-#if defined HAVE_DLSYM
+#ifdef _MSC_VER
+# include <evil_private>
+#elif defined HAVE_DLSYM
 # include <dlfcn.h>      /* dlopen,dlclose,etc */
 #elif _WIN32
 # include <evil_private.h> /* dlopen dlclose dlsym mmap */

--- a/src/tests/evas/evas_test_image.c
+++ b/src/tests/evas/evas_test_image.c
@@ -5,7 +5,14 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
+#ifndef _WIN32
+# include <evil_private.h>
+#endif
 
 #include <Evas.h>
 #include <Ecore_Evas.h>

--- a/src/tests/evas/evas_test_image.c
+++ b/src/tests/evas/evas_test_image.c
@@ -10,7 +10,7 @@
 # include <unistd.h>
 #endif
 
-#ifndef _WIN32
+#ifdef _WIN32
 # include <evil_private.h>
 #endif
 


### PR DESCRIPTION
This is based on [805dccea](https://github.com/expertisesolutions/efl/commit/805dccea1434e7bc6bbf1d112b29ba58063475e0) but instead of guarding with `_WIN32` I'm guarding it with `_MSC_VER` as this should already work with `msys`