### PR TITLE
Make eldbus depended of dbus

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,11 +100,6 @@ add_global_arguments(dev_cflags, language: 'c')
 add_global_arguments(dev_cflags, language: 'cpp')
 
 if sys_windows
-  if not get_option('dbus')
-    dbus = declare_dependency()
-    eldbus = declare_dependency()
-  endif
-
   dl = declare_dependency()
   m = declare_dependency()
 
@@ -439,7 +434,7 @@ subprojects = [
 ['emile'            ,[]                    , false,  true, false, false,  true,  true,  true, ['eina', 'efl'], ['lz4', 'rg_etc']],
 ['eet'              ,[]                    , false,  true,  true, false,  true,  true,  true, ['eina', 'emile', 'efl'], ['rg_etc']],
 ['ecore'            ,[]                    , false,  true, false, false,  true, false,  true, ['eina', 'eo', 'efl'], ['buildsystem']],
-['eldbus'           ,[]                    , false,  true,  true, false,  true,  true,  true, ['eina', 'eo', 'efl'], []],
+['eldbus'           ,['dbus']              , false,  true,  true, false,  true,  true,  true, ['eina', 'eo', 'efl'], []],
 ['ecore'            ,[]                    ,  true, false, false, false, false,  true,  true, ['eina', 'eo', 'efl'], []], #ecores modules depend on eldbus
 ['ecore_audio'      ,['audio']             , false,  true, false, false, false, false,  true, ['eina', 'eo'], []],
 ['ecore_avahi'      ,['avahi']             , false,  true, false, false, false,  true, false, ['eina', 'ecore'], []],
@@ -472,7 +467,7 @@ subprojects = [
 ['emotion'          ,[]                    ,  true,  true, false, false,  true,  true,  true, ['eina', 'efl', 'eo'], []],
 ['ethumb'           ,['ethumb']            ,  true,  true,  true, false, false, false,  true, ['eina', 'efl', 'eo'], []],
 ['ethumb_client'    ,['ethumb']            , false,  true,  true, false, false,  true,  true, ['eina', 'efl', 'eo', 'ethumb'], []],
-['elementary'       ,[]                    ,  true,  true,  true,  true,  true,  true,  true, ['eina', 'efl', 'eo', 'eet', 'evas', 'ecore', 'ecore-evas', 'ecore-file', 'ecore-input', 'edje', 'emotion', 'ecore-imf', 'ecore-con', 'eldbus', 'efreet', 'efreet-mime', 'efreet-trash', 'eio'], ['atspi']],
+['elementary'       ,[]                    ,  true,  true,  true,  true,  true,  true,  true, ['eina', 'efl', 'eo', 'eet', 'evas', 'ecore', 'ecore-evas', 'ecore-file', 'ecore-input', 'edje', 'emotion', 'ecore-imf', 'ecore-con', 'efreet', 'efreet-mime', 'efreet-trash', 'eio'], ['atspi']],
 ['efl_canvas_wl'    ,['wl']                , false,  true,  true, false, false, false,  true, ['eina', 'efl', 'eo', 'evas', 'ecore'], []],
 ['elua'             ,['elua']              , false,  true,  true, false,  true, false, false, ['eina', lua_pc_name], []],
 ['ecore_wayland'    ,['wl-deprecated']     , false,  true, false, false, false, false, false, ['eina'], []],
@@ -483,7 +478,6 @@ subprojects = [
 if sys_windows
   ignored_subprojects = [
     # don't make sense in windows
-    'eldbus',
     'elput',
     # temporarily ignored
     'ecore_audio',

--- a/src/bin/elementary/meson.build
+++ b/src/bin/elementary/meson.build
@@ -125,8 +125,6 @@ elementary_test_src = [
   'test_slideshow.c',
   'test_spinner.c',
   'test_store.c',
-  'test_sys_notify.c',
-  'test_systray.c',
   'test_table.c',
   'test_toolbar.c',
   'test_tooltip.c',
@@ -175,6 +173,13 @@ endif
 
 if get_option('ethumb')
   elementary_test_src += ['test_thumb.c']
+endif
+
+if get_option('dbus')
+  elementary_test_src += [
+    'test_sys_notify.c',
+    'test_systray.c',
+  ]
 endif
 
 elementary_test = executable('elementary_test',

--- a/src/bin/elementary/test.c
+++ b/src/bin/elementary/test.c
@@ -1272,8 +1272,10 @@ add_tests:
 //   ADD_TEST(NULL, "Helpers", "Factory", test_factory);
 
    //------------------------------//
+#ifdef HAVE_ELDBUS
    ADD_TEST(NULL, "System", "Notification", test_sys_notify);
    ADD_TEST(NULL, "System", "Systray Item", test_systray);
+#endif
 
    //------------------------------//
    ADD_TEST(NULL, "Drag & Drop", "Genlist DnD Dflt Anim", test_dnd_genlist_default_anim);

--- a/src/lib/ecore_con/meson.build
+++ b/src/lib/ecore_con/meson.build
@@ -1,6 +1,11 @@
-ecore_con_deps = [buildsystem, eldbus, eet]
+ecore_con_deps = [buildsystem, eet]
 ecore_con_pub_deps = [eina, eo, efl, ecore]
 ecore_con_ext_deps = [buildsystem_simple, dl, http_parser]
+
+if get_option('dbus')
+  ecore_con_deps += eldbus
+endif
+
 if sys_windows == true
   ipv6 = true
 else

--- a/src/lib/elementary/Elementary.h
+++ b/src/lib/elementary/Elementary.h
@@ -71,7 +71,9 @@
 #include <Ecore_IMF.h>
 #include <Ecore_Con.h>
 #include <Edje.h>
-#include <Eldbus.h>
+#ifdef HAVE_ELDBUS
+# include <Eldbus.h>
+#endif
 #include <Efreet.h>
 #include <Efreet_Mime.h>
 #include <Efreet_Trash.h>

--- a/src/lib/elementary/efl_access_object.c
+++ b/src/lib/elementary/efl_access_object.c
@@ -626,9 +626,10 @@ _efl_access_object_relationships_clear(Eo *obj EINA_UNUSED, Efl_Access_Object_Da
 EOLIAN Eo*
 _efl_access_object_access_root_get(void)
 {
+#ifdef HAVE_ELDBUS
    if (!root)
      root = efl_add(ELM_ATSPI_APP_OBJECT_CLASS, efl_main_loop_get());
-
+#endif
    return root;
 }
 

--- a/src/lib/elementary/efl_ui_win.c
+++ b/src/lib/elementary/efl_ui_win.c
@@ -7428,12 +7428,14 @@ _on_atspi_bus_connected(void *data EINA_UNUSED, const Efl_Event *event EINA_UNUS
 EOLIAN static void
 _efl_ui_win_class_constructor(Efl_Class *klass EINA_UNUSED)
 {
+#ifdef HAVE_ELDBUS
    if (_elm_config->atspi_mode)
      {
         Eo *bridge = _elm_atspi_bridge_get();
         if (bridge)
            efl_event_callback_add(bridge, ELM_ATSPI_BRIDGE_EVENT_CONNECTED, _on_atspi_bus_connected, NULL);
      }
+#endif
 }
 
 EOLIAN static void

--- a/src/lib/elementary/elm_config.c
+++ b/src/lib/elementary/elm_config.c
@@ -1049,8 +1049,10 @@ static void _elm_config_atspi_mode_set(Eina_Bool is_enabled)
    if (_elm_config->atspi_mode == is_enabled) return;
    _elm_config->atspi_mode = is_enabled;
 
+#ifdef HAVE_ELDBUS
    if (!is_enabled) _elm_atspi_bridge_shutdown();
    else _elm_atspi_bridge_init();
+#endif
 }
 
 static Eina_Bool _elm_config_selection_unfocused_clear_get(void)
@@ -2844,8 +2846,10 @@ _env_get(void)
    if (s) _elm_config->magnifier_enable = !!atoi(s);
    s = _getenv_once("ELM_MAGNIFIER_SCALE");
    if (s) _elm_config->magnifier_scale = _elm_atof(s);
+#ifdef HAVE_EDLBUS
    s = _getenv_once("ELM_ATSPI_MODE");
    if (s) _elm_config->atspi_mode = ELM_ATSPI_MODE_ON;
+#endif
    s = _getenv_once("ELM_SPINNER_MIN_MAX_FILTER_ENABLE");
    if (s) _elm_config->spinner_min_max_filter_enable = !!atoi(s);
 

--- a/src/lib/elementary/elm_main.c
+++ b/src/lib/elementary/elm_main.c
@@ -439,8 +439,10 @@ elm_init(int argc, char **argv)
 
    ELM_CNP_EVENT_SELECTION_CHANGED = ecore_event_type_new();
 
+#ifdef HAVE_ELDBUS
    if (_elm_config->atspi_mode != ELM_ATSPI_MODE_OFF)
      _elm_atspi_bridge_init();
+#endif
    if (!_elm_config->web_backend)
      _elm_config->web_backend = eina_stringshare_add("none");
    if (!_elm_web_init(_elm_config->web_backend))
@@ -475,7 +477,9 @@ elm_shutdown(void)
    ecore_event_handler_del(system_handlers[1]);
 
    _elm_win_shutdown();
+#ifdef HAVE_ELDBUS
    _elm_atspi_bridge_shutdown();
+#endif
 
    while (_elm_win_deferred_free) ecore_main_loop_iterate();
 
@@ -675,18 +679,22 @@ static Eina_Bool _elm_need_eldbus = EINA_FALSE;
 ELM_API Eina_Bool
 elm_need_eldbus(void)
 {
+#ifdef HAVE_ELDBUS
    if (_elm_need_eldbus) return EINA_TRUE;
    _elm_need_eldbus = EINA_TRUE;
    eldbus_init();
+#endif
    return EINA_TRUE;
 }
 
 static void
 _elm_unneed_eldbus(void)
 {
+#ifdef HAVE_ELDBUS
    if (!_elm_need_eldbus) return;
    _elm_need_eldbus = EINA_FALSE;
    eldbus_shutdown();
+#endif
 }
 
 ELM_API Eina_Bool
@@ -940,12 +948,16 @@ elm_quicklaunch_shutdown(void)
    ELM_SAFE_FREE(_elm_exit_handler, ecore_event_handler_del);
 
    _elm_theme_shutdown();
+#ifdef HAVE_ELDBUS
    _elm_unneed_systray();
    _elm_unneed_sys_notify();
+#endif
    _elm_unneed_efreet();
+#ifdef HAVE_ELDBUS
    _elm_unneed_e_dbus();
    _elm_unneed_eldbus();
    _elm_unneed_ethumb();
+#endif
    _elm_unneed_web();
 
 #ifdef HAVE_ELEMENTARY_EMAP
@@ -1229,8 +1241,10 @@ elm_quicklaunch_fork(int    argc,
 
    if (setsid() < 0) perror("could not setsid");
    if (chdir(cwd) != 0) perror("could not chdir");
+#ifdef HAVE_ELDBUS
    if (_elm_config->atspi_mode != ELM_ATSPI_MODE_OFF)
      _elm_atspi_bridge_init();
+#endif
 
    if (qre_main)
      {

--- a/src/lib/elementary/elm_menu.c
+++ b/src/lib/elementary/elm_menu.c
@@ -97,8 +97,9 @@ _elm_menu_item_elm_widget_item_disable(Eo *eo_item, Elm_Menu_Item_Data *item)
      }
    else
      elm_layout_signal_emit(VIEW(item), "elm,state,enabled", "elm");
-
+#ifdef HAVE_ELDBUS
    if (item->dbus_menu) _elm_dbus_menu_update(item->dbus_menu);
+#endif
    edje_object_message_signal_process(elm_layout_edje_get(VIEW(item)));
 }
 
@@ -731,8 +732,9 @@ _elm_menu_efl_canvas_group_group_del(Eo *obj, Elm_Menu_Data *sd)
 {
    Elm_Object_Item *eo_item;
 
+#ifdef HAVE_ELDBUS
    _elm_dbus_menu_unregister(obj);
-
+#endif
    if (sd->parent)
      {
         evas_object_event_callback_del_full
@@ -1038,8 +1040,10 @@ _elm_menu_item_efl_object_destructor(Eo *eo_item, Elm_Menu_Item_Data *item)
    else
      sd->items = eina_list_remove(sd->items, eo_item);
 
+#ifdef HAVE_ELDBUS
    if (sd->dbus_menu)
      _elm_dbus_menu_item_delete(sd->dbus_menu, item->dbus_idx);
+#endif
 
    efl_destructor(efl_super(eo_item, ELM_MENU_ITEM_CLASS));
 }
@@ -1089,6 +1093,7 @@ _elm_menu_item_add(Eo *obj, Elm_Menu_Data *sd, Elm_Object_Item *parent, const ch
 
    _elm_menu_item_add_helper(obj, it->parent, it, sd);
 
+#ifdef HAVE_ELDBUS
    if (sd->dbus_menu)
    {
      it->dbus_idx = _elm_dbus_menu_item_add(sd->dbus_menu, eo_item);
@@ -1099,7 +1104,7 @@ _elm_menu_item_add(Eo *obj, Elm_Menu_Data *sd, Elm_Object_Item *parent, const ch
         efl_access_added(eo_item);
         efl_access_children_changed_added_signal_emit(parent ? parent : obj, eo_item);
      }
-
+#endif
    return eo_item;
 }
 
@@ -1162,13 +1167,16 @@ _elm_menu_item_separator_add(Eo *obj, Elm_Menu_Data *sd, Elm_Object_Item *eo_p_i
    subitem->parent = efl_data_scope_get(eo_p_item, ELM_MENU_ITEM_CLASS);
 
    _item_separator_obj_create(subitem);
+#ifdef HAVE_ELDBUS
    _elm_menu_item_add_helper(obj, subitem->parent, subitem, sd);
-
+#endif
    _sizing_eval(obj);
 
+#ifdef HAVE_ELDBUS
    if (sd->dbus_menu)
      subitem->dbus_idx = _elm_dbus_menu_item_add(sd->dbus_menu,
                                                  eo_subitem);
+#endif
    return eo_subitem;
 }
 

--- a/src/lib/elementary/meson.build
+++ b/src/lib/elementary/meson.build
@@ -740,8 +740,6 @@ elementary_src = files([
   'elm_access.c',
   'efl_ui_vg_animation.c',
   'elm_actionslider.c',
-  'elm_atspi_app_object.c',
-  'elm_atspi_bridge.c',
   'efl_ui_legacy.c',
   'efl_ui_bg.c',
   'elm_box.c',
@@ -770,7 +768,6 @@ elementary_src = files([
   'elm_conform.c',
   'elm_datetime.c',
   'elm_dayselector.c',
-  'elm_dbus_menu.c',
   'elm_diskselector.c',
   'elm_entry.c',
   'efl_ui_flip.c',
@@ -842,11 +839,6 @@ elementary_src = files([
   'elm_slideshow.c',
   'elm_spinner.c',
   'elm_store.c',
-  'elm_systray.c',
-  'elm_systray_watcher.c',
-  'elm_sys_notify_interface.c',
-  'elm_sys_notify.c',
-  'elm_sys_notify_dbus.c',
   'elm_table.c',
   'elm_theme.c',
   'elm_toolbar.c',
@@ -957,16 +949,33 @@ elementary_src = files([
   'efl_ui_spotlight_animation_manager.c',
 ])
 
-elementary_deps = [emile, eo, efl, edje, emotion, ecore_imf, ecore_con, eldbus, efreet, eio, buildsystem]
+elementary_deps = [emile, eo, efl, edje, emotion, ecore_imf, ecore_con, efreet, eio, buildsystem]
 elementary_pub_deps = [eina, eet, evas, ecore, ecore_evas, ecore_file, ecore_input, ecore_imf, ecore_con,
-                       edje, eldbus, efreet, efl]
-elementary_ext_deps = [atspi, dl, intl, buildsystem_simple]
+                       edje, efreet, efl]
+elementary_ext_deps = [dl, intl, buildsystem_simple]
 
 if get_option('ethumb')
   elementary_src += files('elm_thumb.c')
   elementary_deps += [ethumb, ethumb_client]
   elementary_pub_deps += ethumb_client
 endif
+
+if get_option('dbus')
+  elementary_src += files([
+    'elm_atspi_app_object.c',
+    'elm_atspi_bridge.c',
+    'elm_dbus_menu.c',
+    'elm_sys_notify.c',
+    'elm_sys_notify_dbus.c',
+    'elm_sys_notify_interface.c',
+    'elm_systray.c',
+    'elm_systray_watcher.c',
+  ])
+  elementary_deps += [eldbus]
+  elementary_pub_deps += [eldbus]
+  elementary_ext_deps += [atspi]
+endif
+
 elm_options = configuration_data()
 
 config_h.set_quoted('ELM_TOP_BUILD_DIR', meson.build_root())

--- a/src/tests/elementary/efl_ui_suite.c
+++ b/src/tests/elementary/efl_ui_suite.c
@@ -9,7 +9,9 @@ static const Efl_Test_Case etc[] = {
   //{ "elm_focus", elm_test_focus},
   //{ "elm_focus_sub", elm_test_focus_sub},
   //{ "elm_widget_focus", elm_test_widget_focus},
+#ifdef HAVE_ELDBUS
   { "efl_ui_atspi", efl_ui_test_atspi},
+#endif
   { "efl_ui_callback", efl_ui_test_callback},
   { "efl_ui_config", efl_ui_test_config},
   { "efl_ui_focus", efl_ui_test_focus},

--- a/src/tests/elementary/elm_suite.c
+++ b/src/tests/elementary/elm_suite.c
@@ -14,7 +14,9 @@ static const Efl_Test_Case etc[] = {
   { "elm_check", elm_test_check },
   { "elm_colorselector", elm_test_colorselector },
   { "elm_entry", elm_test_entry},
+#ifdef HAVE_ELDBUS
   { "elm_atspi", elm_test_atspi},
+#endif
   { "elm_button", elm_test_button},
   { "elm_image", elm_test_image},
   { "elm_list", elm_test_list},

--- a/src/tests/elementary/meson.build
+++ b/src/tests/elementary/meson.build
@@ -26,7 +26,6 @@ elementary_suite_src = [
   'elm_suite.c',
   'elm_suite_build.c',
   'suite_helpers.c',
-  'elm_test_atspi.c',
   'elm_test_check.c',
   'elm_test_colorselector.c',
   'elm_test_entry.c',
@@ -110,6 +109,10 @@ if get_option('ethumb')
   elementary_suite_src += ['elm_test_thumb.c']
 endif
 
+if get_option('dbus')
+  elementary_suite_src += ['elm_test_atspi.c']
+endif
+
 elementary_suite = executable('elementary_suite',
   elementary_suite_src,
   dependencies: [check, eina, elementary, elementary_deps, intl],
@@ -129,7 +132,6 @@ efl_ui_suite_src = [
   'suite_helpers.h',
   'elm_test_init.c',
   'efl_ui_test_win.c',
-  'efl_ui_test_atspi.c',
   'efl_ui_test_callback.c',
   'efl_ui_test_config.c',
   'efl_ui_test_focus_common.c',
@@ -173,6 +175,10 @@ efl_ui_suite_src = [
   'custom_recognizer.c',
   'custom_recognizer2.c',
 ]
+
+if get_option('dbus')
+  efl_ui_suite_src += ['efl_ui_test_atspi.c']
+endif
 
 efl_ui_suite = executable('efl_ui_suite',
   efl_ui_suite_src, priv_eo_file_target,


### PR DESCRIPTION
This makes `eldbus` optional by making it dependent on `dbus` option.

As now it is optional, this:
- removes is from ignored subprojects;
- set `eldbus` option to false for native-windows builds;
- remove it and `atspi` from `elementary` default dependencies and add it when `dbus` option is enabled;
- make related files only compile when `dbus` option is enabled;
- guard related code in `elementary` with `HAVE_ELDBUS`;

Note that `HAVE_<LIB>` is already defined at [meson.build](https://github.com/expertisesolutions/efl/blob/devs/expertise/native-windows/meson.build#L563).

Originals:
- 5202192b0569873093d2441e48b6187b6c98d194
- 2e0c6914f6937b33ac423e6a7c1125a53f364dc2
 