### PR TITLE
Eet: Resolve eet_test_identity test case

### DIFF
--- a/src/tests/eet/eet_suite.c
+++ b/src/tests/eet/eet_suite.c
@@ -8,6 +8,14 @@
 #include "../efl_check.h"
 #include <Eet.h>
 
+#ifdef _MSC_VER
+/* On windows, applink.c needs to be included in the executable; otherwise
+ * all the tests which are using file pointer will fail in runtime, throwing
+ * `No OPENSSL_Applink` messages, i.e: eet_test_identity.
+ * */
+# include <openssl/applink.c>
+#endif
+
 char argv0[PATH_MAX];
 
 static const Efl_Test_Case etc[] = {

--- a/src/tests/eet/eet_test_identity.c
+++ b/src/tests/eet/eet_test_identity.c
@@ -135,7 +135,7 @@ EFL_START_TEST(eet_test_identity_simple)
    ef = eet_open(tmpfile, EET_FILE_MODE_READ);
    fail_if(ef);
 
-   fail_if(eina_file_unlink(file) != EINA_TRUE);
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
    eina_tmpstr_del(tmpfile);
 }
 EFL_END_TEST

--- a/src/tests/eet/eet_test_identity.c
+++ b/src/tests/eet/eet_test_identity.c
@@ -74,7 +74,11 @@ EFL_START_TEST(eet_test_identity_simple)
    fail_if(-1 == tmpfd);
    fail_if(!!close(tmpfd));
 
+#ifdef _MSC_VER
+   fail_if(!(noread = fopen("nul", "wb")));
+#else
    fail_if(!(noread = fopen("/dev/null", "wb")));
+#endif
 
    /* Sign an eet file. */
    ef = eet_open(tmpfile, EET_FILE_MODE_WRITE);


### PR DESCRIPTION
Before:
```PowerShell
24/35 eet-suite                 TIMEOUT        37.92s

--- command ---
Running suite(s): Eet
95%: Checks: 22, Failures: 1, Errors: 0
../src/tests/eet/eet_test_identity.c:74:F:Eet Identity:eet_test_identity_simple:0: Failure '-1 == (fd = mkstemp(file))' occurred
```

After solving temporary file creation:
```PowerShell
Running suite(s): Eet
OPENSSL_Uplink(00007FF9E25D9D30,08): no OPENSSL_Applink
1/1 eet-suite FAIL           0.97s (exit status 1)
```

After including `openssl/applink.c`:
```PowerShell
Running suite(s): Eet
24/35 eet-suite                 OK             2.69s
```