### PR TITLE
win32: Avoid compiling examples that use platform-specific functions not available in Windows

### DIFF
--- a/src/examples/elementary/meson.build
+++ b/src/examples/elementary/meson.build
@@ -102,10 +102,6 @@ examples = [
   'web_example_02',
   'win_example',
   'track_example_01',
-  'efl_thread_1',
-  'efl_thread_2',
-  'efl_thread_3',
-  'efl_thread_4',
   'efl_thread_5',
   'efl_thread_6',
   'efl_ui_list_example_1',
@@ -122,6 +118,16 @@ examples = [
   'efl_ui_grid_view_example_1',
   'efl_canvas_textblock_obstacles_example'
 ]
+
+# Disabling examples that are directly using pthreads 
+if not sys_windows
+  examples += [
+    'efl_thread_1',
+    'efl_thread_2',
+    'efl_thread_3',
+    'efl_thread_4',
+  ]
+endif
 
 examples_deps = [elementary, ecore, eio, m]
 


### PR DESCRIPTION
Yeah, we are talking specifically about `phtread` here. `usleep` is already available from `Evil`.

Originally 97d5ddbc2f1fe62c0e3da4cc129cb40ddabb3639