### PR TITLE
evil: Remove unnecessary delay for evil startup

### DIFF
--- a/src/lib/evil/evil_main.c
+++ b/src/lib/evil/evil_main.c
@@ -41,24 +41,10 @@ evil_init(void)
 
    if (!QueryPerformanceFrequency(&freq))
        return 0;
-
    _evil_time_freq = freq.QuadPart;
 
-   /* be sure that second + 1 != 0 */
-   while (second == 59)
-     {
-        GetSystemTime(&st);
-        second = st.wSecond;
-     }
-
-   /* retrieve the tick corresponding to the time we retrieve above */
-   while (1)
-     {
-        GetSystemTime(&st);
-        QueryPerformanceCounter(&count);
-        if (st.wSecond == second + 1)
-          break;
-     }
+   QueryPerformanceCounter(&count);
+   GetSystemTime(&st);
 
    _evil_time_second = _evil_systemtime_to_time(st);
    if (_evil_time_second < 0)

--- a/src/lib/evil/evil_main.c
+++ b/src/lib/evil/evil_main.c
@@ -41,6 +41,7 @@ evil_init(void)
 
    if (!QueryPerformanceFrequency(&freq))
        return 0;
+
    _evil_time_freq = freq.QuadPart;
 
    QueryPerformanceCounter(&count);


### PR DESCRIPTION
Without this `ecore-suite`, `efl-app` and `evas-suite` gets timeout:
```
25/29 ecore-suite               TIMEOUT        30.12s
26/29 efl-app                   TIMEOUT        30.14s
...
29/29 evas-suite                TIMEOUT        60.07s
```

As a side effect, this speed up `evil`'s tests thus closing #190.

Based on 8d083963454a9da3045a53315954bd321c75230e