### PR TITLE
ecore_file: Resolve  ecore_test_ecore_file_operations

### DIFF
--- a/src/lib/ecore_file/ecore_file.c
+++ b/src/lib/ecore_file/ecore_file.c
@@ -311,6 +311,9 @@ ecore_file_unlink(const char *file)
 ECORE_FILE_API Eina_Bool
 ecore_file_remove(const char *file)
 {
+#ifdef _MSC_VER
+   if (ecore_file_is_dir(file)) return ecore_file_rmdir(file);
+#endif
    if (remove(file) < 0) return EINA_FALSE;
    return EINA_TRUE;
 }

--- a/src/tests/ecore/ecore_test_ecore_file.c
+++ b/src/tests/ecore/ecore_test_ecore_file.c
@@ -248,7 +248,9 @@ EFL_START_TEST(ecore_test_ecore_file_operations)
    fail_if(ecore_file_mod_time(dest_file) == 0);
    fail_if(ecore_file_can_read(dest_file) != EINA_TRUE);
    fail_if(ecore_file_can_write(dest_file) != EINA_TRUE);
+#ifndef _MSC_VER
    fail_if(ecore_file_can_exec(dest_file) != EINA_FALSE);
+#endif
    fail_if(ecore_file_remove(dest_file) != EINA_TRUE);
 
    ck_assert_str_eq(ecore_file_app_exe_get(exe_cmd), exe);
@@ -262,8 +264,9 @@ EFL_START_TEST(ecore_test_ecore_file_operations)
    fd = open(src_file, O_RDWR | O_BINARY | O_CREAT, 0700);
    fail_if(fd < 0);
    fail_if(close(fd) != 0);
+#ifndef _MSC_VER
    fail_if(ecore_file_can_exec(src_file) != EINA_TRUE);
-
+#endif
    src_dir = get_tmp_dir();
    fail_if(!src_dir);
    snprintf(dir, sizeof(dir), "%s/%s", src_dir, dirs[0]);
@@ -303,6 +306,7 @@ EFL_START_TEST(ecore_test_ecore_file_operations)
    ck_assert_str_eq(ecore_file_realpath(NULL), "");
    ck_assert_str_eq(ecore_file_realpath(not_exist_file), "");
 
+#ifndef _MSC_VER
    src_file = get_tmp_file();
    fail_if(!src_file);
    fail_if(ecore_file_remove(src_file) != EINA_TRUE);
@@ -319,6 +323,7 @@ EFL_START_TEST(ecore_test_ecore_file_operations)
      }
    fail_if(ecore_file_cp(src_file, src_file) != EINA_FALSE);
    fail_if(ecore_file_remove(src_file) != EINA_TRUE);
+#endif
 
    src_file = get_tmp_file();
    fail_if(!src_file);
@@ -329,13 +334,16 @@ EFL_START_TEST(ecore_test_ecore_file_operations)
 #if defined(HAVE_GETUID) && defined(HAVE_GETEUID)
    if (getuid() || geteuid())
 #endif
+#ifndef _MSC_VER
      {
         fail_if(ecore_file_can_read(src_file) != EINA_FALSE);
      }
    fail_if(ecore_file_can_exec(src_file) != EINA_FALSE);
+#endif
    fail_if(ecore_file_can_write(src_file) != EINA_TRUE);
    fail_if(ecore_file_remove(src_file) != EINA_TRUE);
 
+#ifndef _MSC_VER
    src_file = get_tmp_file();
    fail_if(!src_file);
    fail_if(ecore_file_remove(src_file) != EINA_TRUE);
@@ -351,6 +359,7 @@ EFL_START_TEST(ecore_test_ecore_file_operations)
      }
    fail_if(ecore_file_can_exec(src_file) != EINA_TRUE);
    fail_if(ecore_file_remove(src_file) != EINA_TRUE);
+#endif
 
    fail_if(ecore_file_unlink(not_exist_file) != EINA_FALSE);
    fail_if(ecore_file_remove(not_exist_file) != EINA_FALSE);


### PR DESCRIPTION
Work toward  #397

Failing initialy with:
```
../src/tests/ecore/ecore_test_ecore_file.c:186:F:Ecore_File:ecore_test_ecore_file_operations:0: Failure 'res != EINA_TRUE' occurred
```

This happens because `UCRT`'s `remove` only works on files, it doesn't
call `rmdir` in case the specified path is a directory
instead of a file like in Linux.

So this patch changes `ecore_file_remove`: now it verifies if the given
path is a directory and if so calls the correct function
(`ecore_file_rmdir`).

Next, there are some file permission related errors, this happens
because Windows only has 2 file permissions:
- `_S_IREAD ==  0o400` which means a read-only file;
- `_S_IWRITE == 0o200` which means a file with write permission;
- `_S_IWRITE | _S_IREAD == 0o600` which is equivalent to `_S_IWRITE`;
Because of this:
- every file is readable, thus every execution of `ecore_file_can_read`
  return `EINA_TRUE`;
- the concept of an execute permission as in Linux doesn't exist.  On
  Windows only `.exe` files are executables, even `.bat` are not
  considered here (as in `GetBinaryTypeA` function).  `evil` has a
  bypass for the execute permission: `X_OK` (test for execute
  permission) actually returns `F_OK` (test for existence), so as for
  the concept of execute permission as in Linux, every file is
  considered executable because they all exist. Thus, every call to
  `ecore_file_can_exec` return `EINA_TRUE`;
- a file without write permission can not be removed thus making calls
  to `ecore_file_remove` to files without `_S_IWRITE` return
  `EINA_FALSE` with internal `remove` rising `EACESS`.

So here every one of those calls that expects a fail is bypassed. It
should be brought to further discussion at EFL latter;

After this:
```
../src/tests/ecore/ecore_test_ecore_file.c:384:P:Ecore_File:ecore_test_ecore_file_operations:0: Passed
```

