### PR TITLE
 elm: Change module names

### DIFF
--- a/src/modules/elementary/access_output/meson.build
+++ b/src/modules/elementary/access_output/meson.build
@@ -2,7 +2,7 @@ src = files([
   'mod.c',
 ])
 
-shared_module(mod,
+shared_module(mod_name,
     src,
     c_args : package_c_args,
     dependencies: [elementary],

--- a/src/modules/elementary/meson.build
+++ b/src/modules/elementary/meson.build
@@ -7,7 +7,12 @@ mods = [
 ]
 
 foreach mod : mods
+  if sys_native_windows
+    mod_name = 'module'
+  else
+    mod_name = mod
+  endif
   mod_install_dir = join_paths(dir_lib, 'elementary', 'modules', mod, version_name)
   subdir(mod)
-  module_files += join_paths(mod_install_dir, 'lib'+mod+'.'+sys_mod_extension)
+  module_files += join_paths(mod_install_dir, 'lib' + mod_name + '.' + sys_mod_extension)
 endforeach

--- a/src/modules/elementary/prefs/meson.build
+++ b/src/modules/elementary/prefs/meson.build
@@ -16,7 +16,7 @@ src = files([
   'elm_horizontal_frame.c'
 ])
 
-shared_module(mod,
+shared_module(mod_name,
     src,
     c_args : package_c_args,
     dependencies: [elementary],

--- a/src/modules/elementary/test_entry/meson.build
+++ b/src/modules/elementary/test_entry/meson.build
@@ -2,7 +2,7 @@ src = files([
   'mod.c',
 ])
 
-shared_module(mod,
+shared_module(mod_name,
     src,
     c_args : package_c_args,
     dependencies: [elementary],

--- a/src/modules/elementary/test_map/meson.build
+++ b/src/modules/elementary/test_map/meson.build
@@ -2,7 +2,7 @@ src = files([
   'mod.c',
 ])
 
-shared_module(mod,
+shared_module(mod_name,
     src,
     c_args : package_c_args,
     dependencies: [elementary],

--- a/src/modules/elementary/web/none/meson.build
+++ b/src/modules/elementary/web/none/meson.build
@@ -2,7 +2,13 @@ src = files([
   'elm_web_none.c'
 ])
 
-shared_module('none',
+if sys_native_windows
+  mod_name = 'module'
+else
+  mod_name = 'none'
+endif
+
+shared_module(mod_name,
     src,
     dependencies: [elementary, elementary_deps],
     install: true,


### PR DESCRIPTION
On Windows, we want to use the final name of modules `module.dll`
instead of its real name like in Linux.

Test Plan
=========
This was tested with `example/elementary/bg_example_0[1,2,3].exe` but it is
expected that with this, there should be no error about failing to load
`prefs_iface` module at elm examples. 