### PR TITLE
Rename shutdown as proxy_helper_shutdown

### DIFF
--- a/src/bin/ecore_con/efl_net_proxy_helper.c
+++ b/src/bin/ecore_con/efl_net_proxy_helper.c
@@ -115,7 +115,7 @@ init(void)
 }
 
 static void
-shutdown(void)
+proxy_helper_shutdown(void)
 {
    if (_libproxy.factory)
      {
@@ -253,7 +253,7 @@ main(int argc EINA_UNUSED, char **argv EINA_UNUSED)
              clean_threads();
           }
         eina_spinlock_free(&pending_lock);
-        shutdown();
+        proxy_helper_shutdown();
      }
    else
      {


### PR DESCRIPTION
This change is needed because `winsock.h/winsock2.h` define a `shutdown` function so we have a naming clash here. 
As we don't have power over `winsock.h/winsock2.h` , our alternative is to change _our_ function name.

Depends on #312 as you can see at `devs/coquinho/clean/evas-fixes` but as ecore_con is not being compiled yet, this doesn't need to be merged after #312;

Based on 2c3143b57eb966797e8df96c7f61d02e858a3dc2