### PR TITLE
Make lua dependency optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -261,7 +261,12 @@ ecore_evas_wayland_engine_include_dir = []
 
 evas_static_list = []
 
-if get_option('lua-interpreter') != 'none'
+have_elua = get_option('elua')
+if get_option('lua-interpreter') == 'none'
+  lua_pc_name = []
+  lua = declare_dependency()
+else
+  config_h.set('HAVE_LUA', 1)
   luaold_interpreters = [
     ['lua',     ['>=5.1.0', '<5.3.0']],
     ['lua51',   ['>=5.1.0', '<5.2.0']],
@@ -273,7 +278,6 @@ if get_option('lua-interpreter') != 'none'
   ]
 
   lua_pc_name = ''
-  have_elua = get_option('elua')
 
   if get_option('lua-interpreter') == 'lua'
     config_h.set('ENABLE_LUA_OLD', '1')
@@ -304,8 +308,6 @@ if get_option('lua-interpreter') != 'none'
       link_args: ['-L' + lua.get_pkgconfig_variable('libdir'), '-l' + lua.get_pkgconfig_variable('libname')]
     )
   endif
-else
-  lua_pc_name = []
 endif
 
 subprojects = [

--- a/meson.build
+++ b/meson.build
@@ -261,47 +261,51 @@ ecore_evas_wayland_engine_include_dir = []
 
 evas_static_list = []
 
-luaold_interpreters = [
-  ['lua',     ['>=5.1.0', '<5.3.0']],
-  ['lua51',   ['>=5.1.0', '<5.2.0']],
-  ['lua-5.1', ['>=5.1.0', '<5.2.0']],
-  ['lua5.1',  ['>=5.1.0', '<5.2.0']],
-  ['lua52',   ['>=5.2.0', '<5.3.0']],
-  ['lua-5.2', ['>=5.2.0', '<5.3.0']],
-  ['lua5.2',  ['>=5.2.0', '<5.3.0']],
-]
+if get_option('lua-interpreter') != 'none'
+  luaold_interpreters = [
+    ['lua',     ['>=5.1.0', '<5.3.0']],
+    ['lua51',   ['>=5.1.0', '<5.2.0']],
+    ['lua-5.1', ['>=5.1.0', '<5.2.0']],
+    ['lua5.1',  ['>=5.1.0', '<5.2.0']],
+    ['lua52',   ['>=5.2.0', '<5.3.0']],
+    ['lua-5.2', ['>=5.2.0', '<5.3.0']],
+    ['lua5.2',  ['>=5.2.0', '<5.3.0']],
+  ]
 
-lua_pc_name = ''
-have_elua = get_option('elua')
+  lua_pc_name = ''
+  have_elua = get_option('elua')
 
-if get_option('lua-interpreter') == 'lua'
-  config_h.set('ENABLE_LUA_OLD', '1')
-  foreach l : luaold_interpreters
-    lua = dependency(l[0], version: l[1], required:false)
-    lua_pc_name = l[0]
-    if lua.found()
-      break
+  if get_option('lua-interpreter') == 'lua'
+    config_h.set('ENABLE_LUA_OLD', '1')
+    foreach l : luaold_interpreters
+      lua = dependency(l[0], version: l[1], required:false)
+      lua_pc_name = l[0]
+      if lua.found()
+        break
+      endif
+    endforeach
+    if not lua.found()
+      error('Lua not found')
     endif
-  endforeach
-  if not lua.found()
-    error('Lua not found')
+    if have_elua
+      message('Using experimental Elua with interpreter support...')
+    endif
+  else
+    lua = dependency(get_option('lua-interpreter'))
+    lua_pc_name = 'luajit'
   endif
-  if have_elua
-    message('Using experimental Elua with interpreter support...')
+
+  if sys_osx and get_option('lua-interpreter') == 'luajit'
+    # luajit on macro is broken, this means we need to generate our own
+    # dependency with our arguments, a library later still needs to link to
+    # luajit for the pagesize argument thingy
+    lua = declare_dependency(
+      include_directories: include_directories(lua.get_pkgconfig_variable('includedir')),
+      link_args: ['-L' + lua.get_pkgconfig_variable('libdir'), '-l' + lua.get_pkgconfig_variable('libname')]
+    )
   endif
 else
-  lua = dependency(get_option('lua-interpreter'))
-  lua_pc_name = 'luajit'
-endif
-
-if sys_osx and get_option('lua-interpreter') == 'luajit'
-  # luajit on macro is broken, this means we need to generate our own
-  # dependency with our arguments, a library later still needs to link to
-  # luajit for the pagesize argument thingy
-  lua = declare_dependency(
-    include_directories: include_directories(lua.get_pkgconfig_variable('includedir')),
-    link_args: ['-L' + lua.get_pkgconfig_variable('libdir'), '-l' + lua.get_pkgconfig_variable('libname')]
-  )
+  lua_pc_name = []
 endif
 
 subprojects = [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -323,7 +323,7 @@ option('dotnet',
 
 option('lua-interpreter',
   type: 'combo',
-  choices: ['luajit', 'lua'],
+  choices: ['luajit', 'lua', 'none'],
   value: 'luajit',
   description: 'Which Lua back-end library to use in efl'
 )

--- a/src/bin/edje/edje_cc_handlers.c
+++ b/src/bin/edje/edje_cc_handlers.c
@@ -265,7 +265,9 @@ static void       st_collections_group_inherit(void);
 static void       st_collections_group_program_source(void);
 static void       st_collections_group_part_remove(void);
 static void       st_collections_group_program_remove(void);
+#ifdef HAVE_LUA
 static void       st_collections_group_lua_script_only(void);
+#endif
 static void       st_collections_group_script_recursion(void);
 static void       st_collections_group_alias(void);
 static void       st_collections_group_min(void);
@@ -281,7 +283,9 @@ static void       st_collections_group_limits_vertical(void);
 static void       st_collections_group_limits_horizontal(void);
 
 static void       ob_collections_group_script(void);
+#ifdef HAVE_LUA
 static void       ob_collections_group_lua_script(void);
+#endif
 
 static void       st_collections_group_parts_alias(void);
 
@@ -674,7 +678,9 @@ New_Statement_Handler statement_handlers[] =
    {"collections.group.target_group", st_collections_group_target_group},   /* dup */
    {"collections.group.part_remove", st_collections_group_part_remove},
    {"collections.group.program_remove", st_collections_group_program_remove},
+#ifdef HAVE_LUA
    {"collections.group.lua_script_only", st_collections_group_lua_script_only},
+#endif
    {"collections.group.script_recursion", st_collections_group_script_recursion},
    {"collections.group.alias", st_collections_group_alias},
    {"collections.group.min", st_collections_group_min},
@@ -1371,7 +1377,9 @@ New_Object_Handler object_handlers[] =
    {"collections.group.data", NULL},
    {"collections.group.limits", NULL},
    {"collections.group.script", ob_collections_group_script},
+#ifdef HAVE_LUA
    {"collections.group.lua_script", ob_collections_group_lua_script},
+#endif
    {"collections.group.externals", NULL},   /* dup */
    {"collections.group.set", ob_images_set},   /* dup */
    {"collections.group.set.image", ob_images_set_image},   /* dup */
@@ -4851,7 +4859,9 @@ st_collections_group_inherit(void)
    pc->prop.min.h = pc2->prop.min.h;
    pc->prop.orientation = pc2->prop.orientation;
 
+#ifdef HAVE_LUA
    pc->lua_script_only = pc2->lua_script_only;
+#endif
    pc->use_custom_seat_names = pc2->use_custom_seat_names;
 
    pcp = (Edje_Part_Collection_Parser *)pc;
@@ -5034,6 +5044,7 @@ st_collections_group_inherit(void)
         Defaults: off
     @endproperty
  */
+#ifdef HAVE_LUA
 static void
 st_collections_group_lua_script_only(void)
 {
@@ -5044,6 +5055,7 @@ st_collections_group_lua_script_only(void)
    pc = eina_list_data_get(eina_list_last(edje_collections));
    pc->lua_script_only = parse_bool(0);
 }
+#endif
 
 /**
     @page edcref

--- a/src/bin/edje/edje_cc_out.c
+++ b/src/bin/edje/edje_cc_out.c
@@ -23,8 +23,10 @@
 #include "edje_convert.h"
 #include "edje_multisense_convert.h"
 
+#ifdef HAVE_LUA
 #include <lua.h>
 #include <lauxlib.h>
+#endif
 
 typedef struct _External_Lookup External_Lookup;
 typedef struct _Part_Lookup     Part_Lookup;
@@ -105,6 +107,7 @@ struct _Code_Lookup
    Eina_Bool set;
 };
 
+#ifdef HAVE_LUA
 typedef struct _Script_Lua_Writer Script_Lua_Writer;
 
 struct _Script_Lua_Writer
@@ -112,6 +115,7 @@ struct _Script_Lua_Writer
    char *buf;
    int   size;
 };
+#endif
 
 typedef struct _Script_Write    Script_Write;
 typedef struct _Head_Write      Head_Write;
@@ -2403,6 +2407,7 @@ data_write_scripts(Eet_File *ef)
      }
 }
 
+#ifdef HAVE_LUA
 #ifdef LUA_BINARY
 static int
 _edje_lua_script_writer(lua_State *L EINA_UNUSED, const void *chunk_buf, size_t chunk_size, void *_data)
@@ -2602,6 +2607,7 @@ data_write_lua_scripts(Eet_File *ef)
           }
      }
 }
+#endif
 
 static void
 data_thread_source(void *data, Ecore_Thread *thread EINA_UNUSED)
@@ -2836,8 +2842,10 @@ data_write(void)
    INF("groups: %3.5f", ecore_time_get() - t); t = ecore_time_get();
    data_write_scripts(ef);
    INF("scripts: %3.5f", ecore_time_get() - t); t = ecore_time_get();
+#ifdef HAVE_LUA
    data_write_lua_scripts(ef);
    INF("lua scripts: %3.5f", ecore_time_get() - t); t = ecore_time_get();
+#endif
 
    if (!no_save)
      {
@@ -3758,8 +3766,10 @@ data_process_lookups(void)
         unsigned int count = 0;
         unsigned int i;
 
+#ifdef HAVE_LUA
         if (pc->lua_script_only)
           is_lua = EINA_TRUE;
+#endif
 #define PROGRAM_ID_SET(Type, Pc, It, Count)            \
   for (It = 0; It < Pc->programs.Type ## _count; ++It) \
     {                                                  \

--- a/src/examples/edje/meson.build
+++ b/src/examples/edje/meson.build
@@ -28,7 +28,6 @@ edc_files = [
   'external_elm_panes.edc',
   'external_emotion_elm.edc',
   'focus.edc',
-  'lua_script.edc',
   'messages_echo.edc',
   'multiseat.edc',
   'multiseat_custom_names.edc',
@@ -36,7 +35,6 @@ edc_files = [
   'perspective.edc',
   'signals-messages.edc',
   'signalsBubble.edc',
-  'sigtest.edc',
   'svg.edc',
   'swallow.edc',
   'table.edc',
@@ -46,6 +44,13 @@ edc_files = [
   'multisense.edc',
   'center_zoom.edc',
 ]
+
+if get_option('lua-interpreter') != 'none'
+  edc_files += [
+    'lua_script.edc',
+    'sigtest.edc',
+  ]
+endif
 
 if (get_option('physics'))
   edc_files += [

--- a/src/lib/edje/edje_cache.c
+++ b/src/lib/edje/edje_cache.c
@@ -329,6 +329,7 @@ _edje_file_coll_open(Edje_File *edf, const char *coll)
         free(data);
      }
 
+#ifdef HAVE_LUA
    snprintf(buf, sizeof(buf), "edje/scripts/lua/%i", id);
    data = eet_read(edf->ef, buf, &size);
 
@@ -337,6 +338,7 @@ _edje_file_coll_open(Edje_File *edf, const char *coll)
         _edje_lua2_script_load(edc, data, size);
         free(data);
      }
+#endif
 
    ce->ref = edc;
 

--- a/src/lib/edje/edje_data.c
+++ b/src/lib/edje/edje_data.c
@@ -1302,7 +1302,9 @@ _edje_edd_init(void)
    EET_DATA_DESCRIPTOR_ADD_BASIC(_edje_edd_edje_part_collection, Edje_Part_Collection, "prop.max.w", prop.max.w, EET_T_INT);
    EET_DATA_DESCRIPTOR_ADD_BASIC(_edje_edd_edje_part_collection, Edje_Part_Collection, "prop.max.h", prop.max.h, EET_T_INT);
    EET_DATA_DESCRIPTOR_ADD_BASIC(_edje_edd_edje_part_collection, Edje_Part_Collection, "part", part, EET_T_STRING);
+#ifdef HAVE_LUA
    EET_DATA_DESCRIPTOR_ADD_BASIC(_edje_edd_edje_part_collection, Edje_Part_Collection, "lua_script_only", lua_script_only, EET_T_UCHAR);
+#endif
    EET_DATA_DESCRIPTOR_ADD_BASIC(_edje_edd_edje_part_collection, Edje_Part_Collection, "prop.orientation", prop.orientation, EET_T_INT);
    EET_DATA_DESCRIPTOR_ADD_BASIC(_edje_edd_edje_part_collection, Edje_Part_Collection, "broadcast_signal", broadcast_signal, EET_T_UCHAR);
 #ifdef HAVE_EPHYSICS

--- a/src/lib/edje/edje_load.c
+++ b/src/lib/edje/edje_load.c
@@ -793,7 +793,9 @@ _edje_object_file_set_internal(Evas_Object *obj, const Eina_File *file, const ch
    if (collect)
      part_match = eina_hash_string_superfast_new(NULL);
 
+#ifdef HAVE_LUA
    if (_edje_lua_script_only(ed)) _edje_lua_script_only_shutdown(ed);
+#endif
 
 #ifdef HAVE_EPHYSICS
    /* clear physics world  / shutdown ephysics */
@@ -837,12 +839,14 @@ _edje_object_file_set_internal(Evas_Object *obj, const Eina_File *file, const ch
 
         ed->groups = eina_list_append(ed->groups, ed);
 
+#ifdef HAVE_LUA
         if (ed->collection->lua_script_only)
           {
              ed->load_error = EDJE_LOAD_ERROR_NONE;
              _edje_lua_script_only_init(ed);
           }
         else
+#endif
           {
              unsigned int i;
 
@@ -2071,7 +2075,9 @@ _edje_file_del(Edje *ed)
         ed->seats_count = 0;
      }
 
+#ifdef HAVE_LUA
    if (ed->L) _edje_lua2_script_shutdown(ed);
+#endif
    while (ed->subobjs)
      _edje_subobj_unregister(ed, ed->subobjs->data);
    if (ed->table_parts) free(ed->table_parts);
@@ -2370,7 +2376,9 @@ _edje_collection_free(Edje_File *edf, Edje_Part_Collection *ec, Edje_Part_Collec
    ec->patterns.table_programs_size = 0;
 
    if (ec->script) embryo_program_free(ec->script);
+#ifdef HAVE_LUA
    _edje_lua2_script_unload(ec);
+#endif
 
    if (ec->limits.parts) free(ec->limits.parts);
 

--- a/src/lib/edje/edje_message_queue.c
+++ b/src/lib/edje/edje_message_queue.c
@@ -840,11 +840,13 @@ _edje_message_process(Edje_Message *em)
      }
    /* now this message is destined for the script message handler fn */
    if (!(em->edje->collection)) return;
+#ifdef HAVE_LUA
    if (em->edje->L)
      {
         _edje_lua_script_only_message(em->edje, em);
         return;
      }
+#endif
    fn = embryo_program_function_find(em->edje->collection->script, "message");
    if (fn == EMBRYO_FUNCTION_NONE) return;
    /* reset the engine */

--- a/src/lib/edje/edje_private.h
+++ b/src/lib/edje/edje_private.h
@@ -31,9 +31,11 @@
 
 #include <fcntl.h>
 
+#ifdef HAVE_LUA
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
+#endif
 #include <setjmp.h>
 
 // auto_unref
@@ -1146,7 +1148,9 @@ struct _Edje_Part_Collection
    } patterns;
    /* *** *** */
 
+#ifdef HAVE_LUA
    unsigned char    lua_script_only;
+#endif
    unsigned char    broadcast_signal;
    unsigned char    physics_enabled; /* will be 1 if a body is declared */
    unsigned char    script_recursion; /* permits unsafe Embryo->EDC->Embryo scripting */
@@ -1608,12 +1612,16 @@ struct _Edje
    double                duration_scale;
    double                paused_at;
    Eina_Hash            *user_defined;
+#ifdef HAVE_LUA
    lua_State            *L;
    Eina_Inlist          *lua_objs;
+#endif
 
    Eina_Inlist          *messages;
 
+#ifdef HAVE_LUA
    int                   lua_ref;
+#endif
    int                   processing_messages;
    int                   references;
 
@@ -2741,6 +2749,7 @@ void _edje_embryo_globals_init(Edje *ed);
    if ((___cptr = (int *)embryo_data_address_get(ep, (par)))) { \
       *___cptr = (int)val; } }
 
+#ifdef HAVE_LUA
 extern jmp_buf _edje_lua_panic_jmp;
 #define _edje_lua_panic_here() setjmp(_edje_lua_panic_jmp)
 
@@ -2767,6 +2776,7 @@ void _edje_lua_script_only_hide(Edje *ed);
 void _edje_lua_script_only_move(Edje *ed);
 void _edje_lua_script_only_resize(Edje *ed);
 void _edje_lua_script_only_message(Edje *ed, Edje_Message *em);
+#endif
 
 void _edje_entry_init(Edje *ed);
 void _edje_entry_shutdown(Edje *ed);
@@ -2891,6 +2901,7 @@ void edje_object_propagate_callback_add(Evas_Object *obj, void (*func) (void *da
 EAPI void _edje_program_insert(Edje_Part_Collection *ed, Edje_Program *p);
 EAPI void _edje_program_remove(Edje_Part_Collection *ed, Edje_Program *p);
 
+#ifdef HAVE_LUA
 void _edje_lua2_error_full(const char *file, const char *fnc, int line, lua_State *L, int err_code);
 #define _edje_lua2_error(L, err_code) _edje_lua2_error_full(__FILE__, __func__, __LINE__, L, err_code)
 void _edje_lua2_script_init(Edje *ed);
@@ -2905,6 +2916,7 @@ void _edje_lua2_script_func_move(Edje *ed);
 void _edje_lua2_script_func_resize(Edje *ed);
 void _edje_lua2_script_func_message(Edje *ed, Edje_Message *em);
 void _edje_lua2_script_func_signal(Edje *ed, const char *sig, const char *src);
+#endif
 
 const char *edje_string_get(const Edje_String *es);
 const char *edje_string_id_get(const Edje_String *es);

--- a/src/lib/edje/edje_program.c
+++ b/src/lib/edje/edje_program.c
@@ -1538,8 +1538,10 @@ _edje_emit_handle(Edje *ed, const char *sig, const char *src,
    _edje_ref(ed);
    _edje_util_freeze(ed);
 
+#ifdef HAVE_LUA
    if (ed->collection && ed->L)
      _edje_lua2_script_func_signal(ed, sig, src);
+#endif
 
    if (ed->collection)
      {

--- a/src/lib/edje/edje_smart.c
+++ b/src/lib/edje/edje_smart.c
@@ -166,7 +166,9 @@ _efl_canvas_layout_efl_canvas_group_group_del(Eo *obj, Edje *ed)
    _edje_block_violate(ed);
    ed->delete_me = 1;
    _edje_edjes = eina_inlist_remove(_edje_edjes, EINA_INLIST_GET(ed));
+#ifdef HAVE_LUA
    if (_edje_lua_script_only(ed)) _edje_lua_script_only_shutdown(ed);
+#endif
 #ifdef HAVE_EPHYSICS
    /* clear physics world  / shutdown ephysics */
    if ((ed->collection) && (ed->collection->physics_enabled) && (ed->world))
@@ -200,11 +202,13 @@ _efl_canvas_layout_efl_gfx_entity_position_set(Eo *obj, Edje *ed, Eina_Position2
    ed->y = pos.y;
 //   evas_object_move(ed->clipper, ed->x, ed->y);
 
+#ifdef HAVE_LUA
    if (_edje_lua_script_only(ed))
      {
         _edje_lua_script_only_move(ed);
         return;
      }
+#endif
 
    for (i = 0; i < ed->table_parts_size; i++)
      {
@@ -314,11 +318,13 @@ _efl_canvas_layout_efl_gfx_entity_size_set(Eo *obj, Edje *ed, Eina_Size2D sz)
 #ifdef EDJE_CALC_CACHE
    ed->all_part_change = EINA_TRUE;
 #endif
+#ifdef HAVE_LUA
    if (_edje_lua_script_only(ed))
      {
         _edje_lua_script_only_resize(ed);
         goto super;
      }
+#endif
 //   evas_object_resize(ed->clipper, ed->w, ed->h);
    ed->dirty = EINA_TRUE;
    _edje_recalc_do(ed);
@@ -335,11 +341,13 @@ _edje_object_show(Eo *obj, Edje *ed)
    Edje *edg;
 
    efl_gfx_entity_visible_set(efl_super(obj, MY_CLASS), EINA_TRUE);
+#ifdef HAVE_LUA
    if (_edje_lua_script_only(ed))
      {
         _edje_lua_script_only_show(ed);
         return;
      }
+#endif
    if (eina_list_count(ed->groups) > 1)
      {
         EINA_LIST_FOREACH(ed->groups, l, edg)
@@ -362,11 +370,13 @@ _edje_object_hide(Eo *obj, Edje *ed)
    Edje *edg;
 
    efl_gfx_entity_visible_set(efl_super(obj, MY_CLASS), EINA_FALSE);
+#ifdef HAVE_LUA
    if (_edje_lua_script_only(ed))
      {
         _edje_lua_script_only_hide(ed);
         return;
      }
+#endif
    EINA_LIST_FOREACH(ed->groups, l, edg)
      if (edg != ed) evas_object_hide(edg->obj);
    _edje_emit(ed, "hide", NULL);
@@ -406,7 +416,9 @@ EOLIAN static void
 _efl_canvas_layout_efl_file_unload(Eo *obj, Edje *ed)
 {
    efl_file_unload(efl_super(obj, MY_CLASS));
+#ifdef HAVE_LUA
    if (_edje_lua_script_only(ed)) _edje_lua_script_only_shutdown(ed);
+#endif
 #ifdef HAVE_EPHYSICS
    /* clear physics world  / shutdown ephysics */
    if ((ed->collection) && (ed->collection->physics_enabled) && (ed->world))

--- a/src/lib/edje/meson.build
+++ b/src/lib/edje/meson.build
@@ -117,9 +117,6 @@ edje_src = files([
   'edje_entry.c',
   'edje_external.c',
   'edje_load.c',
-  'edje_lua.c',
-  'edje_lua2.c',
-  'edje_lua_script_only.c',
   'edje_main.c',
   'edje_match.c',
   'edje_message_queue.c',
@@ -144,6 +141,14 @@ edje_src = files([
   'edje_part_text.c',
   'edje_part_invalid.c'
 ])
+
+if get_option('lua-interpreter') != 'none'
+  edje_src += files([
+    'edje_lua.c',
+    'edje_lua2.c',
+    'edje_lua_script_only.c',
+  ])
+endif
 
 edje_lib = library('edje',
     edje_src, pub_eo_file_target, priv_eo_file_target,

--- a/src/lib/evas/filters/evas_filter_parser.c
+++ b/src/lib/evas/filters/evas_filter_parser.c
@@ -2,6 +2,7 @@
 
 #include <stdarg.h>
 
+#ifdef HAVE_LUA
 // Lua breaks API all the time
 #ifdef ENABLE_LUA_OLD
 // For 5.2 --> 5.1 compatibility
@@ -13,6 +14,7 @@
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
+#endif
 
 #define FILTERS_LEGACY_COMPAT
 
@@ -242,15 +244,17 @@ static struct
    { "stretch_xy", EVAS_FILTER_FILL_MODE_STRETCH_XY }
 };
 
+#ifdef HAVE_LUA
 static const char *_lua_buffer_meta = "buffer";
 static const char *_lua_color_meta = "color";
 #define _lua_methods_table "__methods"
 #define _lua_register_func "__register"
 #define _lua_errfunc_name "__backtrace"
 
-static Evas_Filter_Fill_Mode _fill_mode_get(Evas_Filter_Instruction *instr);
 static Eina_Bool _lua_instruction_run(lua_State *L, Evas_Filter_Instruction *instr);
 static int _lua_backtrace(lua_State *L);
+#endif
+static Evas_Filter_Fill_Mode _fill_mode_get(Evas_Filter_Instruction *instr);
 
 typedef enum
 {
@@ -293,7 +297,9 @@ struct _Instruction_Param
       Buffer *buf;
       struct {
          void *data;
+#ifdef HAVE_LUA
          Eina_Bool (*func)(lua_State *L, int i, Evas_Filter_Program *, Evas_Filter_Instruction *, Instruction_Param *);
+#endif
       } special;
    } value;
    Eina_Bool set : 1;
@@ -308,7 +314,9 @@ struct _Evas_Filter_Instruction
    int /*Evas_Filter_Mode*/ type;
    Eina_Inlist /* Instruction_Param */ *params;
    int return_count;
+#ifdef HAVE_LUA
    Eina_Bool (* parse_run) (lua_State *L, Evas_Filter_Program *, Evas_Filter_Instruction *);
+#endif
    struct
    {
       int (* update) (Evas_Filter_Program *, Evas_Filter_Instruction *, int *, int *, int *, int *);
@@ -328,8 +336,10 @@ struct _Evas_Filter_Program
    } pad;
    Efl_Canvas_Filter_State state;
    Eina_Inlist *data; // Evas_Filter_Data_Binding
+#ifdef HAVE_LUA
    lua_State *L;
    int       lua_func;
+#endif
    int       last_bufid;
    Eina_Bool valid : 1;
    Eina_Bool padding_calc : 1; // Padding has been calculated
@@ -382,7 +392,9 @@ _instruction_param_addv(Evas_Filter_Instruction *instr, const char *name,
         param->value.c = va_arg(args, DATA32);
         break;
       case VT_SPECIAL:
+#ifdef HAVE_LUA
         param->value.special.func = va_arg(args, typeof(param->value.special.func));
+#endif
         param->value.special.data = va_arg(args, void *);
         break;
       case VT_NONE:
@@ -616,6 +628,7 @@ _buffer_get(Evas_Filter_Program *pgm, const char *name)
    return NULL;
 }
 
+#ifdef HAVE_LUA
 static Eina_Bool
 _lua_buffer_push(lua_State *L, Buffer *buf)
 {
@@ -721,6 +734,7 @@ _lua_implicit_metatable_drop(lua_State *L, const char *name)
      }
    return ret;
 }
+#endif
 
 // End of all lua metamethods and stuff
 
@@ -787,7 +801,9 @@ _buffer_add(Evas_Filter_Program *pgm, const char *name, Eina_Bool alpha,
    buf->h = pgm->state.h;
 
    pgm->buffers = eina_inlist_append(pgm->buffers, EINA_INLIST_GET(buf));
+#ifdef HAVE_LUA
    _lua_buffer_push(pgm->L, buf);
+#endif
 
    return buf;
 }
@@ -803,6 +819,7 @@ _buffer_del(Buffer *buf)
 
 static const int this_is_not_a_cat = 42;
 
+#ifdef HAVE_LUA
 static Evas_Filter_Program *
 _lua_program_get(lua_State *L)
 {
@@ -813,6 +830,7 @@ _lua_program_get(lua_State *L)
    lua_pop(L, 1);
    return pgm;
 }
+#endif
 
 /* Instruction definitions */
 
@@ -850,6 +868,7 @@ _lua_program_get(lua_State *L)
   @since 1.10
  */
 
+#ifdef HAVE_LUA
 static Eina_Bool
 _buffer_instruction_parse_run(lua_State *L,
                               Evas_Filter_Program *pgm,
@@ -915,6 +934,7 @@ _lua_buffer_new(lua_State *L)
 
    return instr->return_count;
 }
+#endif
 
 static int
 _blend_padding_update(Evas_Filter_Program *pgm EINA_UNUSED,
@@ -1212,6 +1232,7 @@ _bump_instruction_prepare(Evas_Filter_Program *pgm, Evas_Filter_Instruction *ins
    return EINA_TRUE;
 }
 
+#ifdef HAVE_LUA
 static Eina_Bool
 _lua_curve_points_func(lua_State *L, int i, Evas_Filter_Program *pgm EINA_UNUSED,
                        Evas_Filter_Instruction *instr, Instruction_Param *param)
@@ -1344,6 +1365,7 @@ _lua_curve_points_func(lua_State *L, int i, Evas_Filter_Program *pgm EINA_UNUSED
 
    return EINA_TRUE;
 }
+#endif
 
 /**
   @page evasfiltersref
@@ -1404,7 +1426,9 @@ _curve_instruction_prepare(Evas_Filter_Program *pgm, Evas_Filter_Instruction *in
 
    // TODO: Allow passing an array of 256 values as points.
    // It could be easily computed from another function in the script.
+#ifdef HAVE_LUA
    _instruction_param_seq_add(instr, "points", VT_SPECIAL, _lua_curve_points_func, NULL);
+#endif
    if (instr->params)
      {
         last = instr->params->last;
@@ -1934,8 +1958,10 @@ evas_filter_program_del(Evas_Filter_Program *pgm)
 
    if (!pgm) return;
 
+#ifdef HAVE_LUA
    if (pgm->L)
      lua_close(pgm->L);
+#endif
 
    EINA_INLIST_FREE(pgm->buffers, buf)
      {
@@ -1954,6 +1980,7 @@ evas_filter_program_del(Evas_Filter_Program *pgm)
 }
 
 // [-1, +1, e] -- converts the top of the stack to a valid 'color' object
+#ifdef HAVE_LUA
 static Eina_Bool
 _lua_convert_color(lua_State *L)
 {
@@ -2102,6 +2129,7 @@ fail:
    ERR("Invalid value for parameter %s", param->name);
    return luaL_error(L, "Invalid value for parameter %s", param->name);
 }
+#endif
 
 static Instruction_Param *
 _parameter_get_by_id(Evas_Filter_Instruction *instr, int id)
@@ -2119,6 +2147,7 @@ _parameter_get_by_id(Evas_Filter_Instruction *instr, int id)
    return NULL;
 }
 
+#ifdef HAVE_LUA
 static Eina_Bool
 _lua_instruction_run(lua_State *L, Evas_Filter_Instruction *instr)
 {
@@ -2389,6 +2418,7 @@ _lua_import_class(lua_State *L, const char *name, char **code)
      }
    return EINA_TRUE;
 }
+#endif
 
 static void
 _filter_program_buffers_set(Evas_Filter_Program *pgm)
@@ -2426,6 +2456,7 @@ _filter_program_buffers_set(Evas_Filter_Program *pgm)
      }
 }
 
+#ifdef HAVE_LUA
 static inline void
 _lua_class_create(lua_State *L, const char *name,
                   const luaL_Reg *meta, const luaL_Reg *methods)
@@ -2596,6 +2627,7 @@ _lua_backtrace(lua_State *L)
    lua_call(L, 2, 1);  /* call debug.traceback */
    return 1;
 }
+#endif
 
 #ifdef FILTERS_LEGACY_COMPAT
 // This function is here to avoid breaking the ABI too much.
@@ -2722,6 +2754,7 @@ _legacy_strdup(const char *str)
 static Eina_Bool
 _filter_program_state_set(Evas_Filter_Program *pgm)
 {
+#ifdef HAVE_LUA
    lua_State *L = pgm->L;
 
    // TODO:
@@ -2820,13 +2853,18 @@ _filter_program_state_set(Evas_Filter_Program *pgm)
 #undef JOINC
 #undef SETFIELD
 #undef SETCOLOR
+#else
+   return EINA_FALSE;
+#endif
 }
 
 static Eina_Bool
 _filter_program_reset(Evas_Filter_Program *pgm)
 {
    Evas_Filter_Instruction *instr;
+#ifdef HAVE_LUA
    lua_State *L = pgm->L;
+#endif
    Eina_Inlist *il;
    Buffer *buf;
 
@@ -2840,8 +2878,10 @@ _filter_program_reset(Evas_Filter_Program *pgm)
    // Clear out buffers
    EINA_INLIST_FOREACH_SAFE(pgm->buffers, il, buf)
      {
+#ifdef HAVE_LUA
         lua_pushnil(L);
         lua_setglobal(L, buf->name);
+#endif
         pgm->buffers = eina_inlist_remove(pgm->buffers, EINA_INLIST_GET(buf));
         _buffer_del(buf);
      }
@@ -2858,8 +2898,9 @@ _filter_program_reset(Evas_Filter_Program *pgm)
 EAPI Eina_Bool
 evas_filter_program_parse(Evas_Filter_Program *pgm, const char *str)
 {
+   Eina_Bool ok = EINA_FALSE;
+#ifdef HAVE_LUA
    lua_State *L;
-   Eina_Bool ok;
 
    EINA_SAFETY_ON_NULL_RETURN_VAL(pgm, EINA_FALSE);
    EINA_SAFETY_ON_NULL_RETURN_VAL(str, EINA_FALSE);
@@ -2913,6 +2954,7 @@ evas_filter_program_parse(Evas_Filter_Program *pgm, const char *str)
    pgm->valid = ok;
    pgm->padding_calc = EINA_FALSE;
    pgm->changed = EINA_FALSE;
+#endif
 
    return ok;
 }
@@ -3628,6 +3670,7 @@ evas_filter_context_program_use(void *engine, void *output,
      {
         pgm->changed = EINA_FALSE;
         _filter_program_reset(pgm);
+#ifdef HAVE_LUA
         lua_getglobal(pgm->L, _lua_errfunc_name);
         lua_rawgeti(pgm->L, LUA_REGISTRYINDEX, pgm->lua_func);
         success = !lua_pcall(pgm->L, 0, LUA_MULTRET, -2);
@@ -3637,6 +3680,10 @@ evas_filter_context_program_use(void *engine, void *output,
              ERR("Lua execution failed: %s", msg);
              goto end;
           }
+#else
+        ERR("Lua execution failed: Lua was disabled in this build.");
+        goto end;
+#endif
      }
 
    // Create or update all buffers
@@ -3668,6 +3715,8 @@ end:
 void
 evas_filter_parser_shutdown(void)
 {
+#ifdef HAVE_LUA
    free(_lua_color_code);
    _lua_color_code = NULL;
+#endif
 }

--- a/src/lib/evas/filters/meson.build
+++ b/src/lib/evas/filters/meson.build
@@ -1,4 +1,8 @@
-subdir('lua')
+if get_option('lua-interpreter') != 'none'
+  subdir('lua')
+
+  evas_deps += lua
+endif
 
 evas_src += files([
   'evas_filter.c',
@@ -6,5 +10,3 @@ evas_src += files([
   'evas_filter_private.h',
   'evas_filter_utils.c',
 ])
-
-evas_deps += lua

--- a/src/tests/evas/evas_suite.c
+++ b/src/tests/evas/evas_suite.c
@@ -17,7 +17,9 @@ static const Efl_Test_Case etc[] = {
   { "Object Text", evas_test_text },
   { "Callbacks", evas_test_callbacks },
   { "Render Engines", evas_test_render_engines },
+#if HAVE_LUA
   { "Filters", evas_test_filters },
+#endif
   { "Images", evas_test_image_object },
   { "Images", evas_test_image_object2 },
   { "Masking", evas_test_mask },


### PR DESCRIPTION
This patch adds an option to disable Lua dependency by setting the meson option `lua-interpreter` to `none`. That is:

```console
$ meson builddir -Dlua-interpreter=none
```

This should be enough to disable lua-interpreter.