### PR TITLE
 elm: Fix path search for app_data

### DIFF
--- a/src/lib/ecore_evas/ecore_evas_module.c
+++ b/src/lib/ecore_evas/ecore_evas_module.c
@@ -165,7 +165,7 @@ _ecore_evas_engine_init(void)
 
    /* 1. libecore_evas.so/../ecore_evas/engines/ */
    paths[0] = eina_module_symbol_path_get(_ecore_evas_engine_init, "/ecore_evas/engines");
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(_MSC_VER)
    /* 3. PREFIX/ecore_evas/engines/ */
    paths[1] = strdup(PACKAGE_LIB_DIR "/ecore_evas/engines");
 #else

--- a/src/lib/elementary/elm_main.c
+++ b/src/lib/elementary/elm_main.c
@@ -186,11 +186,12 @@ _prefix_check(void)
    dirs[2] = app_compile_data_dir;
    dirs[3] = app_compile_locale_dir;
 
-   if (!dirs[0]) dirs[0] = "/usr/local/bin";
-   if (!dirs[1]) dirs[1] = "/usr/local/lib";
+   if (!dirs[0]) dirs[0] = PACKAGE_BIN_DIR;
+   if (!dirs[1]) dirs[1] = PACKAGE_LIB_DIR;
    if (!dirs[2])
      {
-        snprintf(buf, sizeof(buf), "/usr/local/share/%s", app_domain);
+        // LOCALE_DIR is set to <prefix>/share/local but we want <prefix>/share
+        snprintf(buf, sizeof(buf), "%s/../%s", LOCALE_DIR, app_domain);
         dirs[2] = buf;
      }
    if (!dirs[3]) dirs[3] = dirs[2];


### PR DESCRIPTION
`elm` was using `/usr/local/[bin, lib, share]` which don't exist on
native-windows, this change it to paths set at `build\config.h`:
- `/usr/local/bin` -> `PACKAGE_BIN_DIR` == `<prefix>/bin`;
- `/usr/local/lib` -> `PACKAGE_LIB_DIR` == `<prefix>/lib`;
- `/usr/local/share` -> `LOCALE_DIR/..` == `<prefix>/share/local/..`;

Note that `<prefix>/share/local/` doesn't exist.

Depends on #415 

Test plan
=========
With this, `example/elementary/bg_example_02.c` should show a image, without
this, the image should not be found.