### PR TITLE
Evas: Fix evas modules name in native-windows builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,9 +52,10 @@ osx = ['darwin']
 sys_linux = linux.contains(host_machine.system())
 sys_bsd = bsd.contains(host_machine.system())
 sys_windows = windows.contains(host_machine.system())
+sys_native_windows = sys_windows and cc.get_id() in ['msvc', 'clang-cl']
 sys_osx = osx.contains(host_machine.system())
 
-if sys_windows and cc.get_id() in ['msvc', 'clang-cl']
+if sys_native_windows
   pkgconfig = disabler()
 else
   pkgconfig = import('pkgconfig')
@@ -766,7 +767,7 @@ if get_option('build-examples')
 endif
 
 # disabled for windows for now
-if not sys_windows
+if not sys_native_windows
   subdir(join_paths(local_scripts))
 
   meson.add_install_script('meson/meson_modules.sh', module_files)

--- a/src/lib/evas/file/evas_module.c
+++ b/src/lib/evas/file/evas_module.c
@@ -611,7 +611,7 @@ evas_module_find_type(Evas_Module_Type type, const char *name)
 
         if (buffer[0] == '\0')
           snprintf(buffer, sizeof(buffer), "%s/%s/%s/%s/%s",
-                   path, type_str, name, MODULE_ARCH, EVAS_MODULE_NAME);
+                   path, type_str, name, !run_in_tree ? MODULE_ARCH : "", EVAS_MODULE_NAME);
 
         if (!evas_file_path_is_file(buffer)) continue;
 

--- a/src/modules/ecore_evas/meson.build
+++ b/src/modules/ecore_evas/meson.build
@@ -29,7 +29,12 @@ foreach engine_conf : engines
 
     config_h.set('BUILD_ECORE_EVAS_'+engine.to_upper(), '1')
 
-    mod_full_name = engine
+    if sys_native_windows
+      mod_full_name = 'module'
+    else
+      mod_full_name = engine
+    endif
+
     mod_install_dir = join_paths(dir_lib, package_name, 'engines', engine, version_name)
 
     subdir(join_paths('engines', engine))

--- a/src/modules/evas/engines/meson.build
+++ b/src/modules/evas/engines/meson.build
@@ -54,7 +54,12 @@ foreach engine_conf : engines
     var_name = 'engine_'+engine
     set_variable(var_name, engine_dep)
 
-    mod_full_name = engine
+    if sys_native_windows
+      mod_full_name = 'module'
+    else
+      mod_full_name = engine
+    endif
+
     # root meson.build declares the root evas engines project as `evas/engines`,
     # but modules must be installed in evas/modules
     evas_package_modules = join_paths(dir_lib, 'evas', 'modules')


### PR DESCRIPTION
On native-windows we don't have the `MODULE_ARCH` at the path of
modules, so `evas` we don't need to search there;
Another change at the name is that on native-windows builds we want to
use the final name of modules instead of it intermediary one.
So this changes module names for its final version (`module`) when on
native windows builds. To achieve this, it creates a
`sys_native_windows` variable, which is only true when using `msvc` or
`clang-cl` while in a `windows` host.

Original:
 - 2f3c8295db3e1fa9c62462dbeb6057085e19f87e
 - 426386578bb6f4e045474dbf1d94a502f29ff18b

Co-authored-by: Felipe Magno de Almeida <felipe@expertise.dev>