### PR TITLE
Eet: Resolve eet_test_cache test case

### DIFF
--- a/src/tests/eet/eet_test_cache.c
+++ b/src/tests/eet/eet_test_cache.c
@@ -60,7 +60,10 @@ EFL_START_TEST(eet_test_cache_concurrency)
    Eina_Bool r;
    int tmpfd;
 
-   file = strdup("/tmp/eet_suite_testXXXXXX");
+   int path_size = strlen(eina_environment_tmp_get()) + strlen("eet_suite_testXXXXXX") + 2;
+   file = malloc(sizeof(char)*path_size);
+   eina_file_path_join(file, path_size
+      , eina_environment_tmp_get(), "eet_suite_testXXXXXX");
 
    eina_threads_init();
 
@@ -94,7 +97,7 @@ EFL_START_TEST(eet_test_cache_concurrency)
    thread_ret = eina_thread_join(thread);
    fail_unless(thread_ret == NULL, (char const *)thread_ret);
 
-   eet_close(ef);
+   eet_clearcache();
 
    fail_if(unlink(file) != 0);
 

--- a/src/tests/eet/eet_test_cache.c
+++ b/src/tests/eet/eet_test_cache.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 #ifndef _WIN32
-#include <unistd.h>
+# include <unistd.h>
 #else
 # include <evil_private.h>
 #endif
@@ -51,22 +51,14 @@ _open_close_worker(void *path, Eina_Thread tid EINA_UNUSED)
 
 EFL_START_TEST(eet_test_cache_concurrency)
 {
-   char *file;
    const char *buffer = "test data";
    Eet_File *ef;
    void *thread_ret;
    unsigned int n;
    Eina_Thread thread;
+   Eina_Tmpstr *tmpfile = NULL;
    Eina_Bool r;
    int tmpfd;
-
-   const char * filename = "eet_suite_testXXXXXX";
-   const char * tmpdir = eina_environment_tmp_get();
-   // +2 stands for <path separator> + <end of string>
-   size_t path_size = strlen(tmpdir) + strlen(filename) + 2;
-
-   file = malloc(sizeof(char)*path_size);
-   eina_file_path_join(file, path_size , tmpdir, filename);
 
    eina_threads_init();
 
@@ -74,16 +66,18 @@ EFL_START_TEST(eet_test_cache_concurrency)
    eina_condition_new(&open_worker_cond, &open_worker_mutex);
 
    /* create a file to test with */
-   fail_if(-1 == (tmpfd = mkstemp(file)));
+   /* tmpfile will be created in temporary directory (with eina_environment_tmp) */
+   tmpfd = eina_file_mkstemp("eet_suite_testXXXXXX", &tmpfile);
+   fail_if(-1 == tmpfd);
    fail_if(!!close(tmpfd));
-   ef = eet_open(file, EET_FILE_MODE_WRITE);
+   ef = eet_open(tmpfile, EET_FILE_MODE_WRITE);
    fail_if(!ef);
    fail_if(!eet_write(ef, "keys/tests", buffer, strlen(buffer) + 1, 0));
 
    eina_lock_take(&open_worker_mutex);
    /* start a thread that repeatedly opens and closes a file */
    open_worker_stop = 0;
-   r = eina_thread_create(&thread, EINA_THREAD_NORMAL, -1, _open_close_worker, file);
+   r = eina_thread_create(&thread, EINA_THREAD_NORMAL, -1, _open_close_worker, tmpfile);
    fail_unless(r);
 
    eina_condition_wait(&open_worker_cond);
@@ -102,9 +96,10 @@ EFL_START_TEST(eet_test_cache_concurrency)
 
    eet_clearcache();
 
-   fail_if(unlink(file) != 0);
+   fail_if(unlink(tmpfile) != 0);
 
    eina_threads_shutdown();
+   eina_tmpstr_del(tmpfile);
 }
 EFL_END_TEST
 

--- a/src/tests/eet/eet_test_cache.c
+++ b/src/tests/eet/eet_test_cache.c
@@ -95,6 +95,10 @@ EFL_START_TEST(eet_test_cache_concurrency)
    fail_unless(thread_ret == NULL, (char const *)thread_ret);
 
    eet_close(ef);
+    /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
+     * successfully if there is any reference to the file, here `eet_clearcache` is
+     * used to assure that the file is really closed when the unlink happens.
+     */
    eet_clearcache();
 
    fail_if(unlink(tmpfile) != 0);

--- a/src/tests/eet/eet_test_cache.c
+++ b/src/tests/eet/eet_test_cache.c
@@ -60,10 +60,13 @@ EFL_START_TEST(eet_test_cache_concurrency)
    Eina_Bool r;
    int tmpfd;
 
-   int path_size = strlen(eina_environment_tmp_get()) + strlen("eet_suite_testXXXXXX") + 2;
+   const char * filename = "eet_suite_testXXXXXX";
+   const char * tmpdir = eina_environment_tmp_get();
+   // +2 stands for <path separator> + <end of string>
+   size_t path_size = strlen(tmpdir) + strlen(filename) + 2;
+
    file = malloc(sizeof(char)*path_size);
-   eina_file_path_join(file, path_size
-      , eina_environment_tmp_get(), "eet_suite_testXXXXXX");
+   eina_file_path_join(file, path_size , tmpdir, filename);
 
    eina_threads_init();
 

--- a/src/tests/eet/eet_test_cache.c
+++ b/src/tests/eet/eet_test_cache.c
@@ -94,6 +94,7 @@ EFL_START_TEST(eet_test_cache_concurrency)
    thread_ret = eina_thread_join(thread);
    fail_unless(thread_ret == NULL, (char const *)thread_ret);
 
+   eet_close(ef);
    eet_clearcache();
 
    fail_if(unlink(tmpfile) != 0);


### PR DESCRIPTION
This test case had 2 problems one while creating a temporary file and other
while closing it:

About creating the file: `/tmp` doesn't exist in windows and `mkstemp` expects
that all path given already exists (besides the file it will create), causing a
fail:
```
74:    fail_if(-1 == (tmpfd = mkstemp(file)));
```
Here this is solved by using `eina_file_mkstemp` that creates a temporary file
at a temporary directory obtained with `eina_envitonment_tmp` which is an
architecture-independent function.

About closing it: `eet_close` is a postponed close, it doesn't immediately close
files opened as `write and read` nor `write` unless it has non saved changes nor
immediately closes files opened as `read` files. So when arriving at `unlink`
the file may not be closed yet. 
On linux it isn't a problem, as when `unlink`ing an open file it returns `0` and
waits until all references to the file to be closed for its removal.
But on windows while `unlink`ing an open file `-1` is returnged,  causing a fail
at:
```
102:  fail_if(unlink(file) != 0);
```
With `unlink` setting `errno` to `13`(`strerror(13)` = `Permission denied`).

This is solved using `eet_clearcache` which forces the closure of every file (in
case the file has been altered it flushes it before closing).
Note that this solves the problem for *this* test, but it isn't the best
solution, an user still needs to know where his program will run to know if they
need to force file closure before  `unlink`.