### PR TITLE
build: Also include libname into 'Tried: <lib list>'

### DIFF
--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -240,7 +240,7 @@ foreach libname, alternatives : alternative_lib_names
   if not lib.found()
     error('Dependency "@0@" not found. Tried: @1@.'.format(
         libname,
-        ','.join(alternatives))
+        ','.join([libname] + alternatives))
     )
   endif
 


### PR DESCRIPTION
When fetching `freetype2` and `libjpeg` dependencies, the error message was wrongly stating that it tried only the alternatives (when it actually tried the given library name too). So this patch changes this:

```
Dependency "freetype2" not found. Tried: freetype.
```

To this:

```
Dependency "freetype2" not found. Tried: freetype2, freetype.
```