### PR TITLE
win32: Fix unistd.h include and incdir

### DIFF
--- a/src/generic/evas/meson.build
+++ b/src/generic/evas/meson.build
@@ -12,7 +12,8 @@ subdir('common')
 inc_dir = config_dir
 common_deps = generic_deps
 if sys_windows
-  inc_dir = [inc_dir, zlib_include_dir]
+  inc_dir = [inc_dir]
+  common_deps = [evil, zlib]
 else
   common_deps = [generic_deps, rt]
 endif


### PR DESCRIPTION
Based on https://github.com/expertisesolutions/efl/commit/f199fbc671f0827999eccc283734ea9d7b98defe