### PR TITLE
Eina: Max count of semaphore must be greater than 0

### DIFF
--- a/src/lib/eina/eina_inline_lock_win32.x
+++ b/src/lib/eina/eina_inline_lock_win32.x
@@ -539,7 +539,7 @@ static inline Eina_Bool
 _eina_semaphore_new(Eina_Semaphore *sem, int count_init)
 {
    if (count_init < 0) return EINA_FALSE;
-   *sem = CreateSemaphoreW(NULL, count_init, count_init, NULL);
+   *sem = CreateSemaphoreW(NULL, count_init, INT_MAX, NULL);
    return *sem ? EINA_TRUE : EINA_FALSE;
 }
 


### PR DESCRIPTION
As `count_init` may be 0, we should not set the maximun count as
`count_init`.

Original: fd8042ad956dd7b36501a222b6bdda4a50b44088