### PR TITLE
emile: Change jpeg inclusion order

### DIFF
--- a/src/lib/emile/emile_image.c
+++ b/src/lib/emile/emile_image.c
@@ -10,8 +10,6 @@
 
 #include <stdio.h>
 #include <setjmp.h>
-#include <jpeglib.h>
-#include <jerror.h>
 
 #include "rg_etc1.h"
 #include "Emile.h"
@@ -20,6 +18,9 @@
 #ifdef BUILD_NEON
 #include <arm_neon.h>
 #endif
+
+#include <jpeglib.h>
+#include <jerror.h>
 
 #define IMG_MAX_SIZE 65000
 


### PR DESCRIPTION
Without this, we have some errors about redefining things from jpeg like:

```
In file included from ../src/lib/emile/emile_image.c:13:
In file included from ..\subprojects\jpeg\jpeglib.h:25:
subprojects\jpeg\jconfig.h(11,9): warning: 'HAVE_STDLIB_H' macro redefined [-Wmacro-redefined]
#define HAVE_STDLIB_H
        ^
.\config.h(116,9): note: previous definition is here
#define HAVE_STDLIB_H 1
        ^
In file included from ../src/lib/emile/emile_image.c:13:
In file included from ..\subprojects\jpeg\jpeglib.h:25:
subprojects\jpeg\jconfig.h(12,9): warning: 'HAVE_LOCALE_H' macro redefined [-Wmacro-redefined]
#define HAVE_LOCALE_H
        ^
.\config.h(106,9): note: previous definition is here
#define HAVE_LOCALE_H 1
        ^
In file included from ../src/lib/emile/emile_image.c:17:
In file included from ..\src\lib\emile/Emile.h:22:
In file included from ..\src\lib\eina\Eina.h:222:
In file included from ..\src\lib\eina\eina_file.h:31:
In file included from ..\src\lib\eina/eina_str.h:11:
In file included from ..\src\lib\evil\evil_private.h:28:
In file included from ..\src\lib\evil\evil_windows.h:11:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um\windows.h:171:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\shared\windef.h:24:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\shared\minwindef.h:182:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\um\winnt.h:198:
C:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\shared\basetsd.h(77,29): error: typedef redefinition wit
h different types ('int' vs 'long')
typedef signed int          INT32, *PINT32;
                            ^
..\subprojects\jpeg/jmorecfg.h(216,14): note: previous definition is here
typedef long INT32;
             ^
```
Original 28ece6b677484265345c7c6439daf612ad5b90d7