### PR TITLE
win32: Module macros are always export

### DIFF
--- a/src/lib/eina/eina_inline_modinfo.x
+++ b/src/lib/eina/eina_inline_modinfo.x
@@ -24,7 +24,7 @@
 #define __EINA_MODULE_UNIQUE_ID(id) _EINA_MODINFO_CONCAT(__EINA_MODULE_UNIQUE_ID_, id)
 
 #define _EINA_MODINFO(name, info) \
-  EINA_API const char __EINA_MODULE_UNIQUE_ID(name)[] \
+  EXPORTAPI const char __EINA_MODULE_UNIQUE_ID(name)[] \
 __attribute__((__used__)) __attribute__((unused, aligned(1))) = info;
 #define EINA_MODINFO(tag, info) _EINA_MODINFO(tag, info)
 


### PR DESCRIPTION
Always use dllexport for module macros.

originally: 4d74e5e4c8f8e68c5063dc0895755ed06cc64c2c