### PR TITLE
Install ninja through pip on Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,7 @@ jobs:
       run: nasm -v
     - name: install ninja
       # unexplicably, installation returns error code 1 if a cache location is used
-      run: choco install ninja
+      run: py -3 -m pip install ninja
     - name: test ninja
       run: ninja --version
     - name: install meson
@@ -100,7 +100,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: install ninja
       # unexplicably, installation returns error code 1 if a cache location is used
-      run: choco install ninja
+      run: py -3 -m pip install ninja
     - name: test ninja
       run: ninja --version
     - name: install meson

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,18 +42,17 @@ jobs:
       run: echo "::add-path::C:\Program Files\Nasm"
     - name: Test nasm
       run: nasm -v
+    - name: add python scripts to path
+      run: |
+        $python_version = (py -3 --version).replace("Python ", "")
+        $python_scripts_path = ($(echo C:\hostedtoolcache\windows\Python\$python_version\x64\Scripts ) -join "")
+        echo "::add-path::$python_scripts_path"
     - name: install ninja
-      # unexplicably, installation returns error code 1 if a cache location is used
       run: py -3 -m pip install ninja
     - name: test ninja
       run: ninja --version
     - name: install meson
       run: py -3 -m pip install meson
-    - name: add meson to path
-      run: |
-        $python_version = (py -3 --version).replace("Python ", "")
-        $meson_path = ($(echo C:\hostedtoolcache\windows\Python\$python_version\x64\Scripts ) -join "")
-        echo "::add-path::$meson_path"
     - name: test meson
       run: meson -v
     - name: Cache OpenSSL compilation
@@ -98,6 +97,11 @@ jobs:
     needs: build
     steps:
     - uses: actions/checkout@v2
+    - name: add python scripts to path
+      run: |
+        $python_version = (py -3 --version).replace("Python ", "")
+        $python_scripts_path = ($(echo C:\hostedtoolcache\windows\Python\$python_version\x64\Scripts ) -join "")
+        echo "::add-path::$python_scripts_path"
     - name: install ninja
       # unexplicably, installation returns error code 1 if a cache location is used
       run: py -3 -m pip install ninja
@@ -105,11 +109,6 @@ jobs:
       run: ninja --version
     - name: install meson
       run: py -3 -m pip install meson
-    - name: add meson to path
-      run: |
-        $python_version = (py -3 --version).replace("Python ", "")
-        $meson_path = ($(echo C:\hostedtoolcache\windows\Python\$python_version\x64\Scripts ) -join "")
-        echo "::add-path::$meson_path"
     - name: test meson
       run: meson -v
     - name: Download artifact


### PR DESCRIPTION
This shaves off at least a minute from the CI builds :rocket: 

Meson and Ninja are Python applications. Installing through choco probably required downloading a much beefier package, with an embedded CPython build. Installing with pip is the logical way to do it, especially considering we already install Meson this way.