### PR TITLE
Fix: add libcurl to meson

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,6 +91,9 @@ jobs:
     - name: Install getopt (vcpkg)
       if: steps.cache-vcpkg.outputs.cache-hit != 'true'
       run: .\vcpkg\vcpkg install getopt:x64-windows
+    - name: Install curl (vcpkg)
+      if: steps.cache-vcpkg.outputs.cache-hit != 'true'
+      run: .\vcpkg\vcpkg install curl:x64-windows
     - name: Add vcpkg installed package dirs to path
       run: echo "::add-path::${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
     - name: Add vcpkg installed package dirs to path (debug libs)

--- a/header_checks/meson.build
+++ b/header_checks/meson.build
@@ -223,6 +223,7 @@ endif
 alternative_lib_names = {
   'freetype2': ['freetype'],
   'jpeg': ['libjpeg'],
+  'curl': ['libcurl'],
 }
 
 foreach libname, alternatives : alternative_lib_names


### PR DESCRIPTION
libcurl cannot be used if meson doesn't link it:
```PowerShell
ERR:ecore_con ../src/lib/ecore_con/ecore_con_url_curl.c:255 _c_init()
Cannot find libcurl at runtime!
```