### PR TITLE
build: Properly handle --verbose arg

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -1,14 +1,17 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-if "%~1"=="--verbose" (
+:: Receive extra-flags
+set MESONFLAGS_EXTRA=%*
+
+:: Look for verbosity of this script and additional flags for meson
+(echo %MESONFLAGS_EXTRA% | findstr /i /c:"--verbose" >nul) && set VERBOSE=ON
+if defined VERBOSE (
     echo Verbose ON.
-    set VERBOSE=ON
+    set MESONFLAGS_EXTRA=%MESONFLAGS_EXTRA:--verbose=%
 ) else (
     echo Verbose OFF.
 )
-
-set MESONFLAGS_EXTRA=%*
 
 call :main || (echo Build configure failed.)
 exit /B %errorlevel%
@@ -107,7 +110,7 @@ exit /B 0
     @echo Here %NL%we go
     @echo Meson flags: %MESONFLAGS:        =!NL!%
     @echo ------------------------------
-    @echo Extra flags: %MESONFLAGS_EXTRA%
+    @echo Extra flags: !MESONFLAGS_EXTRA!
     @echo ------------------------------
     @set MESONFLAGS=%MESONFLAGS:            = %
 exit /B 0


### PR DESCRIPTION
# Current scenario

In `configure.bat`, the user may want to add custom flags to meson calling:

```console
$ configure <extra args to meson>
```

Meanwhile, a "verbose" mode was also available for configure, which would send `-v` flag to the `clang-cl` compiler (making it always output its command line, so there would be no need to check every `.rsp` to see compiler flags).

# The problems

Previously, verbose output from configure only had effect if `--verbose` was the **first** argument. Not only that, we had a hidden bug on it:
- Since `%MESONFLAGS_EXTRA%` was used (instead of `!MESONFLAGS_EXTRA!`), no flags were sent to meson from `configure` command line (because of how delayed expansion works on Windows);
- By fixing the usage of  `!` instead of `%`, since there was no filter on extra args sent to meson, the `--verbose` flag was also being sent, which would make `meson` fail due to not having a `--verbose` flag.

# The fix
- Fix sending extra flags to meson replacing `%MESONFLAGS_EXTRA%` with `!MESONFLAGS_EXTRA!`;
- Filter `configure.bat`-specific args by not sending them to meson.