### PR TITLE
win32: Guard platform-specific headers with _MSC_VER

### DIFF
--- a/src/bin/edje/edje_cc.c
+++ b/src/bin/edje/edje_cc.c
@@ -6,7 +6,10 @@
 #include <locale.h>
 #include <limits.h>
 #include <sys/stat.h>
-#include <sys/time.h>
+
+#ifndef _MSC_VER
+# include <sys/time.h>
+#endif
 
 #ifdef HAVE_SYS_RESOURCE_H
 # include <sys/resource.h>

--- a/src/bin/edje/edje_cc_handlers.c
+++ b/src/bin/edje/edje_cc_handlers.c
@@ -34,8 +34,12 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <ctype.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #ifdef _WIN32
 # include <evil_private.h> /* mmap */
 #else

--- a/src/bin/edje/edje_cc_out.c
+++ b/src/bin/edje/edje_cc_out.c
@@ -13,9 +13,12 @@
 
 #include <string.h>
 #include <limits.h>
-#include <unistd.h>
 #include <sys/stat.h>
-#include <libgen.h>
+
+#ifndef _MSC_VER
+ #include <unistd.h>
+ #include <libgen.h>
+#endif
 
 #include <Ecore_Evas.h>
 
@@ -736,7 +739,7 @@ check_program(Edje_Part_Collection *pc, Edje_Program *ep, Eet_File *ef)
 
         if (et->id >= (int) pc->parts_count)
           {
-             ERR("In group '%s' program '%s', target id '%d' greater than possible index '%d'.", 
+             ERR("In group '%s' program '%s', target id '%d' greater than possible index '%d'.",
                  pc->part ? pc->part : "", ep->name ? ep->name : "", et->id, (int) pc->parts_count - 1);
              exit(-1);
           }

--- a/src/bin/edje/edje_cc_parse.c
+++ b/src/bin/edje/edje_cc_parse.c
@@ -8,9 +8,12 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <math.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include "edje_cc.h"
 #include <Ecore.h>

--- a/src/bin/edje/edje_codegen.c
+++ b/src/bin/edje/edje_codegen.c
@@ -6,8 +6,11 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <locale.h>
-#include <unistd.h>
 #include <errno.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eina.h>
 #include <Ecore.h>

--- a/src/bin/edje/edje_decc.c
+++ b/src/bin/edje/edje_decc.c
@@ -6,11 +6,14 @@
 
 #include <string.h>
 #include <ctype.h>
-#include <unistd.h>
 #include <locale.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore_File.h>
 #include <Ecore_Evas.h>

--- a/src/bin/edje/edje_inspector.c
+++ b/src/bin/edje/edje_inspector.c
@@ -4,8 +4,11 @@
 
 #include <locale.h>
 #include <Eina.h>
-#include <unistd.h>
 #include <errno.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include "Edje.h"
 #define EDJE_EDIT_IS_UNSTABLE_AND_I_KNOW_ABOUT_IT 1

--- a/src/bin/edje/edje_pick.c
+++ b/src/bin/edje/edje_pick.c
@@ -6,9 +6,13 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <ctype.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #include <Ecore_Getopt.h>
 
 #include "edje_cc.h"

--- a/src/bin/edje/edje_player.c
+++ b/src/bin/edje/edje_player.c
@@ -6,9 +6,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <ctype.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Evas.h>
 #include <Ecore.h>

--- a/src/bin/edje/epp/cpplib.c
+++ b/src/bin/edje/epp/cpplib.c
@@ -4,20 +4,20 @@
  * Based on CCCP program by by Paul Rubin, June 1986
  * Adapted to ANSI C, Richard Stallman, Jan 1987
  * Copyright (C) 2003-2011 Kim Woelders
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; either version 2, or (at your option) any
  * later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * In other words, you are welcome to use, share and improve this program.
  * You are forbidden to forbid anyone else to use, share and improve
  * what you give them.   Help stamp out software-hoarding!  */
@@ -68,13 +68,16 @@ const char         *version_string = "0.0.0";
 #include <string.h>
 #include <signal.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdlib.h>
 
-#ifndef VMS
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
+#if !defined(VMS) && !defined(_WIN32)
 #ifndef USG
 #include <time.h>
 #include <sys/time.h>		/* for __DATE__ and __TIME__ */
@@ -1198,7 +1201,7 @@ struct arglist {
  * in that list, or -1 for a macro name that wants no argument list.
  * MACRONAME is the macro name itself (so we can avoid recursive expansion)
  * and NAMELEN is its length in characters.
- * 
+ *
  * Note that comments, backslash-newlines, and leading white space
  * have already been deleted from the argument.  */
 
@@ -1279,7 +1282,7 @@ collect_expansion(cpp_reader * pfile, unsigned char *buf, unsigned char *limit,
              else
                 expected_delimiter = c;
              break;
-             
+
            case '\\':
              if (p < limit && expected_delimiter)
                {
@@ -1288,14 +1291,14 @@ collect_expansion(cpp_reader * pfile, unsigned char *buf, unsigned char *limit,
                   *exp_p++ = *p++;
                }
              break;
-             
+
            case '@':
              /* An '@' in a string or character constant stands for itself,
               * and does not need to be escaped. */
              if (!expected_delimiter)
                 *exp_p++ = c;
              break;
-             
+
            case '#':
              /* # is ordinary inside a string.  */
              if (expected_delimiter)
@@ -1431,7 +1434,7 @@ collect_expansion(cpp_reader * pfile, unsigned char *buf, unsigned char *limit,
 }
 
 /*
- * special extension string that can be added to the last macro argument to 
+ * special extension string that can be added to the last macro argument to
  * allow it to absorb the "rest" of the arguments when expanded.  Ex:
  *              #define wow(a, b...)            process (b, a, b)
  *              { wow (1, 2, 3); }      ->      { process (2, 3, 1, 2, 3); }
@@ -1446,7 +1449,7 @@ static char         rest_extension[] = "...";
 
 #define REST_EXTENSION_LENGTH	(sizeof (rest_extension) - 1)
 
-/* Create a DEFINITION node from a #define directive.  Arguments are 
+/* Create a DEFINITION node from a #define directive.  Arguments are
  * as for do_define. */
 static void
 create_definition(MACRODEF * mdef, unsigned char *buf, unsigned char *limit,
@@ -1864,7 +1867,7 @@ do_define(cpp_reader * pfile, struct directive *keyword,
  * `stringified_length' is the length the argument would have
  * if stringified.
  * `use_count' is the number of times this macro arg is substituted
- * into the macro.  If the actual use count exceeds 10, 
+ * into the macro.  If the actual use count exceeds 10,
  * the value stored is 10. */
 
 /* raw and expanded are relative to ARG_BASE */
@@ -1973,8 +1976,8 @@ cpp_expand_to_buffer(cpp_reader * pfile, unsigned char *buf, int length)
       unsigned char      *p1 = buf;
       unsigned char      *p2 = buf1;
       int                 in_string = 0;
-      
-#if 0 /* old behavior */ 
+
+#if 0 /* old behavior */
       while (p1 != limit) *p2++ = *p1++;
 #else /* new one - handle \ escapes if not in string */
       while (p1 != limit)
@@ -2676,7 +2679,7 @@ unsafe_chars(int c1, int c2)
  * HP points to the symbol that is the macro being called.
  * Put the result of expansion onto the input stack
  * so that subsequent input by our caller will use it.
- * 
+ *
  * If macro wants arguments, caller has already verified that
  * an argument list follows; arguments come from the input stack.  */
 
@@ -2731,7 +2734,7 @@ macroexpand(cpp_reader * pfile, HASHNODE * hp)
 	     if (i < nargs || (nargs == 0 && i == 0))
 	       {
                   unsigned char *bp;
-                  
+
 		  /* if we are working on last arg which absorbs rest of args... */
 		  if (i == nargs - 1 && defn->rest_args)
 		     rest_args = 1;
@@ -2748,7 +2751,7 @@ macroexpand(cpp_reader * pfile, HASHNODE * hp)
                        bp = ARG_BASE + args[i].raw + args[i].raw_length - 1;
                        while (is_space[(unsigned char)(*bp)])
                          {
-                            bp--; 
+                            bp--;
                             args[i].raw_length--;
                             if (args[i].raw_length < 1) break;
                          }
@@ -3096,17 +3099,17 @@ push_macro_expansion(cpp_reader * pfile, unsigned char *xbuf, int xbuf_len,
     * collect_expansion.  This is to prevent accidental token-pasting
     * between the text preceding the macro invocation, and the macro
     * expansion text.
-    * 
+    *
     * We would like to avoid adding unneeded spaces (for the sake of
     * tools that use cpp, such as imake).  In some common cases we can
     * tell that it is safe to omit the space.
-    * 
+    *
     * The character before the macro invocation cannot have been an
     * idchar (or else it would have been pasted with the idchars of
     * the macro name).  Therefore, if the first non-space character
     * of the expansion is an idchar, we do not need the extra space
     * to prevent token pasting.
-    * 
+    *
     * Also, we don't need the extra space if the first char is '(',
     * or some other (less common) characters.  */
 
@@ -3155,7 +3158,7 @@ get_directive_token(cpp_reader * pfile)
 
 /* Handle #include and #import.
  * This function expects to see "fname" or <fname> on the input.
- * 
+ *
  * The input is normally in part of the output_buffer following
  * CPP_WRITTEN, and will get overwritten by output_line_command.
  * I.e. in input file specification has been popped by handle_directive.
@@ -3575,7 +3578,7 @@ redundant_include_p(cpp_reader * pfile, char *name)
  * include file directory, or within any subdirectory thereof, then the
  * given file must be a "system" include file.  This function tells us
  * if we should suppress pedantic errors/warnings for the given FILENAME.
- * 
+ *
  * The value is 2 if the file is a C-language system header file
  * for which C++ should (on most systems) assume `extern "C"'.  */
 
@@ -4487,7 +4490,7 @@ do_endif(cpp_reader * pfile, struct directive *keyword EINA_UNUSED,
 		   * that contains all of the file (aside from whitespace).
 		   * Arrange not to include the file again
 		   * if the macro that was tested is defined.
-		   * 
+		   *
 		   * Do not do this for the top-level file in a -include or any
 		   * file in a -imacros.  */
 		  {
@@ -5565,7 +5568,7 @@ dos2unix(cpp_buffer *fp, int length)
 {
    unsigned char *tbuf;
    int nlen = 0, i;
-   
+
    tbuf = xmalloc(length + 4);
    if (!tbuf) return length;
    for (i = 0; i < length; i++)
@@ -5580,7 +5583,7 @@ dos2unix(cpp_buffer *fp, int length)
         nlen++;
      }
    tbuf[nlen] = 0;
-   
+
    free(fp->buf);
    fp->buf = tbuf;
    return nlen;
@@ -5594,7 +5597,7 @@ dos2unix(cpp_buffer *fp, int length)
  * DIRPTR is the link in the dir path through which this file was found,
  * or 0 if the file name was absolute or via the current directory.
  * Return 1 on success, 0 on failure.
- * 
+ *
  * The caller is responsible for the cpp_push_buffer.  */
 
 static int
@@ -5629,7 +5632,7 @@ finclude(cpp_reader * pfile, int f, const char *fname, int system_header_p,
 	 * on the number of bytes we can read.  */
 	length = safe_read(f, (char *)fp->buf, st_size);
         length = dos2unix(fp, length);
-        
+
 	fp->alimit = fp->buf + st_size + 2;
 	fp->cur = fp->buf;
 	fp->rlimit = fp->buf + length;
@@ -5675,7 +5678,7 @@ finclude(cpp_reader * pfile, int f, const char *fname, int system_header_p,
 	fp->buf[length++] = '\n';
      }
    fp->buf[length] = '\0';
-     
+
    fp->rlimit = fp->buf + length;
 
    /* Close descriptor now, so nesting does not use lots of descriptors.  */

--- a/src/bin/efreet/efreet_desktop_cache_create.c
+++ b/src/bin/efreet/efreet_desktop_cache_create.c
@@ -3,14 +3,16 @@
 #endif
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <errno.h>
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/time.h>
 #include <sys/resource.h>
 #endif
 
-#include <libgen.h>
+#ifndef _MSC_VER
+# include <unistd.h>
+# include <libgen.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* fcntl realpath */

--- a/src/bin/efreet/efreet_icon_cache_create.c
+++ b/src/bin/efreet/efreet_icon_cache_create.c
@@ -3,11 +3,14 @@
 #endif
 
 #include <fcntl.h>
-#include <unistd.h>
 #include <errno.h>
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/time.h>
 #include <sys/resource.h>
+#endif
+
+#ifndef _MSC_VER
+# include <unistd.h>
 #endif
 
 #ifdef _WIN32

--- a/src/bin/efreet/efreet_mime_cache_create.c
+++ b/src/bin/efreet/efreet_mime_cache_create.c
@@ -3,15 +3,18 @@
 #endif
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <errno.h>
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/time.h>
 #include <sys/resource.h>
 #endif
 
-#include <libgen.h>
 #include <ctype.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+# include <libgen.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* fcntl */
@@ -249,7 +252,7 @@ store_cache(const char *out)
    if (fwrite("EfrEeT-MiMeS-001", 16, 1, f) != 1)
      goto write_error;
    // note: all offsets are in bytes from start of file
-   // 
+   //
    // "EfrEeT-MiMeS-001" <- magic 16 byte header
    // [int] <- size of mimes array in number of entries
    // [int] <- str byte offset of 1st mime string (sorted)

--- a/src/bin/efreet/efreetd.c
+++ b/src/bin/efreet/efreetd.c
@@ -3,7 +3,6 @@
 #endif
 
 #include <stdlib.h>
-#include <unistd.h>
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -11,6 +10,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Ecore_File.h>

--- a/src/bin/efreet/efreetd_cache.c
+++ b/src/bin/efreet/efreetd_cache.c
@@ -17,7 +17,10 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 static Eina_Hash *icon_change_monitors = NULL;
 static Eina_Hash *icon_change_monitors_mon = NULL;
@@ -283,7 +286,7 @@ subdir_cache_get(const struct stat *st, const char *path)
    // go through content finding directories
    it = eina_file_stat_ls(path);
    if (!it) return cd;
-   
+
    EINA_ITERATOR_FOREACH(it, info)
      {
         // if ., .. or other "hidden" dot files - ignore
@@ -298,7 +301,7 @@ subdir_cache_get(const struct stat *st, const char *path)
           }
      }
    eina_iterator_free(it);
-   
+
    // now convert our temporary list into an array of stringshare strings
    cd->dirs_count = eina_list_count(files);
    if (cd->dirs_count > 0)

--- a/src/bin/elementary/elementary_codegen.c
+++ b/src/bin/elementary/elementary_codegen.c
@@ -17,7 +17,10 @@
 #include <fcntl.h>
 #include <locale.h>
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifndef ENABLE_NLS
 # ifndef libintl_setlocale

--- a/src/bin/elementary/elm_prefs_cc_handlers.c
+++ b/src/bin/elementary/elm_prefs_cc_handlers.c
@@ -32,7 +32,10 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include "elm_prefs_cc.h"
 

--- a/src/bin/elementary/elm_prefs_cc_parse.c
+++ b/src/bin/elementary/elm_prefs_cc_parse.c
@@ -8,10 +8,15 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <math.h>
-#include <regex.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+# include <regex.h>
+#else
+# include <pcreposix.h>
+#endif
 
 #include "elm_prefs_cc.h"
 #include <Ecore.h>

--- a/src/bin/embryo/embryo_cc_sc1.c
+++ b/src/bin/embryo/embryo_cc_sc1.c
@@ -33,8 +33,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/stat.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eina.h>
 
@@ -3491,11 +3494,11 @@ static void
 doif(void)
 {
    int                 flab1, flab2;
-#if 0   
+#if 0
    int                 ifindent;
 
    ifindent = stmtindent;	/* save the indent of the "if" instruction */
-#endif   
+#endif
    flab1 = getlabel();		/* get label number for false branch */
    test(flab1, TRUE, FALSE);	/*get expression, branch to flab1 if false */
    statement(NULL, FALSE);	/* if true, do a statement */

--- a/src/bin/embryo/embryo_cc_sc2.c
+++ b/src/bin/embryo/embryo_cc_sc2.c
@@ -35,6 +35,10 @@
 #include "embryo_cc_sc.h"
 #include "Embryo.h"
 
+#ifdef _WIN32
+#include <evil_private.h>
+#endif
+
 static int          match(char *st, int end);
 static cell         litchar(char **lptr, int rawmode);
 static int          alpha(char c);

--- a/src/bin/embryo/embryo_cc_sc5.c
+++ b/src/bin/embryo/embryo_cc_sc5.c
@@ -31,7 +31,10 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eina.h>
 

--- a/src/lib/edje/edje_private.h
+++ b/src/lib/edje/edje_private.h
@@ -20,14 +20,17 @@
 #endif
 
 #include <locale.h>
-#include <libgen.h>
 #include <string.h>
 #include <limits.h>
 #include <sys/stat.h>
 #include <time.h>
-#include <sys/time.h>
 #include <errno.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <libgen.h>
+# include <sys/time.h>
+# include <unistd.h>
+#endif
 
 #include <fcntl.h>
 

--- a/src/lib/efreet/efreet.c
+++ b/src/lib/efreet/efreet.c
@@ -2,9 +2,12 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eet.h>
 #include <Ecore.h>

--- a/src/lib/efreet/efreet_base.c
+++ b/src/lib/efreet/efreet_base.c
@@ -5,9 +5,12 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <ctype.h>
 #include <sys/types.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <winsock2.h>

--- a/src/lib/efreet/efreet_cache.c
+++ b/src/lib/efreet/efreet_cache.c
@@ -7,10 +7,13 @@
  *       browsing.
  */
 
-#include <libgen.h>
-#include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <libgen.h>
+# include <unistd.h>
+#endif
 
 #include <Eet.h>
 #include <Ecore.h>

--- a/src/lib/efreet/efreet_desktop_command.c
+++ b/src/lib/efreet/efreet_desktop_command.c
@@ -2,8 +2,11 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <ctype.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <direct.h> /* getcwd */

--- a/src/lib/efreet/efreet_menu.c
+++ b/src/lib/efreet/efreet_menu.c
@@ -14,7 +14,10 @@ static int _efreet_menu_log_dom = -1;
 #include "Efreet.h"
 #include "efreet_private.h"
 #include "efreet_xml.h"
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 typedef struct Efreet_Menu_Move Efreet_Menu_Move;
 

--- a/src/lib/efreet/efreet_mime.c
+++ b/src/lib/efreet/efreet_mime.c
@@ -5,7 +5,11 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
+
 #include <Eina.h>
 
 #include <Ecore.h>

--- a/src/lib/efreet/efreet_trash.c
+++ b/src/lib/efreet/efreet_trash.c
@@ -3,9 +3,12 @@
 #endif
 
 #include <sys/stat.h>
-#include <unistd.h>
-#include <libgen.h>
 #include <errno.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+# include <libgen.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* GetCurrentProcessId */

--- a/src/lib/efreet/efreet_xml.c
+++ b/src/lib/efreet/efreet_xml.c
@@ -5,7 +5,10 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* mmap */

--- a/src/lib/eio/Eio.h
+++ b/src/lib/eio/Eio.h
@@ -26,7 +26,10 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eina.h>
 #include <Eet.h>

--- a/src/lib/eio/efl_io_model.c
+++ b/src/lib/eio/efl_io_model.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdint.h>
-#include <libgen.h>
+
+#ifndef _MSC_VER
+# include <libgen.h>
+#endif
 
 #include <Efl.h>
 #include <Eina.h>

--- a/src/lib/eio/eio_private.h
+++ b/src/lib/eio/eio_private.h
@@ -16,15 +16,18 @@
 
 #include <sys/types.h>
 
-#include <libgen.h>
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <libgen.h>
+# include <unistd.h>
+#endif
 
 #ifdef HAVE_FEATURES_H
 # include <features.h>

--- a/src/lib/elementary/Efl_Ui.h
+++ b/src/lib/elementary/Efl_Ui.h
@@ -7,13 +7,17 @@
 /* Standard headers for standard system calls etc. */
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/param.h>
 #include <math.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+# include <sys/time.h>
+# include <sys/param.h>
+#endif
+
 #include <Eina.h>
 #include <limits.h>
 #include <ctype.h>

--- a/src/lib/elementary/Elementary.h
+++ b/src/lib/elementary/Elementary.h
@@ -15,12 +15,9 @@
 /* Standard headers for standard system calls etc. */
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/param.h>
 #include <math.h>
 #include <limits.h>
 #include <ctype.h>
@@ -32,6 +29,12 @@
 # include <pwd.h>
 #endif
 #include <errno.h>
+
+#ifndef MSC_VER
+# include <unistd.h>
+# include <sys/time.h>
+# include <sys/param.h>
+#endif
 
 #ifdef ELM_UNIX
 #include <locale.h>

--- a/src/lib/elementary/elm_calendar.c
+++ b/src/lib/elementary/elm_calendar.c
@@ -13,6 +13,10 @@
 #include "elm_calendar_eo.h"
 #include "elm_calendar_item_eo.h"
 
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
+
 #define MY_CLASS ELM_CALENDAR_CLASS
 
 #define MY_CLASS_NAME "Elm_Calendar"

--- a/src/lib/elementary/elm_code_indent.c
+++ b/src/lib/elementary/elm_code_indent.c
@@ -2,7 +2,12 @@
 # include "elementary_config.h"
 #endif
 
-#include "regex.h"
+#ifndef _MSC_VER
+# include "regex.h"
+#else
+# include "pcreposix.h"
+#endif
+
 #include "Elementary.h"
 
 #include "elm_code_private.h"

--- a/src/lib/elementary/elm_helper.c
+++ b/src/lib/elementary/elm_helper.c
@@ -3,7 +3,12 @@
 #endif
 
 #include <Elementary.h>
-#include <regex.h>
+
+#ifndef _MSC_VER
+# include <regex.h>
+#else
+# include <pcreposix.h>
+#endif
 
 struct _Elm_Validator_Regexp
 {

--- a/src/lib/embryo/embryo_time.c
+++ b/src/lib/embryo/embryo_time.c
@@ -2,8 +2,11 @@
 # include "config.h"
 #endif
 
-#include <sys/time.h>
 #include <time.h>
+
+#ifndef _MSC_VER
+# include <sys/time.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* setenv unsetenv */

--- a/src/modules/elementary/prefs/elm_entry.c
+++ b/src/modules/elementary/prefs/elm_entry.c
@@ -1,7 +1,17 @@
 #include "private.h"
 #include "elm_widget.h"
 #include <sys/types.h>
-#include <regex.h>
+
+#ifdef _WIN32
+# include <evil_private.h>
+#endif
+
+#ifndef _MSC_VER
+# include <regex.h>
+#else
+# include <pcreposix.h>
+#endif
+
 #include "elm_entry_eo.h"
 
 #define BLINK_INTERVAL 0.1

--- a/src/tests/edje/edje_test_container.c
+++ b/src/tests/edje/edje_test_container.c
@@ -2,8 +2,11 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <stdio.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #define EFL_GFX_FILTER_BETA
 #define EFL_CANVAS_LAYOUT_BETA

--- a/src/tests/edje/edje_test_edje.c
+++ b/src/tests/edje/edje_test_edje.c
@@ -2,8 +2,11 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <stdio.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #define EFL_GFX_FILTER_BETA
 #define EFL_CANVAS_LAYOUT_BETA

--- a/src/tests/edje/edje_test_features.c
+++ b/src/tests/edje/edje_test_features.c
@@ -2,8 +2,11 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <stdio.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* setenv realpath */

--- a/src/tests/edje/edje_test_signal.c
+++ b/src/tests/edje/edje_test_signal.c
@@ -2,8 +2,11 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <stdio.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #define EFL_GFX_FILTER_BETA
 #define EFL_CANVAS_LAYOUT_BETA

--- a/src/tests/edje/edje_test_swallow.c
+++ b/src/tests/edje/edje_test_swallow.c
@@ -2,8 +2,11 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <stdio.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #define EFL_GFX_FILTER_BETA
 #define EFL_CANVAS_LAYOUT_BETA

--- a/src/tests/edje/edje_test_text.c
+++ b/src/tests/edje/edje_test_text.c
@@ -2,8 +2,11 @@
 # include <config.h>
 #endif
 
-#include <unistd.h>
 #include <stdio.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #define EFL_GFX_FILTER_BETA
 #define EFL_CANVAS_LAYOUT_BETA

--- a/src/tests/efreet/ef_desktop.c
+++ b/src/tests/efreet/ef_desktop.c
@@ -5,8 +5,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 #include <limits.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <direct.h> /* getcwd */

--- a/src/tests/efreet/ef_menu.c
+++ b/src/tests/efreet/ef_menu.c
@@ -3,7 +3,10 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Efreet.h>
 

--- a/src/tests/efreet/ef_mime.c
+++ b/src/tests/efreet/ef_mime.c
@@ -4,7 +4,10 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
+
+#ifndef _MSC_VER
+# include <sys/time.h>
+#endif
 
 #include <Ecore.h>
 #include <Efreet.h>

--- a/src/tests/efreet/efreet_icon_cache_dump.c
+++ b/src/tests/efreet/efreet_icon_cache_dump.c
@@ -6,8 +6,11 @@
 #include <limits.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <errno.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Eina.h>
 #include <Eet.h>

--- a/src/tests/eio/eio_test_common.c
+++ b/src/tests/eio/eio_test_common.c
@@ -3,10 +3,13 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* mkdir */

--- a/src/tests/eio/eio_test_eet.c
+++ b/src/tests/eio/eio_test_eet.c
@@ -3,10 +3,13 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Eio.h>

--- a/src/tests/eio/eio_test_file.c
+++ b/src/tests/eio/eio_test_file.c
@@ -3,10 +3,13 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Ecore_File.h>

--- a/src/tests/eio/eio_test_manager_xattr.c
+++ b/src/tests/eio/eio_test_manager_xattr.c
@@ -3,9 +3,12 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Ecore_File.h>

--- a/src/tests/eio/eio_test_map.c
+++ b/src/tests/eio/eio_test_map.c
@@ -3,10 +3,13 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Eio.h>

--- a/src/tests/eio/eio_test_monitor.c
+++ b/src/tests/eio/eio_test_monitor.c
@@ -3,8 +3,11 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Ecore_File.h>

--- a/src/tests/eio/eio_test_sentry.c
+++ b/src/tests/eio/eio_test_sentry.c
@@ -5,8 +5,11 @@
 #define EIO_SENTRY_BETA
 
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Ecore_File.h>

--- a/src/tests/eio/eio_test_xattr.c
+++ b/src/tests/eio/eio_test_xattr.c
@@ -3,9 +3,12 @@
 #endif
 
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
 #include <fcntl.h>
+
+#ifndef _MSC_VER
+# include <unistd.h>
+#endif
 
 #include <Ecore.h>
 #include <Ecore_File.h>

--- a/src/tests/elementary/elm_code_file_test_load.c
+++ b/src/tests/elementary/elm_code_file_test_load.c
@@ -2,7 +2,9 @@
 # include "elementary_config.h"
 #endif
 
-#include <libgen.h>
+#ifndef _MSC_VER
+# include <libgen.h>
+#endif
 
 #ifdef _WIN32
 # include <evil_private.h> /* realpath() */


### PR DESCRIPTION
Based on: 0a70a9573fca5be868dfe55ac14123000f00d004 and a2c46b63df0cb1b6c0ee09926e3403d687df71fd