### PR TITLE
Preserve line endings when checking out eolian_gen reference files

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,8 +96,6 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-    - name: set git line ending config
-      run: git config --global core.autocrlf input
     - uses: actions/checkout@v2
     - name: add python scripts to path
       run: |

--- a/src/tests/eolian/data/.gitattributes
+++ b/src/tests/eolian/data/.gitattributes
@@ -1,2 +1,2 @@
-*.h eol=lf
-*.c eol=lf
+*.h crlf=input
+*.c crlf=input

--- a/src/tests/eolian/data/.gitattributes
+++ b/src/tests/eolian/data/.gitattributes
@@ -1,0 +1,2 @@
+*.h eol=lf
+*.c eol=lf


### PR DESCRIPTION
We are currently setting `core.autocrlf` to `input` on Windows, to checkout files without converting line endings to CRLF, but that means we expect anyone cloning the repo to do the same or tests will fail.

Now, I'm setting the line ending for the specific files that **need** to use LF.

Credits to @JPTIZ for the finding!