### PR TITLE
[win32] [examples] Adding guards to headers for windows compatibility

### DIFF
--- a/src/examples/ecore/ecore_audio_custom.c
+++ b/src/examples/ecore/ecore_audio_custom.c
@@ -2,11 +2,16 @@
 // gcc -o ecore_audio_custom ecore_audio_custom.c `pkg-config --libs --cflags ecore ecore-audio`
 
 #include <stdio.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <termios.h>
-#include <unistd.h>
-#include <fcntl.h>
+#ifndef _MSC_VER
+# include <sys/types.h>
+# include <sys/stat.h>
+# include <termios.h>
+# include <unistd.h>
+# include <fcntl.h>
+#endif
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
 #include <Ecore.h>
 #include <Ecore_Audio.h>
 #include <math.h>

--- a/src/examples/ecore/ecore_audio_playback.c
+++ b/src/examples/ecore/ecore_audio_playback.c
@@ -3,12 +3,17 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <libgen.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <termios.h>
-#include <unistd.h>
-#include <fcntl.h>
+#ifndef _MSC_VER
+# include <termios.h>
+# include <libgen.h>
+# include <sys/types.h>
+# include <sys/stat.h>
+# include <unistd.h>
+# include <fcntl.h>
+#endif
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
 #include <Ecore.h>
 #include <Ecore_Audio.h>
 #include <Eina.h>

--- a/src/examples/ecore/ecore_audio_to_ogg.c
+++ b/src/examples/ecore/ecore_audio_to_ogg.c
@@ -2,11 +2,16 @@
 // gcc -o ecore_audio_to_ogg ecore_audio_to_ogg.c `pkg-config --libs --cflags ecore eina ecore-audio`
 
 #include <stdio.h>
-#include <libgen.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <fcntl.h>
+#ifndef _MSC_VER
+# include <libgen.h>
+# include <sys/types.h>
+# include <sys/stat.h>
+# include <unistd.h>
+# include <fcntl.h>
+#endif
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
 #include <Eo.h>
 #include <Ecore.h>
 #include <Ecore_Audio.h>

--- a/src/examples/ecore/ecore_con_server_http_example.c
+++ b/src/examples/ecore/ecore_con_server_http_example.c
@@ -2,7 +2,12 @@
 // gcc -o ecore_con_server_http_example ecore_con_server_http_example.c `pkg-config --libs --cflags ecore ecore-con eina`
 
 #include <stdio.h>
-#include <sys/time.h>
+#ifndef _MSC_VER
+# include <sys/time.h>
+#endif
+#ifdef _WIN32
+# include <evil_private.h> // time, time_t
+#endif
 #include <Ecore.h>
 #include <Ecore_Con.h>
 

--- a/src/examples/ecore/ecore_con_url_download_example.c
+++ b/src/examples/ecore/ecore_con_url_download_example.c
@@ -3,9 +3,14 @@
 
 #include <stdio.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <sys/stat.h>
+# include <fcntl.h>
+# include <unistd.h>
+#endif
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
 
 #include <Ecore.h>
 #include <Ecore_Con.h>

--- a/src/examples/ecore/ecore_evas_basics_example.c
+++ b/src/examples/ecore/ecore_evas_basics_example.c
@@ -11,7 +11,9 @@
 
 #include <Ecore.h>
 #include <Ecore_Evas.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 static Eina_Bool
 _stdin_cb(void *data EINA_UNUSED, Ecore_Fd_Handler *handler EINA_UNUSED)

--- a/src/examples/ecore/ecore_evas_ews_example.c
+++ b/src/examples/ecore/ecore_evas_ews_example.c
@@ -11,7 +11,9 @@
 
 #include <Ecore.h>
 #include <Ecore_Evas.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 #include <stdio.h>
 #include <ctype.h>
 

--- a/src/examples/ecore/ecore_evas_extn_plug_example.c
+++ b/src/examples/ecore/ecore_evas_extn_plug_example.c
@@ -16,7 +16,10 @@
 
 #include <Ecore.h>
 #include <Ecore_Evas.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 // procotol version - change this as needed
 #define MSG_DOMAIN_CONTROL_OBJECT 0x1004
 #define MSG_ID_BG_COLOR 0x1005

--- a/src/examples/ecore/ecore_evas_extn_socket_example.c
+++ b/src/examples/ecore/ecore_evas_extn_socket_example.c
@@ -18,7 +18,9 @@
 
 #include <Ecore.h>
 #include <Ecore_Evas.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 // protocol version - change this as needed
 #define MSG_DOMAIN_CONTROL_OBJECT 0x1004

--- a/src/examples/ecore/ecore_event_example_02.c
+++ b/src/examples/ecore/ecore_event_example_02.c
@@ -2,7 +2,9 @@
 // gcc -g -Wall -o ecore_event_example_02 ecore_event_example_02.c `pkg-config --cflags --libs ecore`
 
 #include <Ecore.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 struct context   // helper struct to give some context to the callbacks
 {

--- a/src/examples/ecore/ecore_exe_example.c
+++ b/src/examples/ecore/ecore_exe_example.c
@@ -5,6 +5,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <Ecore.h>
+#ifdef _WIN32
+# include <evil_private.h> // pid_t
+#endif
 
 #define BUFFER_SIZE 1024
 

--- a/src/examples/ecore/ecore_exe_example_child.c
+++ b/src/examples/ecore/ecore_exe_example_child.c
@@ -3,7 +3,9 @@
  */
 
 #include <stdio.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 #include <Ecore.h>
 
 #define BUFFER_SIZE 1024

--- a/src/examples/ecore/ecore_fd_handler_example.c
+++ b/src/examples/ecore/ecore_fd_handler_example.c
@@ -3,7 +3,9 @@
  */
 
 #include <Ecore.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 struct context
 {

--- a/src/examples/ecore/ecore_idler_example.c
+++ b/src/examples/ecore/ecore_idler_example.c
@@ -7,7 +7,9 @@
 
 #include <Ecore.h>
 #include <Eo.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 struct context   // helper struct to give some context to the callbacks
 {

--- a/src/examples/ecore/ecore_job_example.c
+++ b/src/examples/ecore/ecore_job_example.c
@@ -2,7 +2,9 @@
 // gcc -o ecore_job_example ecore_job_example.c `pkg-config --libs --cflags ecore`
 
 #include <Ecore.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 static void
 _job_print_cb(void *data)

--- a/src/examples/ecore/ecore_pipe_simple_example.c
+++ b/src/examples/ecore/ecore_pipe_simple_example.c
@@ -1,7 +1,12 @@
 //Compile with:
 //gcc -g -Wall -o ecore_pipe_simple_example ecore_pipe_simple_example.c `pkg-config --cflags --libs ecore`
 
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+#ifdef _WIN32
+# include <evil_private.h> // sleep
+#endif
 #include <Ecore.h>
 
 static void

--- a/src/examples/ecore/ecore_poller_example.c
+++ b/src/examples/ecore/ecore_poller_example.c
@@ -3,7 +3,9 @@
 
 #include <Ecore.h>
 //#include <Ecore_Eo.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 static double _initial_time = 0;
 

--- a/src/examples/ecore/ecore_thread_example.c
+++ b/src/examples/ecore/ecore_thread_example.c
@@ -3,7 +3,9 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Ecore_Getopt.h>

--- a/src/examples/ecore/ecore_time_functions_example.c
+++ b/src/examples/ecore/ecore_time_functions_example.c
@@ -2,7 +2,9 @@
 // gcc -o ecore_time_functions_example ecore_time_functions_example.c `pkg-config --libs --cflags ecore`
 
 #include <Ecore.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 static Eina_Bool
 _timer_cb(void *data EINA_UNUSED)

--- a/src/examples/ecore/ecore_timer_example.c
+++ b/src/examples/ecore/ecore_timer_example.c
@@ -2,7 +2,9 @@
 // gcc -o ecore_timer_example ecore_timer_example.c `pkg-config --libs --cflags ecore`
 
 #include <Ecore.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #define TIMEOUT_1 1.0 // interval for timer1
 #define TIMEOUT_2 3.0 // timer2 - delay timer1

--- a/src/examples/eet/eet-data-cipher_decipher.c
+++ b/src/examples/eet/eet-data-cipher_decipher.c
@@ -6,8 +6,10 @@
 #include <stdio.h>
 #include <limits.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <sys/stat.h>
+# include <unistd.h>
+#endif
 #include <string.h>
 
 int

--- a/src/examples/eet/eet-data-file_descriptor_01.c
+++ b/src/examples/eet/eet-data-file_descriptor_01.c
@@ -6,8 +6,10 @@
 #include <stdio.h>
 #include <limits.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <sys/stat.h>
+# include <unistd.h>
+#endif
 
 // complex real-world structures based on elmdentica database
 typedef struct

--- a/src/examples/eet/eet-data-file_descriptor_02.c
+++ b/src/examples/eet/eet-data-file_descriptor_02.c
@@ -6,8 +6,10 @@
 #include <stdio.h>
 #include <limits.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <sys/stat.h>
+# include <unistd.h>
+#endif
 
 typedef enum _Example_Data_Type      Example_Data_Type;
 typedef struct _Example_Variant_Type Example_Variant_Type;

--- a/src/examples/eet/eet-data-nested.c
+++ b/src/examples/eet/eet-data-nested.c
@@ -6,8 +6,10 @@
 #include <stdio.h>
 #include <limits.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <sys/stat.h>
+# include <unistd.h>
+#endif
 
 // The struct that will be loaded and saved.
 // note that only the members described in the eet_data_descriptor

--- a/src/examples/eet/eet-data-simple.c
+++ b/src/examples/eet/eet-data-simple.c
@@ -6,8 +6,10 @@
 #include <stdio.h>
 #include <limits.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <sys/stat.h>
+# include <unistd.h>
+#endif
 
 // The struct that will be loaded and saved.
 // note that only the members described in the eet_data_descriptor

--- a/src/examples/eina/eina_value_03.c
+++ b/src/examples/eina/eina_value_03.c
@@ -2,7 +2,12 @@
 //gcc eina_value_03.c -o eina_value_03 `pkg-config --cflags --libs eina`
 
 #include <Eina.h>
-#include <sys/time.h>
+#ifndef _MSC_VER
+# include <sys/time.h>
+#endif
+#ifdef _WIN32
+# include <evil_private.h> // gettimeofday, timezone
+#endif
 
 static Eina_Bool
 _tz_setup(const Eina_Value_Type *type, void *mem)

--- a/src/examples/emotion/emotion_generic_example.c
+++ b/src/examples/emotion/emotion_generic_example.c
@@ -10,7 +10,12 @@
 #include <Emotion.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+#ifdef _WIN32
+# include <evil_private.h> // sleep
+#endif
 
 #define WIDTH  (320)
 #define HEIGHT (240)


### PR DESCRIPTION
This is a rework of some commits necessary build examples on windows.
based on:
- 2a93955b05f83ab32d26749357fbb849f6c1c561
- f5778429c655e9641b60fb72557449171472927f
- 276d039c35d31df2f2a2adebad6240a373d27356