### PR TITLE
evil: Define file creation flags and file status flags

### DIFF
--- a/src/lib/evil/evil_fcntl.h
+++ b/src/lib/evil/evil_fcntl.h
@@ -5,6 +5,11 @@
 #include "evil_private.h"
 #include <sys/types.h>
 
+#if _MSC_VER
+# define _CRT_DECLARE_NONSTDC_NAMES 1
+# include <fcntl.h>
+# undef _CRT_DECLARE_NONSTDC_NAMES
+#endif
 
 /**
  * @def O_ACCMODE


### PR DESCRIPTION
UCRT `fcntl.h` already define those as `_<FLAG>` and by defining
`_CRT_DECLARE_NONSTDC_NAMES` it does a `#define _<FLAG> <FLAG>` making
them available the way a POSIX system expects.

This corrects the error of undefined idetifiers on file creation/status
flags such as:
```
../src/tests/ecore/ecore_test_ecore_file.c(262,24): error: use of undeclared identifier 'O_RDWR'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0700);
                       ^
../src/tests/ecore/ecore_test_ecore_file.c(262,44): error: use of undeclared identifier 'O_CREAT'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0700);
                                           ^
../src/tests/ecore/ecore_test_ecore_file.c(309,24): error: use of undeclared identifier 'O_RDWR'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0400);
                       ^
../src/tests/ecore/ecore_test_ecore_file.c(309,44): error: use of undeclared identifier 'O_CREAT'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0400);
                                           ^
../src/tests/ecore/ecore_test_ecore_file.c(326,24): error: use of undeclared identifier 'O_RDWR'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0200);
                       ^
../src/tests/ecore/ecore_test_ecore_file.c(326,44): error: use of undeclared identifier 'O_CREAT'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0200);
                                           ^
../src/tests/ecore/ecore_test_ecore_file.c(342,24): error: use of undeclared identifier 'O_RDWR'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0100);
                       ^
../src/tests/ecore/ecore_test_ecore_file.c(342,44): error: use of undeclared identifier 'O_CREAT'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0100);
                                           ^
../src/tests/ecore/ecore_test_ecore_file.c(392,24): error: use of undeclared identifier 'O_RDWR'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0700);
                       ^
../src/tests/ecore/ecore_test_ecore_file.c(392,44): error: use of undeclared identifier 'O_CREAT'
   fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0700);

```

Based on 91a14b3a8c675c15756b2d37d4bd06c806cccd51