### PR TITLE
[Eet] [Examples] Fix: eet-file.exe

### DIFF
--- a/src/examples/eet/eet-file.c
+++ b/src/examples/eet/eet-file.c
@@ -32,7 +32,15 @@ create_eet_file(void)
      "\x79\x20\x6c\x6f\x61\x64\x65\x64\x20\x69\x6e\x20\x6d\x65\x6d\x6f"
      "\x72\x79\x2e\x0a\x00";
 
-   ef = eet_open("/tmp/my_file.eet", EET_FILE_MODE_WRITE);
+   char *tmpdir = getenv("TEMP");
+   const char filename[] = "my_file.eet";
+   size_t tmpdir_len = strlen(tmpdir) + 1;
+   size_t filename_len = strlen(filename) + 1;
+   size_t file_len = tmpdir_len + filename_len;
+   char file[file_len];
+   snprintf(file, file_len, "%s" EINA_PATH_SEP_S "%s", tmpdir, filename);
+
+   ef = eet_open(file, EET_FILE_MODE_WRITE);
    if (!ef) return 0;
 
    strcpy(buf, "Here is a string of data to save!");
@@ -75,7 +83,15 @@ main(void)
    if (!create_eet_file())
      return -1;
 
-   ef = eet_open("/tmp/my_file.eet", EET_FILE_MODE_READ);
+   char *tmpdir = getenv("TEMP");
+   const char filename[] = "my_file.eet";
+   size_t tmpdir_len = strlen(tmpdir) + 1;
+   size_t filename_len = strlen(filename) + 1;
+   size_t file_len = tmpdir_len + filename_len;
+   char file[file_len];
+   snprintf(file, file_len, "%s" EINA_PATH_SEP_S "%s", tmpdir, filename);
+
+   ef = eet_open(file, EET_FILE_MODE_READ);
    if (!ef) return -1;
 
    list = eet_list(ef, "*", &num);

--- a/src/examples/eet/eet-file.c
+++ b/src/examples/eet/eet-file.c
@@ -34,11 +34,8 @@ create_eet_file(void)
 
    char *tmpdir = getenv("TEMP");
    const char filename[] = "my_file.eet";
-   size_t tmpdir_len = strlen(tmpdir) + 1;
-   size_t filename_len = strlen(filename) + 1;
-   size_t file_len = tmpdir_len + filename_len;
-   char file[file_len];
-   snprintf(file, file_len, "%s" EINA_PATH_SEP_S "%s", tmpdir, filename);
+   char file[PATH_MAX];
+   eina_file_path_join(file, sizeof(file), tmpdir, filename);
 
    ef = eet_open(file, EET_FILE_MODE_WRITE);
    if (!ef) return 0;
@@ -85,11 +82,8 @@ main(void)
 
    char *tmpdir = getenv("TEMP");
    const char filename[] = "my_file.eet";
-   size_t tmpdir_len = strlen(tmpdir) + 1;
-   size_t filename_len = strlen(filename) + 1;
-   size_t file_len = tmpdir_len + filename_len;
-   char file[file_len];
-   snprintf(file, file_len, "%s" EINA_PATH_SEP_S "%s", tmpdir, filename);
+   char file[PATH_MAX];
+   eina_file_path_join(file, sizeof(file), tmpdir, filename);
 
    ef = eet_open(file, EET_FILE_MODE_READ);
    if (!ef) return -1;
@@ -140,4 +134,3 @@ main(void)
 
    return 0;
 }
-

--- a/src/examples/eet/eet-file.c
+++ b/src/examples/eet/eet-file.c
@@ -32,7 +32,7 @@ create_eet_file(void)
      "\x79\x20\x6c\x6f\x61\x64\x65\x64\x20\x69\x6e\x20\x6d\x65\x6d\x6f"
      "\x72\x79\x2e\x0a\x00";
 
-   char *tmpdir = getenv("TEMP");
+   const char *tmpdir = eina_environment_tmp_get();
    const char filename[] = "my_file.eet";
    char file[PATH_MAX];
    eina_file_path_join(file, sizeof(file), tmpdir, filename);
@@ -80,7 +80,7 @@ main(void)
    if (!create_eet_file())
      return -1;
 
-   char *tmpdir = getenv("TEMP");
+   const char *tmpdir = eina_environment_tmp_get();
    const char filename[] = "my_file.eet";
    char file[PATH_MAX];
    eina_file_path_join(file, sizeof(file), tmpdir, filename);


### PR DESCRIPTION
The `example build/src/examples/eet/eet-file.exe` was trying to create temporary files in `/tmp`, which doesn't exist in windows. This patch changes it to use `getenv("TEMP")`, which correctly uses the OS temp folder.