### PR TITLE
win32: Don't compile kde legacy and deprecated efreed

### DIFF
--- a/src/lib/efreet/efreet_menu.c
+++ b/src/lib/efreet/efreet_menu.c
@@ -454,6 +454,7 @@ efreet_menu_init(void)
 EFREET_API int
 efreet_menu_kde_legacy_init(void)
 {
+#ifndef _WIN32
     FILE *f;
     char buf[PATH_MAX];
     char *p, *s;
@@ -488,6 +489,7 @@ efreet_menu_kde_legacy_init(void)
                             (void *)eina_stringshare_add(s));
 
     pclose(f);
+#endif
     return 1;
 }
 

--- a/src/lib/efreet/meson.build
+++ b/src/lib/efreet/meson.build
@@ -56,6 +56,7 @@ install_headers(efreet_header_src,
   install_dir : dir_package_include,
 )
 
+if not sys_windows
 
 #Deprecated efreet libs
 # everything and everyone should use efreet itself, efreet_mime and efreet_trash are contained in libefreet.so
@@ -90,3 +91,4 @@ pkgconfig.generate(efreet_lib,
         version : version_major + '.' + version_minor + '.' + version_micro,
         libraries : efreet_pub_deps,
 )
+endif


### PR DESCRIPTION
Originally:  
  - b18901bbb7b48f12d36e9e2a75dbff903062f721
  - 0eefd715c48a2f2604fad8551ee8f962b5d0cda7