### PR TITLE
Enable every thing we can with evas

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -435,7 +435,7 @@ subprojects = [
 ['efl'              ,[]                    , false,  true, false, false, false, false,  true, ['eo'], []],
 ['emile'            ,[]                    , false,  true, false, false,  true,  true,  true, ['eina', 'efl'], ['lz4', 'rg_etc']],
 ['eet'              ,[]                    , false,  true,  true, false,  true,  true,  true, ['eina', 'emile', 'efl'], ['rg_etc']],
-['ecore'            ,[]                    , false,  true, false, false, false, false,  true, ['eina', 'eo', 'efl'], ['buildsystem']],
+['ecore'            ,[]                    , false,  true, false, false,  true, false,  true, ['eina', 'eo', 'efl'], ['buildsystem']],
 ['eldbus'           ,[]                    , false,  true,  true, false,  true,  true,  true, ['eina', 'eo', 'efl'], []],
 ['ecore'            ,[]                    ,  true, false, false, false, false,  true,  true, ['eina', 'eo', 'efl'], []], #ecores modules depend on eldbus
 ['ecore_audio'      ,['audio']             , false,  true, false, false, false, false,  true, ['eina', 'eo'], []],
@@ -490,8 +490,6 @@ if sys_windows
     'ecore_drm',
     'ecore_drm2',
     'ecore_fb',
-    'ecore_imf_evas',
-    'ecore_ipc',
     'ecore_sdl',
     'ecore_wayland',
     'ecore_wl2',


### PR DESCRIPTION
This enables:
- ecore_imf_evas
- ecore_input_evas
- ecore_ipc

And re-enables ecore tests

Depends on #332 