### PR TITLE
edje: Fix pending_threads calculation and avoid an infinite loop

### DIFF
--- a/src/bin/edje/edje_cc_out.c
+++ b/src/bin/edje/edje_cc_out.c
@@ -1845,7 +1845,6 @@ data_write_mo(Eet_File *ef, int *mo_num)
              mw->ef = ef;
              mw->mo_entry = &edje_file->mo_dir->mo_entries[i];
              *mo_num += 1;
-             pending_threads++;
 
              po_entry = strdup(mw->mo_entry->mo_src);
              sub_str = strstr(mw->mo_entry->mo_src, ".po");
@@ -1881,6 +1880,7 @@ data_write_mo(Eet_File *ef, int *mo_num)
                }
              else
                {
+                  pending_threads++;
                   if (threads)
                     ecore_thread_run(data_thread_mo, data_thread_mo_end, NULL, mw);
                   else


### PR DESCRIPTION
`pending_threads` was being incremented in every iteration making `edje`
wait for inexistent threads.

Now it is only incremented before the thread use.

Original: 3997580d3a78768c9bea3a7ec75b7e036fb887a9