### PR TITLE
Use eina_file_unlink() instead of unlink()

### DIFF
--- a/src/examples/eet/eet-data-cipher_decipher.c
+++ b/src/examples/eet/eet-data-cipher_decipher.c
@@ -111,7 +111,7 @@ main(void)
    eet_close(ef);
 
 error:
-   if (unlink(file) != 0)
+   if (eina_file_unlink(file) != EINA_TRUE)
      {
         fprintf(
           stderr, "ERROR: could not unlink file (%s).\n", file);

--- a/src/examples/eet/eet-data-file_descriptor_01.c
+++ b/src/examples/eet/eet-data-file_descriptor_01.c
@@ -356,7 +356,7 @@ _my_cache_save(const My_Cache *my_cache,
 
    if (ret)
      {
-        unlink(filename);
+        eina_file_unlink(filename);
         rename(tmp, filename);
      }
 

--- a/src/examples/eet/eet-data-file_descriptor_02.c
+++ b/src/examples/eet/eet-data-file_descriptor_02.c
@@ -637,7 +637,7 @@ _data_save(const Example_Lists *cache,
 
    if (ret)
      {
-        unlink(filename);
+        eina_file_unlink(filename);
         rename(tmp, filename);
      }
 

--- a/src/examples/eet/eet-data-nested.c
+++ b/src/examples/eet/eet-data-nested.c
@@ -205,7 +205,7 @@ _my_conf_save(const My_Conf_Type *my_conf,
 
    if (ret)
      {
-        unlink(filename);
+        eina_file_unlink(filename);
         rename(tmp, filename);
      }
 

--- a/src/examples/eet/eet-data-simple.c
+++ b/src/examples/eet/eet-data-simple.c
@@ -165,7 +165,7 @@ _my_conf_save(const My_Conf_Type *my_conf,
 
    if (ret)
      {
-        unlink(filename);
+        eina_file_unlink(filename);
         rename(tmp, filename);
      }
 

--- a/src/tests/eet/eet_test_cache.c
+++ b/src/tests/eet/eet_test_cache.c
@@ -95,13 +95,8 @@ EFL_START_TEST(eet_test_cache_concurrency)
    fail_unless(thread_ret == NULL, (char const *)thread_ret);
 
    eet_close(ef);
-    /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
-     * successfully if there is any reference to the file, here `eet_clearcache` is
-     * used to assure that the file is really closed when the unlink happens.
-     */
-   eet_clearcache();
 
-   fail_if(unlink(tmpfile) != 0);
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
 
    eina_threads_shutdown();
    eina_tmpstr_del(tmpfile);

--- a/src/tests/eet/eet_test_cipher.c
+++ b/src/tests/eet/eet_test_cipher.c
@@ -64,13 +64,8 @@ EFL_START_TEST(eet_test_cipher_decipher_simple)
      fail_if(memcmp(test, buffer, strlen(buffer) + 1) == 0);
 
    eet_close(ef);
-   /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
-    * successfully if there is any reference to the file, here `eet_clearcache`
-    * is used to assure that the file is really closed when the unlink happens.
-    */
-   eet_clearcache();
 
-   fail_if(unlink(tmpfile) != 0);
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
    eina_tmpstr_del(tmpfile);
 
 }

--- a/src/tests/eet/eet_test_file.c
+++ b/src/tests/eet/eet_test_file.c
@@ -120,13 +120,8 @@ EFL_START_TEST(eet_test_file_simple_write)
    fail_if(memcmp(test, buffer, strlen(buffer) + 1) != 0);
 
    eet_close(ef);
-   /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
-    * successfully if there is any reference to the file, here `eet_clearcache` is
-    * used to assure that the file is really closed when the unlink happens.
-    */
-   eet_clearcache();
 
-   fail_if(unlink(tmpfile) != 0);
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
    eina_tmpstr_del(tmpfile);
 
 }
@@ -284,7 +279,7 @@ EFL_START_TEST(eet_test_file_data)
 
    eet_close(ef);
 
-   fail_if(unlink(tmpfile) != 0);
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
    eina_tmpstr_del(tmpfile);
 
 }
@@ -383,12 +378,8 @@ EFL_START_TEST(eet_test_file_data_dump)
    fail_if(test != 0);
 
    eet_close(ef);
-   /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
-    * successfully if there is any reference to the file, here `eet_clearcache` is
-    * used to assure that the file is really closed when the unlink happens.
-    */
-   eet_clearcache();
-   fail_if(unlink(tmpfile) != 0);
+
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
    eina_tmpstr_del(tmpfile);
 
 }
@@ -460,7 +451,7 @@ EFL_START_TEST(eet_test_file_fp)
 
    eet_close(ef);
 
-   fail_if(unlink(tmpfile) != 0);
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
    eina_tmpstr_del(tmpfile);
 
 }

--- a/src/tests/eet/eet_test_identity.c
+++ b/src/tests/eet/eet_test_identity.c
@@ -130,7 +130,7 @@ EFL_START_TEST(eet_test_identity_simple)
    ef = eet_open(file, EET_FILE_MODE_READ);
    fail_if(ef);
 
-   fail_if(unlink(file) != 0);
+   fail_if(eina_file_unlink(file) != EINA_TRUE);
 
 }
 EFL_END_TEST

--- a/src/tests/eet/eet_test_image.c
+++ b/src/tests/eet/eet_test_image.c
@@ -428,13 +428,8 @@ EFL_START_TEST(eet_test_image_normal)
    free(data);
 
    eet_close(ef);
-   /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
-    * successfully if there is any reference to the file, here `eet_clearcache` is
-    * used to assure that the file is really closed when the unlink happens.
-    */
-   eet_clearcache();
 
-   fail_if(unlink(tmpfile) != 0);
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
    eina_tmpstr_del(tmpfile);
 
 }
@@ -487,13 +482,8 @@ EFL_START_TEST(eet_test_image_small)
    fail_if(data == NULL);
 
    eet_close(ef);
-   /* As `eet_close` is a postponed close and windows' `unlink` doesn't execute
-    * successfully if there is any reference to the file, here `eet_clearcache` is
-    * used to assure that the file is really closed when the unlink happens.
-    */
-   eet_clearcache();
 
-   fail_if(unlink(tmpfile) != 0);
+   fail_if(eina_file_unlink(tmpfile) != EINA_TRUE);
 
    fail_if(data[0] != IM0);
    fail_if(data[1] != IM1);


### PR DESCRIPTION
As `tmpfile` are being created using `eina_file_mkstemp()`, we can use `eina_file_unlink()` instead of `unlink()`, which closes the handles before unlink (see implementation [here](https://github.com/expertisesolutions/efl/blob/devs/expertise/native-windows/src/lib/eina/eina_file_win32.c#L794https://github.com/expertisesolutions/efl/blob/devs/expertise/native-windows/src/lib/eina/eina_file_win32.c#L794)).
This also removes the need to call `eet_clearcache()` before `unlink()` as the handles are being closed by `eina_file_unlink()`.

This patch is a candidate to solve https://phab.enlightenment.org/T8795.