### PR TITLE
evil: Implement evil_localtime_r using localtime

### DIFF
--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -91,6 +91,7 @@ function_checks = [
   ['getxattr', ['sys/types.h', 'sys/xattr.h']],
   ['iconv', ['iconv.h']],
   ['listxattr', ['sys/types.h', 'sys/xattr.h']],
+  ['localtime_r', ['time.h']],
   ['mallinfo', ['malloc.h']],
   ['malloc_info', ['malloc.h']],
   ['malloc_usable_size', ['malloc.h']],

--- a/src/lib/evil/evil_time.c
+++ b/src/lib/evil/evil_time.c
@@ -11,11 +11,8 @@
 EVIL_API struct tm *
 evil_localtime_r(const time_t * time, struct tm * result)
 {
-  *result = *localtime(time);
-  if (!errno)
-    return result;
-  else
-    return NULL;
+   *result = *localtime(time);
+   return result;
 }
 
 /*

--- a/src/lib/evil/evil_time.c
+++ b/src/lib/evil/evil_time.c
@@ -11,8 +11,14 @@
 EVIL_API struct tm *
 evil_localtime_r(const time_t * time, struct tm * result)
 {
-   *result = *localtime(time);
-   return result;
+   struct tm* _result = localtime(time);
+
+   if (_result)
+     {
+        *result = *_result;
+        return result;
+     }
+   return NULL;
 }
 
 /*

--- a/src/lib/evil/evil_time.c
+++ b/src/lib/evil/evil_time.c
@@ -8,8 +8,13 @@
 
 #include "evil_private.h"
 
-inline struct tm *localtime_r(const time_t * time, struct tm * result)
+EVIL_API struct tm *
+evil_localtime_r(const time_t * time, struct tm * result)
 {
+  *result = *localtime(time);
+  if (!errno)
+    return result;
+  else
     return NULL;
 }
 

--- a/src/lib/evil/evil_time.h
+++ b/src/lib/evil/evil_time.h
@@ -19,6 +19,12 @@
  * @{
  */
 
+EVIL_API struct tm *evil_localtime_r(const time_t * time, struct tm * result);
+
+#ifndef HAVE_LOCALTIME_R
+# define HAVE_LOCALTIME_R
+# define localtime_r evil_localtime_r
+#endif
 
 /**
  * @brief Convert a string representation of time to a time tm structure .


### PR DESCRIPTION
Implemente `evil_localtime_r` using win32 `localtime` function.  If
`HAVE_lOCALTIME_R` is not defined, do it and define `localtime_r` as
`evil_localtime_r`.

Original: 0832953c9eae40851f35b300c25f5a19e35879ef