### PR TITLE
Revert "Evas: Call evas modules by its final name in native-windows builds"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,10 +52,9 @@ osx = ['darwin']
 sys_linux = linux.contains(host_machine.system())
 sys_bsd = bsd.contains(host_machine.system())
 sys_windows = windows.contains(host_machine.system())
-sys_native_windows = sys_windows and cc.get_id() in ['msvc', 'clang-cl']
 sys_osx = osx.contains(host_machine.system())
 
-if sys_native_windows
+if sys_windows and cc.get_id() in ['msvc', 'clang-cl']
   pkgconfig = disabler()
 else
   pkgconfig = import('pkgconfig')
@@ -767,7 +766,7 @@ if get_option('build-examples')
 endif
 
 # disabled for windows for now
-if not sys_native_windows
+if not sys_windows
   subdir(join_paths(local_scripts))
 
   meson.add_install_script('meson/meson_modules.sh', module_files)

--- a/src/modules/ecore_evas/meson.build
+++ b/src/modules/ecore_evas/meson.build
@@ -29,12 +29,7 @@ foreach engine_conf : engines
 
     config_h.set('BUILD_ECORE_EVAS_'+engine.to_upper(), '1')
 
-    if sys_native_windows
-      mod_full_name = 'module'
-    else
-      mod_full_name = engine
-    endif
-
+    mod_full_name = engine
     mod_install_dir = join_paths(dir_lib, package_name, 'engines', engine, version_name)
 
     subdir(join_paths('engines', engine))

--- a/src/modules/evas/engines/meson.build
+++ b/src/modules/evas/engines/meson.build
@@ -54,12 +54,7 @@ foreach engine_conf : engines
     var_name = 'engine_'+engine
     set_variable(var_name, engine_dep)
 
-    if sys_native_windows
-      mod_full_name = 'module'
-    else
-      mod_full_name = engine
-    endif
-
+    mod_full_name = engine
     # root meson.build declares the root evas engines project as `evas/engines`,
     # but modules must be installed in evas/modules
     evas_package_modules = join_paths(dir_lib, 'evas', 'modules')


### PR DESCRIPTION
Reverts expertisesolutions/efl#380

Unfortunatelly it was broken and we forgot to rerun CI to have an up-to-date run before merging.