### PR TITLE
Evas: Call evas modules by its final name in native-windows builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,9 +50,10 @@ osx = ['darwin']
 sys_linux = linux.contains(host_machine.system())
 sys_bsd = bsd.contains(host_machine.system())
 sys_windows = windows.contains(host_machine.system())
+sys_native_windows = sys_windows and cc.get_id() in ['msvc', 'clang-cl']
 sys_osx = osx.contains(host_machine.system())
 
-if sys_windows and cc.get_id() in ['msvc', 'clang-cl']
+if sys_native_windows
   pkgconfig = disabler()
 else
   pkgconfig = import('pkgconfig')
@@ -774,7 +775,7 @@ if get_option('build-examples')
 endif
 
 # disabled for windows for now
-if not sys_windows
+if not sys_native_windows
   subdir(join_paths(local_scripts))
 
   meson.add_install_script('meson/meson_modules.sh', module_files)

--- a/src/modules/ecore_evas/meson.build
+++ b/src/modules/ecore_evas/meson.build
@@ -29,7 +29,12 @@ foreach engine_conf : engines
 
     config_h.set('BUILD_ECORE_EVAS_'+engine.to_upper(), '1')
 
-    mod_full_name = engine
+    if sys_native_windows
+      mod_full_name = 'module'
+    else
+      mod_full_name = engine
+    endif
+
     mod_install_dir = join_paths(dir_lib, package_name, 'engines', engine, version_name)
 
     subdir(join_paths('engines', engine))

--- a/src/modules/evas/engines/meson.build
+++ b/src/modules/evas/engines/meson.build
@@ -54,7 +54,12 @@ foreach engine_conf : engines
     var_name = 'engine_'+engine
     set_variable(var_name, engine_dep)
 
-    mod_full_name = engine
+    if sys_native_windows
+      mod_full_name = 'module'
+    else
+      mod_full_name = engine
+    endif
+
     # root meson.build declares the root evas engines project as `evas/engines`,
     # but modules must be installed in evas/modules
     evas_package_modules = join_paths(dir_lib, 'evas', 'modules')


### PR DESCRIPTION
Different from the original intention, this doesn't make modules names
work the same in Linux and windows. This workaround the need for a
script for native windows builds but lets other platforms work as they
already do. This only change module names for its final version
(`module`) when on native windows builds. To achieve this, it creates a
`sys_native_windows` variable, which is only true when using `msvc` or
`clang-cl` while in a `windows` host.

Original: 2f3c8295db3e1fa9c62462dbeb6057085e19f87e