### PR TITLE
win32: Add --in-tree parameter for edje_codegen and elementary_codegen

### DIFF
--- a/src/bin/edje/edje_codegen.c
+++ b/src/bin/edje/edje_codegen.c
@@ -363,6 +363,7 @@ const Ecore_Getopt optdesc = {
    {
       ECORE_GETOPT_STORE_STR('p', "prefix", "The prefix for the " \
                                             "generataed code."),
+      ECORE_GETOPT_STORE_BOOL('t', "in-tree", "Same as setting EFL_RUN_IN_TREE=1 as environment variable"),
       ECORE_GETOPT_LICENSE('L', "license"),
       ECORE_GETOPT_COPYRIGHT('C', "copyright"),
       ECORE_GETOPT_VERSION('V', "version"),
@@ -1093,10 +1094,12 @@ int
 main(int argc, char *argv[])
 {
    Eina_Bool quit_option = EINA_FALSE;
+   Eina_Bool in_tree_option = EINA_FALSE;
    char *source, *header;
    int arg_index, ret = 0;
    Ecore_Getopt_Value values[] = {
       ECORE_GETOPT_VALUE_STR(prefix),
+      ECORE_GETOPT_VALUE_BOOL(in_tree_option),
       ECORE_GETOPT_VALUE_BOOL(quit_option),
       ECORE_GETOPT_VALUE_BOOL(quit_option),
       ECORE_GETOPT_VALUE_BOOL(quit_option),
@@ -1110,8 +1113,6 @@ main(int argc, char *argv[])
 
    eina_init();
    ecore_init();
-   ecore_evas_init();
-   edje_init();
 
    if (argc < 2)
      {
@@ -1147,6 +1148,12 @@ main(int argc, char *argv[])
         goto error_getopt;
      }
 
+   if (in_tree_option)
+     putenv ("EFL_RUN_IN_TREE=1");
+
+   ecore_evas_init();
+   edje_init();
+   
    file = argv[arg_index++];
 
    // check if the file is accessible

--- a/src/bin/elementary/elementary_codegen.c
+++ b/src/bin/elementary/elementary_codegen.c
@@ -275,6 +275,7 @@ const Ecore_Getopt optdesc =
    {
       ECORE_GETOPT_STORE_STR('p', "prefix", "The prefix for the " \
                              "generataed code."),
+      ECORE_GETOPT_STORE_BOOL('t', "in-tree", "Same as setting EFL_RUN_IN_TREE=1 as environment variable"),
       ECORE_GETOPT_LICENSE('L', "license"),
       ECORE_GETOPT_COPYRIGHT('C', "copyright"),
       ECORE_GETOPT_VERSION('V', "version"),
@@ -752,10 +753,12 @@ int
 main(int argc, char *argv[])
 {
    Eina_Bool quit_option = EINA_FALSE;
+   Eina_Bool in_tree_option = EINA_FALSE;
    char *source = NULL, *header = NULL;
    int arg_index, ret = 0;
    Ecore_Getopt_Value values[] = {
      ECORE_GETOPT_VALUE_STR(prefix),
+     ECORE_GETOPT_VALUE_BOOL(in_tree_option),
      ECORE_GETOPT_VALUE_BOOL(quit_option),
      ECORE_GETOPT_VALUE_BOOL(quit_option),
      ECORE_GETOPT_VALUE_BOOL(quit_option),
@@ -767,8 +770,6 @@ main(int argc, char *argv[])
 
    eina_init();
    ecore_init();
-   ecore_evas_init();
-   edje_init();
 
    if (argc < 2)
      {
@@ -803,6 +804,12 @@ main(int argc, char *argv[])
         goto error_getopt;
      }
 
+   if (in_tree_option)
+     putenv ("EFL_RUN_IN_TREE=1");
+
+   ecore_evas_init();
+   edje_init();
+   
    file = argv[arg_index++];
 
    // check if the file is accessible

--- a/src/examples/edje/meson.build
+++ b/src/examples/edje/meson.build
@@ -96,7 +96,7 @@ codegen = custom_target('edje_cc_codegen_edc',
 themes += custom_target('edje_codegen_codegen.edj',
             input : codegen,
             output : ['@BASENAME@_example_generated.c', '@BASENAME@_example_generated.h'],
-            command : edje_codegen_exe + [ '--prefix=codegen_example',  '@INPUT@',
+            command : edje_codegen_exe + ['--in-tree=true', '--prefix=codegen_example',  '@INPUT@',
                        'example_group', '@OUTPUT0@', '@OUTPUT1@'],
             depends : [edje_codegen, themes])
 

--- a/src/examples/elementary/meson.build
+++ b/src/examples/elementary/meson.build
@@ -201,7 +201,7 @@ codegen = custom_target('elementary_codegen_examples',
     depends : [themes, elementary_codegen],
     input : themes[0],
     output : ['codegen_example_generated.c', 'codegen_example_generated.h'],
-    command : elementary_codegen_exe + ['-p=codegen_example', '@INPUT@', 'elm/example/mylayout/default', '@OUTPUT0@', '@OUTPUT1@'],
+    command : elementary_codegen_exe + ['--in-tree=true', '-p=codegen_example', '@INPUT@', 'elm/example/mylayout/default', '@OUTPUT0@', '@OUTPUT1@'],
 )
 
 executable('codegen_example',


### PR DESCRIPTION
This is needed because Windows platform doesn't have a good way to pass
environment variables to executables through meson, so we pass through a
command-line instead.

As `ecore_evas` and `edje` needs in-tree here they are initialize after
in-tree parameter check.

Original:
- f5b3fd6f3a
- a0208c36b6