### PR TITLE
elm: Use platform neutral embed_config C program instead of script

### DIFF
--- a/src/bin/elementary/embed_config.c
+++ b/src/bin/elementary/embed_config.c
@@ -1,4 +1,3 @@
-
 #include <assert.h>
 #include <errno.h>
 #include <getopt.h>
@@ -7,27 +6,27 @@
 #include <string.h>
 
 #ifdef HAVE_CONFIG1
-#include "elementary_config.h"
+# include "elementary_config.h"
 #endif
 
 static void
-_print_usage(const char *progn, FILE *outf)
+_print_usage(const char *progn)
 {
-   fprintf(outf, "Usage: %s [options] [input]\n", progn);
-   fprintf(outf, "Options:\n"
+   fprintf(stdout, "Usage: %s [options] [input]\n", progn);
+   fprintf(stdout, "Options:\n"
                  "  -o output     specify the filename and path for output\n"
                  "  -v            show version number\n"
                  "\n");
 }
 
-char* _read_input_file (FILE* f, const char* fname)
+char *
+_read_input_file(FILE* f, const char* fname)
 {
    fseek(f, 0, SEEK_END);
    long fs = ftell(f);
    if (fs < 0)
      {
         fprintf(stderr, "eolian: could not get length of '%s'\n", fname);
-        fclose(f);
         return NULL;
      }
    fseek(f, 0, SEEK_SET);
@@ -36,7 +35,7 @@ char* _read_input_file (FILE* f, const char* fname)
    if (!cont)
      {
         fprintf(stderr, "eolian: could not allocate memory for '%s'\n", fname);
-        fclose(f);
+        free(cont);
         return NULL;
      }
 
@@ -46,16 +45,15 @@ char* _read_input_file (FILE* f, const char* fname)
         fprintf(stderr, "eolian: could not read %ld bytes from '%s' (got %ld)\n",
                 fs, fname, as);
         free(cont);
-        fclose(f);
         return NULL;
      }
 
    cont[fs] = '\0';
-   fclose(f);
    return cont;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
    char *output = NULL, *input = NULL;
    FILE *fin = NULL, *fout = NULL;
@@ -70,40 +68,40 @@ int main(int argc, char** argv)
           output = strdup(optarg);
           break;
         case 'h':
-          _print_usage(argv[0], stdout);
+          _print_usage(argv[0]);
           return 0;
        }
 
    if (!argv[optind])
      {
         fprintf(stderr, "embed_config: no input file\n");
-        goto no_input;
+        goto clean_return;
      }
    else
      input = strdup(argv[optind]);
 
-   
-   fin = fopen (input, "rb");
-   fout = fopen (output, "wb");
+   fin = fopen(input, "rb");
    if (!fin)
      {
         fprintf(stderr, "embed_config: could not open '%s' (%s)\n",
                 input, strerror(errno));
-        goto not_open_in;
+        goto clean_return;
      }
+
+   fout = fopen(output, "wb");
    if (!fout)
      {
         fprintf(stderr, "embed_config: could not open '%s' (%s)\n",
                 output, strerror(errno));
-        goto not_open_out;
+        goto clean_return;
      }
 
-   char* input_buffer = _read_input_file (fin, input);
+   char *input_buffer = _read_input_file(fin, input);
    if (input_buffer)
      {
         const char file_prefix[] = "static const char *embedded_config = \"\"\n";
         const char file_suffix[] = ";\n";
-        fwrite (&file_prefix[0], sizeof(file_prefix) -1, 1, fout);
+        fwrite(&file_prefix[0], sizeof(file_prefix) -1, 1, fout);
         unsigned int i = 0, eol = 0, eof = strlen(input_buffer);
         
         while (i != eof)
@@ -116,35 +114,34 @@ int main(int argc, char** argv)
 
             while (i != eol)
               {
-                if (input_buffer[i] == '"')
-                {
-                  fputc('\\', fout);
-                }
-                fputc(input_buffer[i], fout);
-                ++i;
+                 if (input_buffer[i] == '"')
+                   fputc('\\', fout);
+                 fputc(input_buffer[i], fout);
+                 ++i;
               }
             fputs("\\n\"", fout);
             if (i != eof)
-            {
-              assert (i == eol);
-              assert (input_buffer[i] == '\n' || input_buffer[i] == '\r');
-              while (input_buffer[i] == '\r' || input_buffer[i] == '\n')
-                fputc(input_buffer[i++], fout);
-            }
+              {
+                 assert(i == eol);
+                 assert(input_buffer[i] == '\n' || input_buffer[i] == '\r');
+                 while (input_buffer[i] == '\r' || input_buffer[i] == '\n')
+                   fputc(input_buffer[i++], fout);
+              }
           }
 
-        fwrite (&file_suffix[0], sizeof(file_suffix) -1, 1, fout);
+        fwrite(&file_suffix[0], sizeof(file_suffix) -1, 1, fout);
 
         err = 0;
      }
    else
      fprintf(stderr, "embed_config: could not read from '%s'\n", input);
-     
-not_open_out:
-   fclose(fout);
-not_open_in:
-   fclose(fin);
-no_input:
-  free(output);
-  return err;
+
+   free(input_buffer);
+
+clean_return:
+   if (fin != NULL) fclose(fin);
+   if (fout != NULL) fclose(fout);
+   free(input);
+   free(output);
+   return err;
 }

--- a/src/bin/elementary/embed_config.c
+++ b/src/bin/elementary/embed_config.c
@@ -1,9 +1,10 @@
 
+#include <assert.h>
+#include <errno.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <getopt.h>
 #include <string.h>
-#include <assert.h>
 
 #ifdef HAVE_CONFIG1
 #include "elementary_config.h"

--- a/src/bin/elementary/embed_config.c
+++ b/src/bin/elementary/embed_config.c
@@ -12,8 +12,8 @@
 static void
 _print_usage(const char *progn)
 {
-   fprintf(stdout, "Usage: %s [options] [input]\n", progn);
-   fprintf(stdout, "Options:\n"
+   printf("Usage: %s [options] [input]\n", progn);
+   printf("Options:\n"
                  "  -o output     specify the filename and path for output\n"
                  "  -v            show version number\n"
                  "\n");

--- a/src/bin/elementary/embed_config.c
+++ b/src/bin/elementary/embed_config.c
@@ -108,9 +108,9 @@ int main(int argc, char** argv)
         while (i != eof)
           {
             eol = i;
-            while (eol != eof && input_buffer[eol] != '\n')
+            while (eol != eof && (input_buffer[eol] != '\n' && input_buffer[eol] != '\r'))
               ++eol;
-            assert (eol == eof || input_buffer[eol] == '\n');
+            assert (eol == eof || input_buffer[eol] == '\n' || input_buffer[eol] == '\r');
             fputc('"', fout);
 
             while (i != eol)
@@ -126,9 +126,9 @@ int main(int argc, char** argv)
             if (i != eof)
             {
               assert (i == eol);
-              assert (input_buffer[i] == '\n');
-              fputc('\n', fout);
-              ++i;
+              assert (input_buffer[i] == '\n' || input_buffer[i] == '\r');
+              while (input_buffer[i] == '\r' || input_buffer[i] == '\n')
+                fputc(input_buffer[i++], fout);
             }
           }
 

--- a/src/bin/elementary/embed_config.c
+++ b/src/bin/elementary/embed_config.c
@@ -1,0 +1,149 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef HAVE_CONFIG1
+#include "elementary_config.h"
+#endif
+
+static void
+_print_usage(const char *progn, FILE *outf)
+{
+   fprintf(outf, "Usage: %s [options] [input]\n", progn);
+   fprintf(outf, "Options:\n"
+                 "  -o output     specify the filename and path for output\n"
+                 "  -v            show version number\n"
+                 "\n");
+}
+
+char* _read_input_file (FILE* f, const char* fname)
+{
+   fseek(f, 0, SEEK_END);
+   long fs = ftell(f);
+   if (fs < 0)
+     {
+        fprintf(stderr, "eolian: could not get length of '%s'\n", fname);
+        fclose(f);
+        return NULL;
+     }
+   fseek(f, 0, SEEK_SET);
+
+   char *cont = malloc(fs + 1);
+   if (!cont)
+     {
+        fprintf(stderr, "eolian: could not allocate memory for '%s'\n", fname);
+        fclose(f);
+        return NULL;
+     }
+
+   long as = fread(cont, 1, fs, f);
+   if (as != fs)
+     {
+        fprintf(stderr, "eolian: could not read %ld bytes from '%s' (got %ld)\n",
+                fs, fname, as);
+        free(cont);
+        fclose(f);
+        return NULL;
+     }
+
+   cont[fs] = '\0';
+   fclose(f);
+   return cont;
+}
+
+int main(int argc, char** argv)
+{
+   char *output = NULL, *input = NULL;
+   FILE *fin = NULL, *fout = NULL;
+   int err = -1;
+  
+   for (int opt; (opt = getopt(argc, argv, "ho:")) != -1;)
+     switch (opt)
+       {
+        case 0:
+          break;
+        case 'o':
+          output = strdup(optarg);
+          break;
+        case 'h':
+          _print_usage(argv[0], stdout);
+          return 0;
+       }
+
+   if (!argv[optind])
+     {
+        fprintf(stderr, "embed_config: no input file\n");
+        goto no_input;
+     }
+   else
+     input = strdup(argv[optind]);
+
+   
+   fin = fopen (input, "rb");
+   fout = fopen (output, "wb");
+   if (!fin)
+     {
+        fprintf(stderr, "embed_config: could not open '%s' (%s)\n",
+                input, strerror(errno));
+        goto not_open_in;
+     }
+   if (!fout)
+     {
+        fprintf(stderr, "embed_config: could not open '%s' (%s)\n",
+                output, strerror(errno));
+        goto not_open_out;
+     }
+
+   char* input_buffer = _read_input_file (fin, input);
+   if (input_buffer)
+     {
+        const char file_prefix[] = "static const char *embedded_config = \"\"\n";
+        const char file_suffix[] = ";\n";
+        fwrite (&file_prefix[0], sizeof(file_prefix) -1, 1, fout);
+        unsigned int i = 0, eol = 0, eof = strlen(input_buffer);
+        
+        while (i != eof)
+          {
+            eol = i;
+            while (eol != eof && input_buffer[eol] != '\n')
+              ++eol;
+            assert (eol == eof || input_buffer[eol] == '\n');
+            fputc('"', fout);
+
+            while (i != eol)
+              {
+                if (input_buffer[i] == '"')
+                {
+                  fputc('\\', fout);
+                }
+                fputc(input_buffer[i], fout);
+                ++i;
+              }
+            fputs("\\n\"", fout);
+            if (i != eof)
+            {
+              assert (i == eol);
+              assert (input_buffer[i] == '\n');
+              fputc('\n', fout);
+              ++i;
+            }
+          }
+
+        fwrite (&file_suffix[0], sizeof(file_suffix) -1, 1, fout);
+
+        err = 0;
+     }
+   else
+     fprintf(stderr, "embed_config: could not read from '%s'\n", input);
+     
+not_open_out:
+   fclose(fout);
+not_open_in:
+   fclose(fin);
+no_input:
+  free(output);
+  return err;
+}

--- a/src/lib/elementary/meson.build
+++ b/src/lib/elementary/meson.build
@@ -262,15 +262,15 @@ endforeach
 
 eolian_include_directories += ['-I', meson.current_source_dir()]
 
-embed_config_exe = executable('embed_config_exe', files('../../bin/elementary/embed_config.c'), dependencies: getopt)
-meson.override_find_program('embed_config', embed_config_exe)
+embed_config = executable('embed_config', 
+  files('../../bin/elementary/embed_config.c'), 
+  dependencies: getopt
+)
 
-embed_script_run = find_program('embed_config', required: false)
-
-embed_config_target = custom_target('create_embedded_default_config',
+elementary_default_config = custom_target('create_embedded_default_config',
   input: join_paths(meson.source_root(), 'data', 'elementary', 'config', 'standard', 'base.src.in'),
   output: 'elm_default_config.x',
-  command: [embed_script_run, '-o', '@OUTPUT@', '@INPUT@'],
+  command: [embed_config, '-o', '@OUTPUT@', '@INPUT@'],
 )
 
 elementary_headers_unstable = [
@@ -1038,13 +1038,15 @@ c = configure_file(
 elm_package_c_args =  package_c_args
 
 elementary_lib = library('elementary',
-    elementary_src, pub_eo_file_target, priv_eo_file_target, c, embed_config_target,
+    elementary_src, pub_eo_file_target, priv_eo_file_target, c, elementary_default_config,
     dependencies: elementary_pub_deps + elementary_deps + elementary_ext_deps,
     include_directories : config_dir + [include_directories('.')] + [include_directories(join_paths('..', '..', '..'))],
     install: true,
     c_args : [elm_package_c_args, '-DELM_BUILD'],
     version : meson.project_version()
 )
+
+
 
 elementary = declare_dependency(
   include_directories: [include_directories('.')],

--- a/src/lib/elementary/meson.build
+++ b/src/lib/elementary/meson.build
@@ -262,16 +262,15 @@ endforeach
 
 eolian_include_directories += ['-I', meson.current_source_dir()]
 
-if sys_windows
-  embed_script = find_program('config_embed.bat')
-else
-  embed_script = find_program('config_embed')
-endif
+embed_config_exe = executable('embed_config_exe', files('../../bin/elementary/embed_config.c'), dependencies: getopt)
+meson.override_find_program('embed_config', embed_config_exe)
 
-embed_config = custom_target('create_embedded_default_config',
+embed_script_run = find_program('embed_config', required: false)
+
+embed_config_target = custom_target('create_embedded_default_config',
   input: join_paths(meson.source_root(), 'data', 'elementary', 'config', 'standard', 'base.src.in'),
   output: 'elm_default_config.x',
-  command: [embed_script, '@INPUT@', '@OUTPUT@']
+  command: [embed_script_run, '-o', '@OUTPUT@', '@INPUT@'],
 )
 
 elementary_headers_unstable = [
@@ -1039,7 +1038,7 @@ c = configure_file(
 elm_package_c_args =  package_c_args
 
 elementary_lib = library('elementary',
-    elementary_src, pub_eo_file_target, priv_eo_file_target, c, embed_config,
+    elementary_src, pub_eo_file_target, priv_eo_file_target, c, embed_config_target,
     dependencies: elementary_pub_deps + elementary_deps + elementary_ext_deps,
     include_directories : config_dir + [include_directories('.')] + [include_directories(join_paths('..', '..', '..'))],
     install: true,


### PR DESCRIPTION
This PR fixes the following error when trying to build elementary:
```
FAILED: src/lib/elementary/elementary-1.dll.p/elm_config.c.obj
<...>
In file included from ../src/lib/elementary/elm_config.c:1706:
src/lib/elementary\elm_default_config.x(1,1): error: expected identifier or '('
"static const char *embedded_config = \"\""
^
```