### PR TITLE
Removing redundant parameters

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -68,10 +68,8 @@ exit /B 0
     :: ------------------------------------------------------
     set MESONFLAGS=^
             -Dopenssl_dir="%OPENSSL_DIR:"=%"^
-            -Dcrypto=openssl^
             -Dnls=false^
             -Dsystemd=false^
-            -Dglib=false^
             -Dgstreamer=false^
             -Ddbus=false^
             -Daudio=false^
@@ -90,7 +88,6 @@ exit /B 0
             "-Devas-loaders-disabler=gst,pdf,ps,raw,svg,rsvg,xcf,bmp,dds,eet,generic,gif,ico,jp2k,pmaps,png,psd,tga,tgv,tiff,wbmp,webp,xpm,json"^
             -Dopengl=none^
             "-Demotion-loaders-disabler=gstreamer1,libvlc,xine"^
-            -Dbuild-tests=true^
             -Dbuild-examples=false^
             -Dbindings=^
             --buildtype=debug^


### PR DESCRIPTION
These options are setting exactly the default set in `meson_options.txt` and since windows have a very short limited line-length for commands we can save some characters here for future usage.