### PR TITLE
evil: Remove OS version check

### DIFF
--- a/src/lib/evil/evil_main.c
+++ b/src/lib/evil/evil_main.c
@@ -28,17 +28,6 @@ evil_init(void)
    if (++_evil_init_count != 1)
      return _evil_init_count;
 
-   {
-      DWORD v;
-
-      v = GetVersion();
-      if (!v || ((DWORD)(LOBYTE(LOWORD(v))) < 6))
-        {
-           fprintf(stderr, "Windows XP not supported anymore, exiting.\n");
-           return 0;
-        }
-   }
-
    if (!QueryPerformanceFrequency(&freq))
        return 0;
 


### PR DESCRIPTION
Current version checking is done with GetVersion, which is now
deprecated and issues the warning:

```
'GetVersion' is deprecated [-Wdeprecated-declarations]
```

The first approach of this commit was to replace GetVersion call with
the newer (and more reliable) `IsWindowsVistaOrGreater()` from
versionhelpers.h, but nowadays it makes more sense to actually not even
make that check, since it is more than unlinkely to happen that someone
tries to compile/run EFL in Windows XP.

This is a PR from the following phab's Differential Revision: https://phab.enlightenment.org/D12095