### PR TITLE
Eet: Resolve eet_test_image test case

### DIFF
--- a/src/tests/eet/eet_test_image.c
+++ b/src/tests/eet/eet_test_image.c
@@ -428,6 +428,10 @@ EFL_START_TEST(eet_test_image_normal)
    free(data);
 
    eet_close(ef);
+   /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
+    * successfully if there is any reference to the file, here `eet_clearcache` is
+    * used to assure that the file is really closed when the unlink happens.
+    */
    eet_clearcache();
 
    fail_if(unlink(tmpfile) != 0);
@@ -483,6 +487,10 @@ EFL_START_TEST(eet_test_image_small)
    fail_if(data == NULL);
 
    eet_close(ef);
+   /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
+    * successfully if there is any reference to the file, here `eet_clearcache` is
+    * used to assure that the file is really closed when the unlink happens.
+    */
    eet_clearcache();
 
    fail_if(unlink(tmpfile) != 0);

--- a/src/tests/eet/eet_test_image.c
+++ b/src/tests/eet/eet_test_image.c
@@ -88,7 +88,13 @@ EFL_START_TEST(eet_test_image_normal)
    unsigned int h;
    int tmpfd;
 
-   file = strdup("/tmp/eet_suite_testXXXXXX");
+   const char * filename = "eet_suite_testXXXXXX";
+   const char * tmpdir = eina_environment_tmp_get();
+   // +2 stands for <path separator> + <end of string>
+   size_t path_size = strlen(tmpdir) + strlen(filename) + 2;
+
+   file = malloc(sizeof(char)*path_size);
+   eina_file_path_join(file, path_size , tmpdir, filename);
 
    fail_if(-1 == (tmpfd = mkstemp(file)));
    fail_if(!!close(tmpfd));
@@ -428,6 +434,7 @@ EFL_START_TEST(eet_test_image_normal)
    free(data);
 
    eet_close(ef);
+   eet_clearcache();
 
    fail_if(unlink(file) != 0);
 
@@ -449,7 +456,13 @@ EFL_START_TEST(eet_test_image_small)
    int result;
    int tmpfd;
 
-   file = strdup("/tmp/eet_suite_testXXXXXX");
+   const char * filename = "eet_suite_testXXXXXX";
+   const char * tmpdir = eina_environment_tmp_get();
+   // +2 stands for <path separator> + <end of string>
+   size_t path_size = strlen(tmpdir) + strlen(filename) + 2;
+
+   file = malloc(sizeof(char)*path_size);
+   eina_file_path_join(file, path_size , tmpdir, filename);
 
    image[0] = IM0;
    image[1] = IM1;
@@ -481,6 +494,7 @@ EFL_START_TEST(eet_test_image_small)
    fail_if(data == NULL);
 
    eet_close(ef);
+   eet_clearcache();
 
    fail_if(unlink(file) != 0);
 

--- a/src/tests/eet/eet_test_image.c
+++ b/src/tests/eet/eet_test_image.c
@@ -77,7 +77,7 @@ static const Eet_Test_Image test_alpha = {
 EFL_START_TEST(eet_test_image_normal)
 {
    Eet_File *ef;
-   char *file;
+   Eina_Tmpstr *tmpfile = NULL;
    unsigned int *data;
    int compress;
    int quality;
@@ -88,19 +88,13 @@ EFL_START_TEST(eet_test_image_normal)
    unsigned int h;
    int tmpfd;
 
-   const char * filename = "eet_suite_testXXXXXX";
-   const char * tmpdir = eina_environment_tmp_get();
-   // +2 stands for <path separator> + <end of string>
-   size_t path_size = strlen(tmpdir) + strlen(filename) + 2;
-
-   file = malloc(sizeof(char)*path_size);
-   eina_file_path_join(file, path_size , tmpdir, filename);
-
-   fail_if(-1 == (tmpfd = mkstemp(file)));
+   /* tmpfile will be created in temporary directory (with eina_environment_tmp) */
+   tmpfd = eina_file_mkstemp("eet_suite_testXXXXXX", &tmpfile);
+   fail_if(-1 == tmpfd);
    fail_if(!!close(tmpfd));
 
    /* Save the encoded data in a file. */
-   ef = eet_open(file, EET_FILE_MODE_READ_WRITE);
+   ef = eet_open(tmpfile, EET_FILE_MODE_READ_WRITE);
    fail_if(!ef);
 
    result = eet_data_image_write(ef,
@@ -230,7 +224,7 @@ EFL_START_TEST(eet_test_image_normal)
    eet_close(ef);
 
    /* Test read of image */
-   ef = eet_open(file, EET_FILE_MODE_READ);
+   ef = eet_open(tmpfile, EET_FILE_MODE_READ);
    fail_if(!ef);
 
    result = eet_data_image_header_read(ef,
@@ -436,14 +430,15 @@ EFL_START_TEST(eet_test_image_normal)
    eet_close(ef);
    eet_clearcache();
 
-   fail_if(unlink(file) != 0);
+   fail_if(unlink(tmpfile) != 0);
+   eina_tmpstr_del(tmpfile);
 
 }
 EFL_END_TEST
 
 EFL_START_TEST(eet_test_image_small)
 {
-   char *file;
+   Eina_Tmpstr *tmpfile = NULL;
    unsigned int image[4];
    unsigned int *data;
    Eet_File *ef;
@@ -456,23 +451,17 @@ EFL_START_TEST(eet_test_image_small)
    int result;
    int tmpfd;
 
-   const char * filename = "eet_suite_testXXXXXX";
-   const char * tmpdir = eina_environment_tmp_get();
-   // +2 stands for <path separator> + <end of string>
-   size_t path_size = strlen(tmpdir) + strlen(filename) + 2;
-
-   file = malloc(sizeof(char)*path_size);
-   eina_file_path_join(file, path_size , tmpdir, filename);
-
    image[0] = IM0;
    image[1] = IM1;
    image[2] = IM2;
    image[3] = IM3;
 
-   fail_if(-1 == (tmpfd = mkstemp(file)));
+   /* tmpfile will be created in temporary directory (with eina_environment_tmp) */
+   tmpfd = eina_file_mkstemp("eet_suite_testXXXXXX", &tmpfile);
+   fail_if(-1 == tmpfd);
    fail_if(!!close(tmpfd));
 
-   ef = eet_open(file, EET_FILE_MODE_WRITE);
+   ef = eet_open(tmpfile, EET_FILE_MODE_WRITE);
    fail_if(!ef);
 
    result = eet_data_image_write(ef, "/images/test", image, 2, 2, 1, 9, 100, 0);
@@ -480,7 +469,7 @@ EFL_START_TEST(eet_test_image_small)
 
    eet_close(ef);
 
-   ef = eet_open(file, EET_FILE_MODE_READ);
+   ef = eet_open(tmpfile, EET_FILE_MODE_READ);
    fail_if(!ef);
 
    data = (unsigned int *)eet_data_image_read(ef,
@@ -496,7 +485,7 @@ EFL_START_TEST(eet_test_image_small)
    eet_close(ef);
    eet_clearcache();
 
-   fail_if(unlink(file) != 0);
+   fail_if(unlink(tmpfile) != 0);
 
    fail_if(data[0] != IM0);
    fail_if(data[1] != IM1);
@@ -504,7 +493,7 @@ EFL_START_TEST(eet_test_image_small)
    fail_if(data[3] != IM3);
 
    free(data);
-
+   eina_tmpstr_del(tmpfile);
 }
 EFL_END_TEST
 


### PR DESCRIPTION
Like others `eet` test cases, this test case had 2 problems one while creating a
temporary file and other while closing it:

About creating the file: `/tmp` doesn't exist in windows and `mkstemp` expects
that all path given already exists (besides the file it will create), causing a
fail:
```
../src/tests/eet/eet_test_image.c:93:F:Eet Image:eet_test_image_normal:0: Failure '-1 == (tmpfd = mkstemp(file))' occurred
../src/tests/eet/eet_test_image.c:459:F:Eet Image:eet_test_image_small:0: Failure '-1 == (tmpfd = mkstemp(file))' occurred
```
Here this is solved by using `eina_file_mkstemp` that creates a temporary file
at a temporary directory obtained with `eina_envitonment_tmp` which is an
architecture-independent function.

About closing it: `eet_close` is a postponed close, it doesn't immediately close
files opened as `write and read` nor `write` unless it has non saved changes nor
immediately closes files opened as `read` files. So when arriving at `unlink`
the file may not be closed yet. 
On linux it isn't a problem, as when `unlink`ing an open file it returns `0` and
waits until all references to the file to be closed for its removal.
But on windows while `unlink`ing an open file `-1` is returnged,  causing a fail
at:
```
../src/tests/eet/eet_test_image.c:438:F:Eet Image:eet_test_image_normal:0: Failure 'unlink(file) != 0' occurred
../src/tests/eet/eet_test_image.c:497:F:Eet Image:eet_test_image_small:0: Failure 'unlink(file) != 0' occurred
```
With `unlink` setting `errno` to `13`(`strerror(13)` = `Permission denied`).

This is solved using `eet_clearcache` which forces the closure of every file (in
case the file has been altered it flushes it before closing).
Note that this solves the problem for *this* test, but it isn't the best
solution, an user still needs to know where his program will run to know if they
need to force file closure before  `unlink`.