### PR TITLE
build: disable elua by default, plus nicer detection

### DIFF
--- a/.ci/ci-configure.sh
+++ b/.ci/ci-configure.sh
@@ -18,7 +18,7 @@ if [ "$DISTRO" != "" ] ; then
   -Ddebug-threads=true -Dglib=true -Dg-mainloop=true -Dxpresent=true -Dxinput22=true \
   -Devas-loaders-disabler=json -Decore-imf-loaders-disabler= \
   -Dharfbuzz=true -Dpixman=true -Dhyphen=true -Defl-one=true \
-  -Dvnc-server=true -Dbindings=lua,cxx,mono -Delogind=false -Dinstall-eo-files=true -Dphysics=true"
+  -Dvnc-server=true -Delua=true -Dbindings=lua,cxx,mono -Delogind=false -Dinstall-eo-files=true -Dphysics=true"
 
   # Enabled png, jpeg evas loader for in tree edje file builds
   DISABLED_LINUX_COPTS=" -Daudio=false -Davahi=false -Dx11=false -Dphysics=false -Deeze=false \
@@ -29,7 +29,7 @@ if [ "$DISTRO" != "" ] ; then
   -Decore-imf-loaders-disabler=xim,ibus,scim \
   -Dfribidi=false -Dfontconfig=false \
   -Dedje-sound-and-video=false -Dembedded-lz4=false -Dlibmount=false -Dv4l2=false \
-  -Delua=true -Dnls=false -Dbindings= -Dlua-interpreter=luajit -Dnative-arch-optimization=false"
+  -Delua=false -Dnls=false -Dbindings= -Dlua-interpreter=luajit -Dnative-arch-optimization=false"
   #evas_filter_parser.c:(.text+0xc59): undefined reference to `lua_getglobal' with interpreter lua
 
   RELEASE_READY_LINUX_COPTS=" --buildtype=release"

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -273,7 +273,7 @@ option('v4l2',
 
 option('elua',
   type : 'boolean',
-  value : true,
+  value : false,
   description : 'Lua launcher binary support in efl'
 )
 
@@ -298,7 +298,7 @@ option('nls',
 option('bindings',
   type : 'array',
   choices : ['lua', 'cxx', 'mono'],
-  value : ['lua', 'cxx'],
+  value : ['cxx'],
   description : 'Which auto-generated language bindings for efl to enable',
 )
 

--- a/src/bindings/meson.build
+++ b/src/bindings/meson.build
@@ -18,6 +18,10 @@ if (bindings.contains('cxx') == false and bindings.contains('mono'))
   )
 endif
 
+if bindings.contains('lua') and not have_elua
+  error('Elua is necessary for Lua bindings')
+endif
+
 foreach binding : bindings_order
   if bindings.contains(binding)
     subdir(join_paths( binding))

--- a/src/lib/elua/meson.build
+++ b/src/lib/elua/meson.build
@@ -2,10 +2,7 @@ elua_deps = [eina, eo, efl, ecore, ecore_file, intl]
 elua_pub_deps = [lua]
 
 if get_option('lua-interpreter') == 'lua'
-  luaver_min = cc.compute_int('LUA_VERSION_NUM - 500',
-    prefix: '#include <lua.h>', dependencies: lua
-  )
-  elua_deps += dependency('cffi-lua-5.@0@'.format(luaver_min))
+  elua_deps += lua_ffi
 endif
 
 elua_src = ['elua.c', 'io.c', 'cache.c']

--- a/src/scripts/meson.build
+++ b/src/scripts/meson.build
@@ -1,2 +1,5 @@
 subdir('eo')
-subdir('elua')
+
+if have_elua
+  subdir('elua')
+endif


### PR DESCRIPTION
> Elua is now disabled by default. There are some other changes:
> 
> 1) Elua scripts are only installed if Elua is enabled
> 2) Lua bindings are only installed if Elua is enabled
> 3) Elua with interpreter is clearly experimental and will message

Originally: c3a1060b94ae9df82e8406b481e8bd5fe5741df5


This PR conflicts with #342 .