### PR TITLE
[Evil] Replacing every evil_*.h include with evil_private.h

### DIFF
--- a/src/lib/evil/evil_basename.c
+++ b/src/lib/evil/evil_basename.c
@@ -2,8 +2,7 @@
 # include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <evil_api.h>
-#include <evil_private.h>
+#include "evil_private.h"
 
 #include <stdlib.h>
 

--- a/src/lib/evil/evil_basename.h
+++ b/src/lib/evil/evil_basename.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_BASENAME_H__
 #define __EVIL_BASENAME_H__
 
-#include <evil_api.h>
+#include "evil_private.h"
 
 EVIL_API char* basename (char* path);
 

--- a/src/lib/evil/evil_dlfcn.h
+++ b/src/lib/evil/evil_dlfcn.h
@@ -2,7 +2,7 @@
 #define __EVIL_DLFCN_H__
 
 
-#include "evil_api.h"
+#include "evil_private.h"
 #include <limits.h>
 
 

--- a/src/lib/evil/evil_fcntl.h
+++ b/src/lib/evil/evil_fcntl.h
@@ -2,7 +2,7 @@
 #define __EVIL_FCNTL_H__
 
 
-#include <evil_api.h>
+#include "evil_private.h"
 #include <sys/types.h>
 
 

--- a/src/lib/evil/evil_langinfo.h
+++ b/src/lib/evil/evil_langinfo.h
@@ -2,7 +2,7 @@
 #define __EVIL_LANGINFO_H__
 
 
-#include <evil_api.h>
+#include "evil_private.h"
 #include <locale.h>
 
 

--- a/src/lib/evil/evil_locale.h
+++ b/src/lib/evil/evil_locale.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_LOCALE_H__
 #define __EVIL_LOCALE_H__
 
-#include <evil_api.h>
+#include "evil_private.h"
 
 /**
  * @file evil_locale.h

--- a/src/lib/evil/evil_macro_wrapper.h
+++ b/src/lib/evil/evil_macro_wrapper.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_MACRO_WRAPPER_H__
 #define __EVIL_MACRO_WRAPPER_H__
 
-#include <evil_api.h>
+#include "evil_private.h"
 #include <direct.h>
 
 /*

--- a/src/lib/evil/evil_main.h
+++ b/src/lib/evil/evil_main.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_MAIN_H__
 #define __EVIL_MAIN_H__
 
-#include <evil_api.h>
+#include "evil_private.h"
 
 /**
  * @page evil_main Evil

--- a/src/lib/evil/evil_mman.c
+++ b/src/lib/evil/evil_mman.c
@@ -2,8 +2,6 @@
 # include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <evil_api.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>

--- a/src/lib/evil/evil_mman.h
+++ b/src/lib/evil/evil_mman.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_SYS_MMAN_H__
 #define __EVIL_SYS_MMAN_H__
 
-#include <evil_api.h>
+#include "evil_private.h"
 
 #include <sys/types.h>
 

--- a/src/lib/evil/evil_stdio.h
+++ b/src/lib/evil/evil_stdio.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_STDIO_H__
 #define __EVIL_STDIO_H__
 
-#include <evil_api.h>
+#include "evil_private.h"
 #include <sys/types.h>
 
 #ifndef HAVE_CYGWIN

--- a/src/lib/evil/evil_stdlib.h
+++ b/src/lib/evil/evil_stdlib.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_STDLIB_H__
 #define __EVIL_STDLIB_H__
 
-#include "evil_api.h"
+#include "evil_private.h"
 
 /**
  * @file evil_stdlib.h

--- a/src/lib/evil/evil_string.h
+++ b/src/lib/evil/evil_string.h
@@ -1,9 +1,6 @@
 #ifndef __EVIL_STRING_H__
 #define __EVIL_STRING_H__
 
-#include <evil_api.h>
-
-#include "evil_strings.h"
 #include "evil_private.h"
 /**
  * @file evil_string.h

--- a/src/lib/evil/evil_strings.c
+++ b/src/lib/evil/evil_strings.c
@@ -1,4 +1,4 @@
-#include "evil_strings.h"
+#include "evil_private.h"
 
 EVIL_API int
 ffs(int i)

--- a/src/lib/evil/evil_strings.h
+++ b/src/lib/evil/evil_strings.h
@@ -1,7 +1,7 @@
 #ifndef EVIL_STRINGS_H__
 #define EVIL_STRINGS_H__
 
-#include <evil_private.h>
+#include "evil_private.h"
 
 #define strncasecmp _strnicmp
 #define strcasecmp _stricmp

--- a/src/lib/evil/evil_time.c
+++ b/src/lib/evil/evil_time.c
@@ -2,7 +2,6 @@
 # include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include "evil_string.h"
 #include <inttypes.h>
 #include <ctype.h>
 #include <time.h>

--- a/src/lib/evil/evil_time.h
+++ b/src/lib/evil/evil_time.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_TIME_H__
 #define __EVIL_TIME_H__
 
-#include <evil_api.h>
+#include "evil_private.h"
 
 #include <stdint.h>
 #include <time.h>

--- a/src/lib/evil/evil_unistd.h
+++ b/src/lib/evil/evil_unistd.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_UNISTD_H__
 #define __EVIL_UNISTD_H__
 
-#include "evil_api.h"
+#include "evil_private.h"
 
 /**
  * @file evil_unistd.h

--- a/src/lib/evil/evil_util.h
+++ b/src/lib/evil/evil_util.h
@@ -1,7 +1,7 @@
 #ifndef __EVIL_UTIL_H__
 #define __EVIL_UTIL_H__
 
-#include <evil_api.h>
+#include "evil_private.h"
 
 /**
  * @brief Convert a string from char * to wchar_t *.

--- a/src/lib/evil/evil_vasprintf.h
+++ b/src/lib/evil/evil_vasprintf.h
@@ -3,7 +3,7 @@
 # include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <evil_api.h>
+#include "evil_private.h"
 
 #include <stdlib.h>
 #include <stdarg.h>

--- a/src/lib/evil/evil_windows.h
+++ b/src/lib/evil/evil_windows.h
@@ -11,6 +11,6 @@
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
 
-#include <evil_api.h>
+#include "evil_private.h"
 
 #endif


### PR DESCRIPTION
This PR is replacing every `[<\"]evil_*[>\"]` occurrence from `src/lib/evil` to `"evil_private.h"` except from the `src/lib/evil/evil_private.h` itself. 

From https://github.com/expertisesolutions/efl/pull/323#discussion_r457891012:

> You should not include evil_api.h except in evil_private.h. You can think that evil_private.h is "the lib", the others are just "organized parts of it".

> So no one includes evil_{something that is not 'private'}.h, but evil_private.h includes everyone. Meanwhile no evil_* header includes any other evil_* (not even evil_private.h), every other file should include evil_private.h if it wants to use evil.
