### PR TITLE
win32: Fix signed overflow with bitsets and enumerations

### DIFF
--- a/src/lib/evas/canvas/evas_object_textblock.c
+++ b/src/lib/evas/canvas/evas_object_textblock.c
@@ -407,7 +407,11 @@ struct _Evas_Object_Textblock_Format
    Eina_Bool            strikethrough : 1;  /**< EINA_TRUE if text should be stricked off, else EINA_FALSE */
    Eina_Bool            backing : 1;  /**< EINA_TRUE if enable background color, else EINA_FALSE */
    Eina_Bool            password : 1;  /**< EINA_TRUE if the text is password, else EINA_FALSE */
+#ifndef _MSC_VER
    Evas_Textblock_Align_Auto halign_auto : 2;  /**< Auto horizontal align mode */
+#else
+   unsigned int         halign_auto : 2;  /**< Auto horizontal align mode */
+#endif
 };
 
 struct _Efl_Canvas_Textblock_Style


### PR DESCRIPTION
To explain a bit, `Evas_Textblock_Align_Auto` is an enum with four defiined values (0 to 3), which could be correctly represented with 2 bits if enum is unsigned, but if enum is signed, it would need 3 bits instead, than an overflow occur.

To deal with it, here we are forcing `halign_auto` to be an `unsigned int` on windows, inevitably loosing the enum flavor. Other option could be reserving one more bit to `halign_auto`, but I don't know what could be its side-effects.