### PR TITLE
win32: Replace scripts with native/cross-files definitions (part II)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,14 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+
+    # Remove Strawberry
+    # Strawberry is added by default to the PATH environmment, and it happens
+    # that the Meson inconveniently preffer its packages over those installed
+    # with vcpkg, so we just rename Strawberry folder so it can't be found.
+    - name: Remove Strawberry
+      run: mv C:\Strawberry C:\Strawberry.disabled
+
     - name: Cache LLVM install
       uses: actions/cache@v2
       id: cache-llvm

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,12 +98,10 @@ jobs:
       run: echo "::add-path::${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
     - name: Add vcpkg installed package dirs to path (debug libs)
       run: echo "::add-path::${{ github.workspace }}/vcpkg/installed/x64-windows/debug/bin"
-    - name: configure
-      run: .\configure.bat
-      env:
-        vcpkg_toolchain_file: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+    - name: Configure
+      run: meson build --native-file platforms/windows-native.txt --native-file platforms/windows-ci-custom-native-properties.txt
     - name: Build
-      run: .\build.bat
+      run: meson compile -C build
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Build
       run: .\build.bat
     - name: Upload artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v2
       with:
         name: build
         path: build
@@ -140,9 +140,10 @@ jobs:
     - name: Test meson
       run: meson -v
     - name: Download build artifact
-      uses: actions/download-artifact@v1.0.0
+      uses: actions/download-artifact@v2
       with:
         name: build
+        path: build
     - name: Check directory tree (for debugging purposes)
       run: tree .
     - name: Add vcpkg installed package dirs to path

--- a/platforms/windows-ci-custom-native-properties.txt
+++ b/platforms/windows-ci-custom-native-properties.txt
@@ -1,0 +1,5 @@
+[properties]
+cmake_toolchain_file = 'D:/a/efl/efl/vcpkg/scripts/buildsystems/vcpkg.cmake'
+
+[project options]
+buildtype = 'debug'

--- a/platforms/windows-native.txt
+++ b/platforms/windows-native.txt
@@ -30,6 +30,6 @@ opengl = 'none'
 emotion-loaders-disabler = 'gstreamer1,libvlc,xine'
 bindings = ''
 
-[properties]
+[built-in options]
 c_args = common_flags
 cpp_args = common_flags

--- a/platforms/windows-native.txt
+++ b/platforms/windows-native.txt
@@ -28,7 +28,7 @@ libmount = 'false'
 evas-loaders-disabler = 'gst,pdf,ps,raw,svg,rsvg,xcf,bmp,dds,generic,gif,ico,jp2k,pmaps,psd,tga,tgv,tiff,wbmp,webp,xpm,json'
 opengl = 'none'
 emotion-loaders-disabler = 'gstreamer1,libvlc,xine'
-bindings=
+bindings = ''
 
 [properties]
 c_args = common_flags


### PR DESCRIPTION
Continuation of #481.