### PR TITLE
evil: Fix fcntl for F_SETLK and F_SETLKW wrong length calculation

### DIFF
--- a/src/lib/evil/evil_fcntl.c
+++ b/src/lib/evil/evil_fcntl.c
@@ -115,7 +115,7 @@ fcntl(int fd, int cmd, ...)
              if (length != -1L)
                res = 0;
           }
-        fl->l_len = length - fl->l_start - 1;
+        fl->l_len = length - fl->l_start;
 
         pos = _lseek(fd, fl->l_start, fl->l_whence);
         if (pos != -1L)


### PR DESCRIPTION
In case a file `length` and `fl->start` are `0` 
`length - fl->start - 1 = -1` which doesn't make sense as a file length