### PR TITLE
[Eina test]Removing a warning by fixing a cast

### DIFF
--- a/src/tests/eina/eina_test_array.c
+++ b/src/tests/eina/eina_test_array.c
@@ -185,7 +185,7 @@ EFL_START_TEST(eina_array_find_test)
    eina_array_step_set(&sea, sizeof(sea), 5);
 
    for (i = 1 ; i < 10 ; i++)
-     eina_array_push(&sea, (uintptr_t) i);
+     eina_array_push(&sea, (void *)i);
 
    fail_if(eina_array_find(&sea, (void *)15, NULL) != EINA_FALSE);
 


### PR DESCRIPTION
Just a small fix to [this](https://travis-ci.com/github/expertisesolutions/efl/jobs/361273167#L3571) warning: [result](https://travis-ci.com/github/expertisesolutions/efl/jobs/361715932#L3609).