### PR TITLE
evas: Make evas examples compilable by MSVC and GUI applications on windows

### DIFF
--- a/src/examples/evas/efl-canvas-animation.c
+++ b/src/examples/evas/efl-canvas-animation.c
@@ -82,8 +82,16 @@ print_help(void)
    printf("evas-animation example\n Press r to reverse the animation of the red rect.\n Press p to pause the animation of the red rect.\n");
 }
 
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/efl-canvas-vg-simple.c
+++ b/src/examples/evas/efl-canvas-vg-simple.c
@@ -635,8 +635,16 @@ _main_menu_key_handle(void *data EINA_UNUSED, const Efl_Event *ev)
 }
 // Main Menu END
 
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-aspect-hints.c
+++ b/src/examples/evas/evas-aspect-hints.c
@@ -164,8 +164,16 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Eina_Bool ret;
 

--- a/src/examples/evas/evas-box.c
+++ b/src/examples/evas/evas-box.c
@@ -311,8 +311,16 @@ _canvas_resize_cb(Ecore_Evas *ee)
    evas_object_resize(d.border, (w / 2) + 4, (h / 2) + 4);
 }
 
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Evas_Object *last, *o;
    int i;

--- a/src/examples/evas/evas-buffer-simple.c
+++ b/src/examples/evas/evas-buffer-simple.c
@@ -43,7 +43,15 @@ static void destroy_canvas(Evas *canvas);
 static void draw_scene(Evas *canvas);
 static void save_scene(Evas *canvas, const char *dest);
 
+#ifndef _MSC_VER
 int main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Evas *canvas;
    Evas_Object *bg, *r1, *r2, *r3;

--- a/src/examples/evas/evas-event-filter.c
+++ b/src/examples/evas/evas-event-filter.c
@@ -221,8 +221,17 @@ _rect_add(Evas *e, Context *ctx, const char *name,
    return obj;
 }
 
+
+#ifndef _MSC_VER
 int
 main(int argc EINA_UNUSED, char *argv[] EINA_UNUSED)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Context ctx = { 0 };
    Ecore_Evas *ee;

--- a/src/examples/evas/evas-events.c
+++ b/src/examples/evas/evas-events.c
@@ -318,8 +318,17 @@ c_end:
      } /* end of obscured region command */
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    int err;
 

--- a/src/examples/evas/evas-gl.c
+++ b/src/examples/evas/evas-gl.c
@@ -472,8 +472,17 @@ _on_canvas_resize_cb(Ecore_Evas *ee)
    evas_object_resize(gldata.win, w, h);
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init()) return 0;
 

--- a/src/examples/evas/evas-hints.c
+++ b/src/examples/evas/evas-hints.c
@@ -280,8 +280,17 @@ _on_destroy(Ecore_Evas *ee EINA_UNUSED)
    ecore_main_loop_quit();
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-images.c
+++ b/src/examples/evas/evas-images.c
@@ -254,8 +254,17 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    int err;
 

--- a/src/examples/evas/evas-images2.c
+++ b/src/examples/evas/evas-images2.c
@@ -219,8 +219,17 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    unsigned int i;
    unsigned int pixels[(WIDTH / 4) * (HEIGHT / 4)];

--- a/src/examples/evas/evas-images3.c
+++ b/src/examples/evas/evas-images3.c
@@ -133,8 +133,17 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-images4.c
+++ b/src/examples/evas/evas-images4.c
@@ -114,8 +114,17 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    int err;
 

--- a/src/examples/evas/evas-images5.c
+++ b/src/examples/evas/evas-images5.c
@@ -133,8 +133,17 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    int err;
 

--- a/src/examples/evas/evas-images6.c
+++ b/src/examples/evas/evas-images6.c
@@ -53,8 +53,17 @@ _canvas_resize_cb(Ecore_Evas *ee)
    evas_object_resize(d.bg, w, h);
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-init-shutdown.c
+++ b/src/examples/evas/evas-init-shutdown.c
@@ -25,8 +25,17 @@
 #include <stdio.h>
 #include <errno.h>
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Eina_List *engine_list, *l;
    char *engine_name;

--- a/src/examples/evas/evas-map-aa-eo.c
+++ b/src/examples/evas/evas-map-aa-eo.c
@@ -256,8 +256,17 @@ _on_delete(Ecore_Evas *ee EINA_UNUSED)
    ecore_main_loop_quit();
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-map-aa.c
+++ b/src/examples/evas/evas-map-aa.c
@@ -267,8 +267,17 @@ _on_delete(Ecore_Evas *ee EINA_UNUSED)
    ecore_main_loop_quit();
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-map-utils-eo.c
+++ b/src/examples/evas/evas-map-utils-eo.c
@@ -224,8 +224,17 @@ _on_free(void *data EINA_UNUSED, Evas *e EINA_UNUSED, Evas_Object *o EINA_UNUSED
    ecore_main_loop_quit();
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Evas_Object *bg, *o, *osrc;
    static App_Data d = {

--- a/src/examples/evas/evas-map-utils.c
+++ b/src/examples/evas/evas-map-utils.c
@@ -242,8 +242,17 @@ _on_free(void *data EINA_UNUSED, Evas *e EINA_UNUSED, Evas_Object *o EINA_UNUSED
    ecore_main_loop_quit();
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Evas_Object *bg, *o, *osrc;
    static App_Data d = {

--- a/src/examples/evas/evas-multi-touch.c
+++ b/src/examples/evas/evas-multi-touch.c
@@ -284,8 +284,17 @@ _axis_update_cb(void *data EINA_UNUSED, Evas *e EINA_UNUSED, Evas_Object *obj EI
     _mouse_update_handle(ev->toolid, azimuth, tilt, twist, pressure);
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!eina_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-multiseat-events.c
+++ b/src/examples/evas/evas-multiseat-events.c
@@ -236,8 +236,17 @@ EFL_CALLBACKS_ARRAY_DEFINE(callbacks,
                            { EFL_EVENT_POINTER_MOVE, _pointer_move_cb },
                            { EFL_EVENT_POINTER_WHEEL, _pointer_wheel_cb });
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Evas_Object *bg, *red_rect, *blue_rect;
    const Eina_List *devices, *l;

--- a/src/examples/evas/evas-object-manipulation-eo.c
+++ b/src/examples/evas/evas-object-manipulation-eo.c
@@ -147,8 +147,17 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Evas_Load_Error err;
 
@@ -193,7 +202,7 @@ main(void)
     * will be deleted automatically by parent.*/
 
    if (efl_file_set(d.img, img_path)) goto panic;
-   
+
    err = efl_file_load(d.img);
 
    if (err != EVAS_LOAD_ERROR_NONE)

--- a/src/examples/evas/evas-object-manipulation.c
+++ b/src/examples/evas/evas-object-manipulation.c
@@ -160,8 +160,17 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    int err;
 

--- a/src/examples/evas/evas-smart-interface.c
+++ b/src/examples/evas/evas-smart-interface.c
@@ -670,8 +670,17 @@ _on_example_smart_object_child_num_change(void *data EINA_UNUSED,
           " object changed to %llu\n", (unsigned long long)(uintptr_t)event_info);
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    const Evas_Smart_Cb_Description **descriptions;
    Evas_Smart_Example_Interface *iface;

--- a/src/examples/evas/evas-smart-object.c
+++ b/src/examples/evas/evas-smart-object.c
@@ -641,8 +641,17 @@ _on_example_smart_object_child_num_change(void *data EINA_UNUSED,
           " object changed to %llu\n", (unsigned long long)(uintptr_t)event_info);
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    const Evas_Smart_Cb_Description **descriptions;
    unsigned int count;

--- a/src/examples/evas/evas-stacking.c
+++ b/src/examples/evas/evas-stacking.c
@@ -249,8 +249,17 @@ _on_destroy(Ecore_Evas *ee EINA_UNUSED)
    ecore_main_loop_quit();
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-table.c
+++ b/src/examples/evas/evas-table.c
@@ -46,8 +46,17 @@ _canvas_resize_cb(Ecore_Evas *ee)
    evas_object_resize(d.bg, w, h);
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Evas_Object *table, *rect;
 

--- a/src/examples/evas/evas-text.c
+++ b/src/examples/evas/evas-text.c
@@ -294,8 +294,17 @@ _on_keydown(void        *data EINA_UNUSED,
      }
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    int size;
    const char *font;

--- a/src/examples/evas/evas-textblock-obstacles.c
+++ b/src/examples/evas/evas-textblock-obstacles.c
@@ -226,8 +226,17 @@ _text_init()
          );
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-transparent.c
+++ b/src/examples/evas/evas-transparent.c
@@ -102,8 +102,17 @@ _on_delete(Ecore_Evas *ee EINA_UNUSED)
    ecore_main_loop_quit();
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    /* In other examples, evas_init() has been used to turn Evas on.  In this
     * example we're using Ecore-Evas' init routine, which takes care of

--- a/src/examples/evas/evas-vg-batman.c
+++ b/src/examples/evas/evas-vg-batman.c
@@ -93,8 +93,17 @@ _animator(void *data EINA_UNUSED, double pos)
    return EINA_TRUE;
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    Ecore_Evas *ee;
    Evas *e;

--- a/src/examples/evas/evas-vg-json.c
+++ b/src/examples/evas/evas-vg-json.c
@@ -54,8 +54,17 @@ _on_delete(Ecore_Evas *ee EINA_UNUSED)
    ecore_main_loop_quit();
 }
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/evas-vg-simple.c
+++ b/src/examples/evas/evas-vg-simple.c
@@ -562,8 +562,17 @@ _main_menu_key_handle(void        *data EINA_UNUSED,
 
 // Main Menu END
 
+
+#ifndef _MSC_VER
 int
 main(void)
+#else
+int
+WinMain(HINSTANCE hInstance EINA_UNUSED
+       ,HINSTANCE hPrevInstance EINA_UNUSED
+       ,LPSTR     lpCmdLine EINA_UNUSED
+       ,int       nShowCmd EINA_UNUSED)
+#endif
 {
    if (!ecore_evas_init())
      return EXIT_FAILURE;

--- a/src/examples/evas/meson.build
+++ b/src/examples/evas/meson.build
@@ -38,5 +38,6 @@ examples = [
 foreach example : examples
   executable(example, example + '.c',
     dependencies: [eina, ecore_evas, ecore_file, m],
-    c_args : ['-DPACKAGE_EXAMPLES_DIR="'+meson.current_source_dir()+'"'])
+    c_args : ['-DPACKAGE_EXAMPLES_DIR="'+meson.current_source_dir()+'"'],
+    gui_app: true)
 endforeach


### PR DESCRIPTION
The entry point function to windows applications is not `int main void`,
instead, windows use:
`int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow);`.
So this, workaround it with `_MSC_VER` guards.

[Docs](https://docs.microsoft.com/en-us/windows/win32/learnwin32/winmain--the-application-entry-point) for reference.
Original: 97e79c0d49fe5a5ffe9dd952143eceeb7cda1632