### PR TITLE
Evas: Resolve some undefined references to Ector + Evas types

### DIFF
--- a/src/lib/evas/include/evas_filter.h
+++ b/src/lib/evas/include/evas_filter.h
@@ -1,11 +1,10 @@
 #ifndef _EVAS_FILTER_H
 #define _EVAS_FILTER_H
 
-#ifdef HAVE_ECTOR
-
 #include "evas_common_private.h"
 #include "evas_private.h"
 
+#ifdef HAVE_ECTOR
 
 #ifdef EAPI
 # undef EAPI


### PR DESCRIPTION
As `src/lib/evas/include/evas_filter.h` don't include `config.h`,
`HAVE_ECTOR` wasn't defined. Which caused almost all the file to be
ignored, making some types defined there unavailable, causing some
undefined references.

This resolve that problem by removing `evas_common_private.h` and
`evas_private.h` from the guard, as they already have theirs, they don't
need to be inside one) which do include `config.h`, making `HAVE_ECTOR`
available when `-Dector=true`.