### PR TITLE
ci: Make vcpkg cache unique for each workflow change.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,15 +22,9 @@ jobs:
     - name: Cache vcpkg
       uses: actions/cache@v2
       id: cache-vcpkg
-      env:
-        cache-name: cache-vcpkg
       with:
         path: ${{ github.workspace }}/vcpkg
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+        key: vcpkg-cache-${{ hashfiles('.github/workflows/windows.yml') }}
     - name: Show vcpkg cache info
       env:
         VCPKG_INFO: ${{ toJSON(steps.cache-vcpkg) }}
@@ -126,15 +120,9 @@ jobs:
     - name: Cache vcpkg
       uses: actions/cache@v2
       id: cache-vcpkg
-      env:
-        cache-name: cache-vcpkg
       with:
         path: ${{ github.workspace }}/vcpkg
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+        key: vcpkg-cache-${{ hashfiles('.github/workflows/windows.yml') }}
     - name: Show vcpkg cache info
       env:
         VCPKG_INFO: ${{ toJSON(steps.cache-vcpkg) }}


### PR DESCRIPTION
In order to have better control over dependencies on vcpkg on CI, this PR uses a hash of the current contents of `.github/workflows/windows.yml` as the vcpkg cache key. This means that vcpkg cache will only be invalidated (i.e. vcpkg will be cloned & setuped and then dependencies will be installed one by one) when that file changes (possibly by adding a new dependency).