### PR TITLE
[Deps] [Redone] Ecore without tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -439,7 +439,7 @@ subprojects = [
 ['eet'              ,[]                    , false,  true,  true, false,  true,  true,  true, ['eina', 'emile', 'efl'], []],
 ['ecore'            ,[]                    , false,  true, false, false, false, false,  true, ['eina', 'eo', 'efl'], ['buildsystem']],
 ['eldbus'           ,[]                    , false,  true,  true, false,  true,  true,  true, ['eina', 'eo', 'efl'], []],
-['ecore'            ,[]                    ,  true, false, false, false,  true,  true,  true, ['eina', 'eo', 'efl'], []], #ecores modules depend on eldbus
+['ecore'            ,[]                    ,  true, false, false, false, false,  true,  true, ['eina', 'eo', 'efl'], []], #ecores modules depend on eldbus
 ['ecore_audio'      ,['audio']             , false,  true, false, false, false, false,  true, ['eina', 'eo'], []],
 ['ecore_avahi'      ,['avahi']             , false,  true, false, false, false,  true, false, ['eina', 'ecore'], []],
 ['ecore_con'        ,[]                    , false,  true,  true, false,  true, false,  true, ['eina', 'eo', 'efl', 'ecore'], ['http-parser']],
@@ -485,7 +485,6 @@ if sys_windows
     'eldbus',
     'elput',
     # temporarily ignored
-    'ecore',
     'ecore_audio',
     'ecore_avahi',
     'ecore_buffer',


### PR DESCRIPTION
After #159 Ecore will be building fine **without tests**.

However before this PR is ready for review we need to:
  - [x] gettimeofday into native-windows (fixed by #159)
  - [x] properly fix winsock2 (fixed by #197)

To be clear why **without tests**, to enable test to be built we'll need to build:
  - ecore_file  
     - ecore_con  
  - ecore_input  
  - ecore_evas  
    - ecore_input_evas  
       - evas  
       - ecore_win32
  - ecore_imf  
  - _and possibly others..._