### PR TITLE
Use eina_file_unlink() instead of unlink()

### DIFF
--- a/src/benchmarks/evas/evas_bench_saver.c
+++ b/src/benchmarks/evas/evas_bench_saver.c
@@ -65,7 +65,7 @@ evas_bench_saver_tgv(int request)
         evas_object_image_save(o, dest, NULL, "compress=1 quality=50");
      }
 
-   unlink(dest);
+   eina_file_unlink(dest);
    eina_tmpstr_del(dest);
 
    evas_free(e);

--- a/src/bin/ecore_evas/ecore_evas_convert.c
+++ b/src/bin/ecore_evas/ecore_evas_convert.c
@@ -92,8 +92,7 @@ static void
 _sigint(int sig EINA_UNUSED)
 {
    EINA_LOG_ERR("Image save interrupted by SIGINT: '%s'.", job.output);
-   // eina_file_unlink
-   unlink(job.output);
+   eina_file_unlink(job.output);
    exit(-1);
 }
 #endif

--- a/src/bin/efreet/efreet_desktop_cache_create.c
+++ b/src/bin/efreet/efreet_desktop_cache_create.c
@@ -555,8 +555,8 @@ main(int argc, char **argv)
       }
     else
       {
-         unlink(tmpuc);
-         unlink(tmpc);
+         eina_file_unlink(tmpuc);
+         eina_file_unlink(tmpc);
       }
 
     {

--- a/src/bin/efreet/efreet_icon_cache_create.c
+++ b/src/bin/efreet/efreet_icon_cache_create.c
@@ -859,7 +859,7 @@ main(int argc, char **argv)
     {
         // delete old cache
         eet_close(theme_ef);
-        if (unlink(efreet_icon_theme_cache_file()) < 0)
+        if (eina_file_unlink(efreet_icon_theme_cache_file()) != EINA_TRUE)
         {
             if (errno != ENOENT) goto on_error_efreet;
         }
@@ -945,7 +945,7 @@ main(int argc, char **argv)
         {
             // delete old cache
             eet_close(icon_ef);
-            if (unlink(efreet_icon_cache_file(theme->theme.name.internal)) < 0)
+            if (eina_file_unlink(efreet_icon_cache_file(theme->theme.name.internal)) != EINA_TRUE)
             {
                 if (errno != ENOENT) goto on_error_efreet;
             }
@@ -1023,7 +1023,7 @@ main(int argc, char **argv)
     {
         // delete old cache
         eet_close(icon_ef);
-        if (unlink(efreet_icon_cache_file(EFREET_CACHE_ICON_FALLBACK)) < 0)
+        if (eina_file_unlink(efreet_icon_cache_file(EFREET_CACHE_ICON_FALLBACK)) != EINA_TRUE)
         {
             if (errno != ENOENT) goto on_error_efreet;
         }

--- a/src/bin/efreet/efreet_mime_cache_create.c
+++ b/src/bin/efreet/efreet_mime_cache_create.c
@@ -373,7 +373,7 @@ write_error:
    ERR("Cannot write to %s", buf);
 error:
    if (f) fclose(f);
-   if (unlink(buf) != 0) WRN("Cannot delete tmp file %s", buf);
+   if (eina_file_unlink(buf) != 0) WRN("Cannot delete tmp file %s", buf);
 }
 
 int

--- a/src/bin/efreet/efreetd_cache.c
+++ b/src/bin/efreet/efreetd_cache.c
@@ -227,7 +227,7 @@ subdir_cache_save(void)
 
    if (rename(tmpstr, eina_strbuf_string_get(buf)) < 0)
      {
-        unlink(tmpstr);
+        eina_file_unlink(tmpstr);
         ERR("Can't save subdir cache %s", eina_strbuf_string_get(buf));
      }
    // we dont need saving anymore - we just did

--- a/src/bin/elementary/elementary_codegen.c
+++ b/src/bin/elementary/elementary_codegen.c
@@ -894,8 +894,8 @@ error_log:
 
    if (ret > 4)
      {
-        unlink(header);
-        unlink(source);
+        eina_file_unlink(header);
+        eina_file_unlink(source);
      }
 
    return ret;

--- a/src/bin/elementary/quicklaunch.c
+++ b/src/bin/elementary/quicklaunch.c
@@ -217,7 +217,7 @@ main(int argc, char **argv)
           }
      }
    eina_vpath_resolve_snprintf(buf, sizeof(buf), "(:usr.run:)/elm-ql-%i/%s", getuid(), domain);
-   unlink(buf);
+   eina_file_unlink(buf);
    sock = socket(AF_UNIX, SOCK_STREAM, 0);
    if (sock < 0)
      {

--- a/src/bin/embryo/embryo_cc_sc1.c
+++ b/src/bin/embryo/embryo_cc_sc1.c
@@ -234,7 +234,7 @@ sc_closebin(void *handle, int deletefile)
 {
    fclose((FILE *) handle);
    if (deletefile)
-      unlink(binfname);
+      eina_file_unlink(binfname);
 }
 
 void
@@ -401,7 +401,7 @@ sc_compile(int argc, char *argv[])
      }				/* if */
    if (outf)
       sc_closeasm(outf);
-   unlink(outfname);
+   eina_file_unlink(outfname);
    eina_tmpstr_del(outfname);
    if (binf)
       sc_closebin(binf, errnum != 0);

--- a/src/bin/exactness/player.c
+++ b/src/bin/exactness/player.c
@@ -826,7 +826,7 @@ _old_shots_rm_cb(const char *name, const char *path, void *data)
         unsigned int length = strlen(path) + strlen(name) + 2;
         char *buf = alloca(length);
         snprintf(buf, length, "%s/%s", path, name);
-        if (unlink(buf))
+        if (eina_file_unlink(buf) != EINA_TRUE)
           {
              printf("Failed deleting '%s/%s': ", path, name);
              perror("");

--- a/src/lib/ecore/ecore.c
+++ b/src/lib/ecore/ecore.c
@@ -872,7 +872,7 @@ _ecore_fps_debug_init(void)
    _ecore_fps_debug_fd = open(buf, O_CREAT | O_BINARY | O_TRUNC | O_RDWR, 0644);
    if (_ecore_fps_debug_fd < 0)
      {
-        unlink(buf);
+        eina_file_unlink(buf);
         _ecore_fps_debug_fd = open(buf, O_CREAT | O_BINARY | O_TRUNC | O_RDWR, 0644);
      }
    if (_ecore_fps_debug_fd >= 0)
@@ -922,7 +922,7 @@ _ecore_fps_debug_shutdown(void)
         pid = (int)getpid();
         snprintf(buf, sizeof(buf), "%s/.ecore_fps_debug-%i",
                  eina_environment_tmp_get(), pid);
-        unlink(buf);
+        eina_file_unlink(buf);
         if (_ecore_fps_runtime_mmap)
           {
              munmap(_ecore_fps_runtime_mmap, sizeof(unsigned int));

--- a/src/lib/ecore_con/efl_net_server_unix.c
+++ b/src/lib/ecore_con/efl_net_server_unix.c
@@ -94,7 +94,7 @@ _efl_net_server_unix_bind_hang_lock_workaround(const char *address, Eina_Bool lo
    else
      {
         flock(lockfile_fd, LOCK_UN | LOCK_NB);
-        unlink(lockfile);
+        eina_file_unlink(lockfile);
         close(lockfile_fd);
         lockfile_fd = -1;
      }
@@ -113,7 +113,7 @@ _efl_net_server_unix_efl_object_destructor(Eo *o, Efl_Net_Server_Unix_Data *pd E
      {
         if ((address) &&
             (strncmp(address, "abstract:", strlen("abstract:")) != 0))
-          unlink(address);
+          eina_file_unlink(address);
      }
 #ifdef BIND_HANG_WORKAROUND
    if ((address) && (pd->have_lock_fd) && (pd->lock_fd >= 0))
@@ -182,7 +182,7 @@ _efl_net_server_unix_bind(Eo *o, Efl_Net_Server_Unix_Data *pd)
         if ((pd->unlink_before_bind) && (addr.sun_path[0] != '\0'))
           {
              DBG("unlinking AF_UNIX path '%s'", addr.sun_path);
-             unlink(addr.sun_path);
+             eina_file_unlink(addr.sun_path);
           }
 
 #ifdef BIND_HANG_WORKAROUND
@@ -196,7 +196,7 @@ _efl_net_server_unix_bind(Eo *o, Efl_Net_Server_Unix_Data *pd)
                   goto error;
                }
              pd->have_lock_fd = EINA_TRUE;
-             unlink(addr.sun_path);
+             eina_file_unlink(addr.sun_path);
           }
 #endif
         r = bind(fd, (struct sockaddr *)&addr, addrlen);
@@ -215,7 +215,7 @@ _efl_net_server_unix_bind(Eo *o, Efl_Net_Server_Unix_Data *pd)
                {
                   DBG("bind(" SOCKET_FMT ", %s): failed with EADDRINUSE but connect also failed, so unlink socket file and try again", fd, address);
                   closesocket(fd);
-                  unlink(addr.sun_path);
+                  eina_file_unlink(addr.sun_path);
                   fd = INVALID_SOCKET;
                   err = 0;
                   continue;

--- a/src/lib/ecore_evas/ecore_evas.c
+++ b/src/lib/ecore_evas/ecore_evas.c
@@ -2990,7 +2990,7 @@ _ecore_evas_fps_debug_init(void)
    _ecore_evas_fps_debug_fd = open(buf, O_CREAT | O_BINARY | O_TRUNC | O_RDWR, 0644);
    if (_ecore_evas_fps_debug_fd < 0)
      {
-        unlink(buf);
+        eina_file_unlink(buf);
         _ecore_evas_fps_debug_fd = open(buf, O_CREAT | O_BINARY | O_TRUNC | O_RDWR, 0644);
      }
    if (_ecore_evas_fps_debug_fd >= 0)
@@ -3038,7 +3038,7 @@ _ecore_evas_fps_debug_shutdown(void)
 
         snprintf(buf, sizeof(buf), "%s/.ecore_evas_fps_debug-%i",
                  eina_environment_tmp_get(), (int)getpid());
-        unlink(buf);
+        eina_file_unlink(buf);
         if (_ecore_evas_fps_rendertime_mmap)
           {
              munmap(_ecore_evas_fps_rendertime_mmap, sizeof(int));

--- a/src/lib/ecore_file/ecore_file.c
+++ b/src/lib/ecore_file/ecore_file.c
@@ -304,8 +304,7 @@ ecore_file_rmdir(const char *dir)
 ECORE_FILE_API Eina_Bool
 ecore_file_unlink(const char *file)
 {
-   if (unlink(file) < 0) return EINA_FALSE;
-   return EINA_TRUE;
+   return eina_file_unlink(file);
 }
 
 ECORE_FILE_API Eina_Bool

--- a/src/lib/ecore_win32/ecore_win32_monitor.c
+++ b/src/lib/ecore_win32/ecore_win32_monitor.c
@@ -195,6 +195,8 @@ ecore_win32_monitor_update(int d)
           ewm->delete_me = EINA_TRUE;
      }
 
+   if (d == 0) d++; // TESTING !!!
+
    EnumDisplayMonitors(NULL, NULL, _ecore_win32_monitor_update_cb, d);
 
    if (d == 2)

--- a/src/lib/edje/edje_edit.c
+++ b/src/lib/edje/edje_edit.c
@@ -12488,7 +12488,7 @@ _edje_edit_embryo_rebuild(Edje_Edit *eed)
    if (!f)
      {
         close(fd);
-        unlink(tmp_in);
+        eina_file_unlink(tmp_in);
         return EINA_FALSE;
      }
 
@@ -12619,11 +12619,11 @@ the_way_out:
 the_doorway:
    if (tmp_out)
      {
-        unlink(tmp_out);
+        eina_file_unlink(tmp_out);
         eina_tmpstr_del(tmp_out);
      }
 almost_out:
-   unlink(tmp_in);
+   eina_file_unlink(tmp_in);
    eina_tmpstr_del(tmp_in);
 
    return success;

--- a/src/lib/eio/eio_dir.c
+++ b/src/lib/eio/eio_dir.c
@@ -607,7 +607,7 @@ _eio_dir_move_heavy(void *data, Ecore_Thread *thread)
                }
 
              /* and unlink the original */
-             if (unlink(file) != 0)
+             if (eina_file_unlink(file) != EINA_TRUE)
                {
                   eio_file_thread_error(&move->progress.common, thread);
                   goto on_error;
@@ -678,7 +678,7 @@ _eio_dir_rmrf_heavy(void *data, Ecore_Thread *thread)
 
    EINA_LIST_FREE(rmrf->files, file)
      {
-        if (unlink(file) != 0)
+        if (eina_file_unlink(file) != EINA_TRUE)
           {
              eio_file_thread_error(&rmrf->progress.common, thread);
              goto on_error;

--- a/src/lib/eio/eio_single.c
+++ b/src/lib/eio/eio_single.c
@@ -75,7 +75,7 @@ _eio_file_unlink(void *data, Ecore_Thread *thread)
 {
    Eio_File_Unlink *l = data;
 
-   if (unlink(l->path) != 0)
+   if (eina_file_unlink(l->path) != EINA_TRUE)
      eio_file_thread_error(&l->common, thread);
 }
 

--- a/src/modules/ecore_buffer/shm/ecore_buffer_shm.c
+++ b/src/modules/ecore_buffer/shm/ecore_buffer_shm.c
@@ -34,7 +34,7 @@ _ecore_buffer_shm_buffer_free(Ecore_Buffer_Module_Data bmdata EINA_UNUSED, Ecore
    Ecore_Buffer_Shm_Data* b = bdata;
 
    if (b->am_owner)
-     if (b->file) unlink(b->file);
+     if (b->file) eina_file_unlink(b->file);
 
    if (b->addr != MAP_FAILED) munmap(b->addr, b->size);
    eina_stringshare_del(b->file);

--- a/src/modules/ecore_evas/engines/extn/ecore_evas_extn_buf.c
+++ b/src/modules/ecore_evas/engines/extn/ecore_evas_extn_buf.c
@@ -84,7 +84,7 @@ _extnbuf_free(Extnbuf *b)
    if (b->am_owner)
      {
         if (b->file) shm_unlink(b->file);
-        if (b->lock) unlink(b->lock);
+        if (b->lock) eina_file_unlink(b->lock);
      }
    
    if (b->addr != MAP_FAILED) munmap(b->addr, b->size);

--- a/src/modules/elementary/access_output/mod.c
+++ b/src/modules/elementary/access_output/mod.c
@@ -27,7 +27,7 @@ _exe_del(void *data EINA_UNUSED, int type EINA_UNUSED, void *event)
      {
         if (tmpf)
           {
-             unlink(tmpf);
+             eina_file_unlink(tmpf);
              free(tmpf);
              tmpf = NULL;
              close(tmpfd);
@@ -112,7 +112,7 @@ out_cancel(void)
      }
    if (tmpf)
      {
-        unlink(tmpf);
+        eina_file_unlink(tmpf);
         free(tmpf);
         tmpf = NULL;
         close(tmpfd);

--- a/src/modules/evas/engines/gl_common/evas_gl_core.c
+++ b/src/modules/evas/engines/gl_common/evas_gl_core.c
@@ -884,7 +884,7 @@ error:
    if (tmpfd >= 0) close(tmpfd);
    if (et) eet_close(et);
    if (evas_gl_common_file_cache_file_exists(tmp_file_path))
-     unlink(tmp_file_path);
+     eina_file_unlink(tmp_file_path);
    eina_tmpstr_del(tmp_file_path);
    eet_shutdown();
    return 0;

--- a/src/modules/evas/engines/gl_common/evas_gl_shader.c
+++ b/src/modules/evas/engines/gl_common/evas_gl_shader.c
@@ -420,7 +420,7 @@ save:
    if (tmpfd >= 0) close(tmpfd);
    if (ef) eet_close(ef);
    if (evas_gl_common_file_cache_file_exists(tmp_file_path))
-     unlink(tmp_file_path);
+     eina_file_unlink(tmp_file_path);
    eina_tmpstr_del(tmp_file_path);
    eet_shutdown();
    return 0;

--- a/src/modules/evas/image_loaders/generic/evas_image_load_generic.c
+++ b/src/modules/evas/image_loaders/generic/evas_image_load_generic.c
@@ -361,7 +361,7 @@ getdata:
                   if (tmpfname)
                     {
                        close(fd);
-                       unlink(tmpfname);
+                       eina_file_unlink(tmpfname);
                     }
 #ifdef HAVE_SHM_OPEN
                   else if (shmfname)

--- a/src/tests/ecore_con/ecore_con_test_ecore_con_url.c
+++ b/src/tests/ecore_con/ecore_con_test_ecore_con_url.c
@@ -26,7 +26,7 @@ typedef struct _url_test
 static void
 _free_url_test(url_test *info)
 {
-   unlink(info->_test_file);
+   eina_file_unlink(info->_test_file);
    eina_tmpstr_del(info->_test_file);
    close(info->_tmpfd);
    free(info);
@@ -371,7 +371,7 @@ static void
 _ecore_con_url_cookies_test_shutdown(Ecore_Con_Url *ec_url, int tmpfd, Eina_Tmpstr **path)
 {
    close(tmpfd);
-   unlink(*path);
+   eina_file_unlink(*path);
    eina_tmpstr_del(*path);
    ecore_con_url_free(ec_url);
    ecore_con_url_shutdown();

--- a/src/tests/efreet/ef_desktop.c
+++ b/src/tests/efreet/ef_desktop.c
@@ -179,14 +179,14 @@ ef_cb_desktop_save(void)
         desktop = efreet_desktop_get("/tmp/test.desktop");
         if (!desktop)
           {
-             unlink("/tmp/test.desktop");
+             eina_file_unlink("/tmp/test.desktop");
              printf("Failed to get Desktop file\n");
              return 0;
           }
 
         printf("save data: %d\n", efreet_desktop_save(desktop));
         efreet_desktop_free(desktop);
-        unlink("/tmp/test.desktop");
+        eina_file_unlink("/tmp/test.desktop");
      }
 
    desktop = efreet_desktop_empty_new("/tmp/test.desktop");
@@ -200,7 +200,7 @@ ef_cb_desktop_save(void)
    desktop->categories = eina_list_append(desktop->categories,
                                           eina_stringshare_add("Enlightenment"));
    printf("save test: %d\n", efreet_desktop_save(desktop));
-   unlink("/tmp/test.desktop");
+   eina_file_unlink("/tmp/test.desktop");
    efreet_desktop_free(desktop);
 
    return 1;

--- a/src/tests/efreet/ef_menu.c
+++ b/src/tests/efreet/ef_menu.c
@@ -83,7 +83,7 @@ ef_cb_menu_save(void)
         printf("efreet_menu_get() returned NULL\n");
         return 0;
      }
-   unlink("/tmp/test.menu");
+   eina_file_unlink("/tmp/test.menu");
    ret = efreet_menu_save(menu, "/tmp/test.menu");
    efreet_menu_free(menu);
    return ret;

--- a/src/tests/eina/eina_test_file.c
+++ b/src/tests/eina/eina_test_file.c
@@ -425,8 +425,8 @@ EFL_START_TEST(eina_file_map_new_test)
    eina_file_close(e_file);
    eina_file_close(e_file2);
 
-   unlink(test_file_path);
-   unlink(test_file2_path);
+   eina_file_unlink(test_file_path);
+   eina_file_unlink(test_file2_path);
    rmdir(test_dirname);
 
    free(test_file_path);
@@ -616,7 +616,7 @@ EFL_START_TEST(eina_test_file_xattr)
    fail_if(count != sizeof (data) / sizeof (data[0]));
    eina_iterator_free(it);
 
-   unlink(test_file_path);
+   eina_file_unlink(test_file_path);
    eina_tmpstr_del(test_file_path);
    eina_file_close(ef);
 }
@@ -678,8 +678,8 @@ EFL_START_TEST(eina_test_file_copy)
    eina_file_map_free(e_file2, content2);
    eina_file_close(e_file1);
    eina_file_close(e_file2);
-   unlink(test_file1_path);
-   unlink(test_file2_path);
+   eina_file_unlink(test_file1_path);
+   eina_file_unlink(test_file2_path);
    eina_tmpstr_del(test_file1_path);
    eina_tmpstr_del(test_file2_path);
 
@@ -722,8 +722,8 @@ EFL_START_TEST(eina_test_file_statat)
         fail_if(st.size != (unsigned int)template_size);
      }
 
-   unlink(test_file1_path);
-   unlink(test_file2_path);
+   eina_file_unlink(test_file1_path);
+   eina_file_unlink(test_file2_path);
    fail_if(rmdir(test_dirname) != 0);
    eina_tmpstr_del(test_file1_path);
    eina_tmpstr_del(test_file2_path);
@@ -766,11 +766,11 @@ EFL_START_TEST(eina_test_file_mktemp)
 #ifdef F_GETPATH
    /* most likely Mac OS */
    if (fcntl(fd, F_GETPATH, buf) != -1)
-     unlink(buf);
+     eina_file_unlink(buf);
 #elif !defined _WIN32
    sprintf(fmt, "/proc/self/fd/%d", fd);
    if (readlink(fmt, buf, sizeof(buf)))
-     unlink(buf);
+     eina_file_unlink(buf);
 #else
    {
       char buf[4096];
@@ -782,7 +782,7 @@ EFL_START_TEST(eina_test_file_mktemp)
       l = GetFinalPathNameByHandle(h, buf, sizeof(buf), 0);
       fail_if(l == 0);
       /* GetFinalPathNameByHandle() preprends path with \\?\ */
-      unlink(buf + 4);
+      eina_file_unlink(buf + 4);
    }
 #endif
    close(fd);
@@ -797,7 +797,7 @@ EFL_START_TEST(eina_test_file_mktemp)
         file = eina_file_open(tmpfile, EINA_FALSE);
         fail_if(!file);
         eina_file_close(file);
-        unlink(tmpfile);
+        eina_file_unlink(tmpfile);
         eina_tmpstr_del(tmpfile);
         close(fd);
      }
@@ -830,7 +830,7 @@ EFL_START_TEST(eina_test_file_mktemp)
 
    eina_iterator_free(it);
 
-   unlink(tmpfile);
+   eina_file_unlink(tmpfile);
    remove(tmpdir);
 }
 EFL_END_TEST

--- a/src/tests/eina/eina_test_xattr.c
+++ b/src/tests/eina/eina_test_xattr.c
@@ -91,7 +91,7 @@ EFL_START_TEST(eina_test_xattr_set)
    fail_if(ret != EINA_TRUE);
 
    close(fd);
-   unlink(test_file_path);
+   eina_file_unlink(test_file_path);
    eina_tmpstr_del(test_file_path);
 
 }
@@ -238,8 +238,8 @@ EFL_START_TEST(eina_test_xattr_list)
 
    close(fd);
    close(fd1);
-   unlink(test_file_path);
-   unlink(cp_file_path);
+   eina_file_unlink(test_file_path);
+   eina_file_unlink(cp_file_path);
    eina_tmpstr_del(test_file_path);
    eina_tmpstr_del(cp_file_path);
 }
@@ -283,7 +283,7 @@ EFL_START_TEST(eina_test_xattr_types)
    fail_if(!EINA_DBL_EQ(double_data, double_ret));
 
    close(fd);
-   unlink(test_file_path);
+   eina_file_unlink(test_file_path);
    eina_tmpstr_del(test_file_path);
 
 }

--- a/src/tests/eio/eio_test_eet.c
+++ b/src/tests/eio/eio_test_eet.c
@@ -107,7 +107,7 @@ EFL_START_TEST(eio_test_eet_cipher_decipher)
    ecore_main_loop_begin();
    fail_if(!ef);
 
-   unlink(file);
+   eina_file_unlink(file);
    eina_tmpstr_del(file);
    eet_shutdown();
 }
@@ -201,7 +201,7 @@ EFL_START_TEST(eio_test_eet_data_cipher_decipher)
    ecore_main_loop_begin();
    fail_if(!ef);
 
-   unlink(file);
+   eina_file_unlink(file);
    eina_tmpstr_del(file);
    eet_shutdown();
 }

--- a/src/tests/eio/eio_test_manager_xattr.c
+++ b/src/tests/eio/eio_test_manager_xattr.c
@@ -188,7 +188,7 @@ EFL_START_TEST(eio_test_job_xattr_set)
 
    efl_unref(job);
    close(fd);
-   unlink(test_file_path);
+   eina_file_unlink(test_file_path);
    eina_tmpstr_del(test_file_path);
 }
 EFL_END_TEST

--- a/src/tests/eio/eio_test_map.c
+++ b/src/tests/eio/eio_test_map.c
@@ -87,7 +87,7 @@ EFL_START_TEST(eio_test_map_simple)
    ecore_main_loop_begin();
    fail_if(!ef);
 
-   unlink(file_path);
+   eina_file_unlink(file_path);
    eina_tmpstr_del(file_path);
 }
 EFL_END_TEST

--- a/src/tests/eio/eio_test_xattr.c
+++ b/src/tests/eio/eio_test_xattr.c
@@ -179,7 +179,7 @@ EFL_START_TEST(eio_test_xattr_set)
    ecore_main_loop_begin();
 
    close(fd);
-   unlink(test_file_path);
+   eina_file_unlink(test_file_path);
    eina_tmpstr_del(test_file_path);
 }
 EFL_END_TEST
@@ -243,7 +243,7 @@ EFL_START_TEST(eio_test_xattr_types_set)
    ecore_main_loop_begin();
 
    close(fd);
-   unlink(test_file_path);
+   eina_file_unlink(test_file_path);
    eina_tmpstr_del(test_file_path);
 }
 EFL_END_TEST

--- a/src/tests/evas/evas_test_image.c
+++ b/src/tests/evas/evas_test_image.c
@@ -925,7 +925,7 @@ EFL_START_TEST(evas_object_image_map_unmap)
         h2 = sz.h;
 
         // unlink now to not leave any crap after failing the test
-        unlink(tmp);
+        eina_file_unlink(tmp);
 
         fail_if(w2 != w);
         fail_if(h2 != h);
@@ -975,7 +975,7 @@ EFL_START_TEST(evas_object_image_map_unmap)
         efl_gfx_buffer_unmap(o, sorig);
         efl_gfx_buffer_unmap(o2, sdest);
      }
-   else unlink(tmp);
+   else eina_file_unlink(tmp);
    eina_tmpstr_del(tmp);
 
    // TODO: test copy-on-write


### PR DESCRIPTION
The `unlink()` function is being used all over the place where `eina_file_unlink()` would possibly fit better.

Note that here I first used a macro to perform the work, so I am still analyzing if it makes sense. For example in `src/bin/edje` there are several uses of `unlink()` that cannot be directly changed to `eina_file_unlink()` or it won't compile, so I didn't add to this batch.