### PR TITLE
win32: Remove multiple frees for stringshare

### DIFF
--- a/src/lib/ecore_evas/ecore_evas_fallback_selection.c
+++ b/src/lib/ecore_evas/ecore_evas_fallback_selection.c
@@ -68,7 +68,6 @@ available_types(Eina_Array *acceptable_types, Eina_Array *available_types)
           {
              found_type = eina_stringshare_ref(type);
           }
-        eina_stringshare_del(type);
      }
   eina_array_free(acceptable_types);
 


### PR DESCRIPTION
The function available_types do not get ownership of the acceptable_types, and so shouldn't free the stringshares it receives. Doing so causes double free.

Original from https://github.com/expertisesolutions/efl/commit/60c3f1e8a5a8ad2c052c00a4be3bda450d781514