### PR TITLE
elm: Remove declaration from the wrong library

### DIFF
--- a/src/lib/elementary/Efl_Ui.h
+++ b/src/lib/elementary/Efl_Ui.h
@@ -74,8 +74,6 @@
 extern "C" {
 #endif
 
-ELM_API extern double _efl_startup_time;
-
 /** Successfully applied the requested style from the current theme. */
 ELM_API extern Eina_Error EFL_UI_THEME_APPLY_ERROR_NONE;
 

--- a/src/lib/elementary/elm_main.c
+++ b/src/lib/elementary/elm_main.c
@@ -15,7 +15,7 @@
 #endif
 
 #include <Emotion.h>
-
+#include <Efl_Core.h>
 #include <Elementary.h>
 
 #include "eina_internal.h"

--- a/src/tests/elementary/suite_helpers.c
+++ b/src/tests/elementary/suite_helpers.c
@@ -7,6 +7,7 @@
 #include "eo_internal.h"
 #include "../efl_check.h"
 #include "elm_widget.h"
+#include <Efl_Core.h>
 #include "ecore_private.h"
 #include "ecore_evas_private.h"
 #include "suite_helpers.h"


### PR DESCRIPTION
`_efl_startup_time` is declared in [Ecore library](https://github.com/expertisesolutions/efl/blob/devs/coquinho/clean/evas-fixes/src/lib/ecore/ecore.c#L47).
It shouldn't be declared in Elementary because it causes mismatches with
importing and exporting of symbol by MSVC's linker.

Original: 06552189d14ff466f93345c87ecdcbf0b7ca526f