### PR TITLE
elm: Fix how elm_config was created

### DIFF
--- a/src/lib/elementary/elm_config.c
+++ b/src/lib/elementary/elm_config.c
@@ -1732,7 +1732,7 @@ _config_system_load(void)
      {
         Eina_Tmpstr* tmp;
         ERR("System loading config failed! Check your setup! Falling back to compile time defaults");
-        EINA_SAFETY_ON_FALSE_RETURN_VAL(eina_file_mkstemp("/tmp/elementary_configXXXXXX", &tmp), NULL);
+        EINA_SAFETY_ON_FALSE_RETURN_VAL(eina_file_mkstemp("elementary_configXXXXXX", &tmp), NULL);
         ef = eet_open(tmp, EET_FILE_MODE_WRITE);
         EINA_SAFETY_ON_FALSE_RETURN_VAL(eet_data_undump(ef, "config", embedded_config, strlen(embedded_config)-1, EINA_FALSE), NULL);
         eet_close(ef);


### PR DESCRIPTION
When there is no `elm_config` it was randomly created with
`eina_file_mkstemp` as `<TEMP DIR>/tmp/elementary_config`, which is a
problem because internally `evil` calls `open` to create the file, but
it cannot create a dir. Thus failing at elm initialization.

This was tested at `examples/elementary/label_example_01.c` that was
failing without running anything of itself.
Now it runs to the end, but failing on almost every other call.