### PR TITLE
ci: Minimize logs noise.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,28 +96,31 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-    - name: set git line ending config
+    - name: Set git line ending config to checkout as-is
       run: git config --global core.autocrlf input
     - uses: actions/checkout@v2
-    - name: add python scripts to path
+    - name: Add python scripts to path
       run: |
         $python_version = (py -3 --version).replace("Python ", "")
         $python_scripts_path = ($(echo C:\hostedtoolcache\windows\Python\$python_version\x64\Scripts ) -join "")
         echo "::add-path::$python_scripts_path"
-    - name: install ninja
+    - name: Install ninja
       # unexplicably, installation returns error code 1 if a cache location is used
       run: py -3 -m pip install ninja
-    - name: test ninja
+    - name: Test ninja
       run: ninja --version
-    - name: install meson
+    - name: Install meson
       run: py -3 -m pip install meson
-    - name: test meson
+    - name: Test meson
       run: meson -v
-    - name: Download artifact
+    - name: Download build artifact
       uses: actions/download-artifact@v1.0.0
       with:
         name: build
-    - name: tree .
+    - name: Check directory tree (for debugging purposes)
       run: tree .
-    - name: ninja? or test?
-      run: meson test --no-rebuild -C build --verbose
+    - name: Run tests
+      run: meson test --no-rebuild -C build --print-errorlogs
+    - name: Show full log
+      run: type build\meson-logs\testlog.txt
+      if: ${{ always() }}


### PR DESCRIPTION
Meson has a flag to show only failed tests' logs (see [other test options section of manual](https://mesonbuild.com/Unit-tests.html#other-test-options), so this will make test loggin a lot less noisy.
But to not loose potential debugging info, the logs are still shown after execution, but in another task.

I also took the chance to rename some steps in order to make them more..."fitting".